### PR TITLE
Redesign field stats lookup.

### DIFF
--- a/packages/core/src/util/summarize.js
+++ b/packages/core/src/util/summarize.js
@@ -1,0 +1,23 @@
+import { Query, count, isNull, max, min } from '@uwdata/mosaic-sql';
+
+export const Count = 'count';
+export const Nulls = 'nulls';
+export const Max = 'max';
+export const Min = 'min';
+export const Distinct = 'distinct';
+
+export const Stats = { Count, Nulls, Max, Min, Distinct };
+
+export const statMap = {
+  [Count]: count,
+  [Distinct]: column => count(column).distinct(),
+  [Max]: max,
+  [Min]: min,
+  [Nulls]: column => count().where(isNull(column))
+};
+
+export function summarize({ table, column }, stats) {
+  return Query
+    .from(table)
+    .select(stats.map(s => [s, statMap[s](column)]));
+}

--- a/packages/inputs/src/Menu.js
+++ b/packages/inputs/src/Menu.js
@@ -1,5 +1,5 @@
 import { isSelection, isSignal, MosaicClient } from '@uwdata/mosaic-core';
-import { Query, column as columnRef, eq, literal } from '@uwdata/mosaic-sql';
+import { Query, eq, literal } from '@uwdata/mosaic-sql';
 
 const isObject = v => {
   return v && typeof v === 'object' && !Array.isArray(v);
@@ -76,11 +76,6 @@ export class Menu extends MosaicClient {
     } else if (isSignal(selection)) {
       selection.update(value);
     }
-  }
-
-  fields() {
-    const { from, column } = this;
-    return from ? [ columnRef(from, column) ] : null;
   }
 
   query(filter = []) {

--- a/packages/inputs/src/Search.js
+++ b/packages/inputs/src/Search.js
@@ -1,6 +1,6 @@
 import { isSelection, isSignal, MosaicClient } from '@uwdata/mosaic-core';
 import {
-  Query, column as columnRef, regexp_matches, contains, prefix, suffix, literal
+  Query, regexp_matches, contains, prefix, suffix, literal
 } from '@uwdata/mosaic-sql';
 
 const FUNCTIONS = { contains, prefix, suffix, regexp: regexp_matches };
@@ -65,11 +65,6 @@ export class Search extends MosaicClient {
     } else if (isSignal(selection)) {
       selection.update(value);
     }
-  }
-
-  fields() {
-    const { from, column } = this;
-    return from ? [ columnRef(from, column) ] : null;
   }
 
   query(filter = []) {

--- a/packages/inputs/src/Table.js
+++ b/packages/inputs/src/Table.js
@@ -67,8 +67,7 @@ export class Table extends MosaicClient {
   }
 
   fields() {
-    const { from, columns } = this;
-    return columns.map(name => column(from, name));
+    return this.columns.map(name => column(this.from, name));
   }
 
   fieldStats(stats) {

--- a/packages/vgplot/src/marks/ConnectedMark.js
+++ b/packages/vgplot/src/marks/ConnectedMark.js
@@ -4,8 +4,11 @@ import { Mark } from './Mark.js';
 
 export class ConnectedMark extends Mark {
   constructor(type, source, encodings) {
-    super(type, source, encodings);
-    this.dim = type.endsWith('X') ? 'y' : 'x';
+    const dim = type.endsWith('X') ? 'y' : 'x';
+    const req = { [dim]: ['count', 'min', 'max'] };
+
+    super(type, source, encodings, req);
+    this.dim = dim;
   }
 
   query(filter = []) {
@@ -16,12 +19,12 @@ export class ConnectedMark extends Mark {
     if (optimize) {
       // TODO: handle stacked data
       const { column } = this.channelField(dim);
-      const { rows, type, min, max } = stats.find(s => s.column === column);
+      const { count, max, min, type } = stats[column];
       const size = dim === 'x' ? plot.innerWidth() : plot.innerHeight();
 
       const [lo, hi] = filteredExtent(filter, column) || [min, max];
       const scale = (hi - lo) / (max - min);
-      if (rows * scale > size * 4) {
+      if (count * scale > size * 4) {
         const dd = type === 'date' ? epoch_ms(dim) : dim;
         const val = dim === 'x' ? 'y' : 'x';
         const cols = q.select().map(c => c.as).filter(c => c !== 'x' && c !== 'y');

--- a/packages/vgplot/src/marks/Density1DMark.js
+++ b/packages/vgplot/src/marks/Density1DMark.js
@@ -2,13 +2,16 @@ import { isSignal } from '@uwdata/mosaic-core';
 import { Query, gt, sum, expr, isBetween } from '@uwdata/mosaic-sql';
 import { Transient } from '../symbols.js';
 import { dericheConfig, dericheConv1d, grid1d } from './util/density.js';
-import { extentX, extentY } from './util/extent.js';
+import { extentX, extentY, xext, yext } from './util/extent.js';
 import { Mark } from './Mark.js';
 
 export class Density1DMark extends Mark {
   constructor(type, source, options) {
     const { bins = 1024, bandwidth = 0.1, ...channels } = options;
-    super(type, source, channels);
+    const dim = type.endsWith('X') ? 'y' : 'x';
+
+    super(type, source, channels, dim === 'x' ? xext : yext);
+    this.dim = dim;
     this.bins = bins;
     this.bandwidth = bandwidth;
 
@@ -30,8 +33,7 @@ export class Density1DMark extends Mark {
   }
 
   query(filter = []) {
-    const dir = 'x'; // TODO: support transpose
-    this.extent = (dir === 'x' ? extentX : extentY)(this, filter);
+    this.extent = (this.dim === 'x' ? extentX : extentY)(this, filter);
     const [lo, hi] = this.extent;
     const weight = this.channelField('weight') ? 'weight' : 1;
     return binLinear1d(super.query(filter), 'x', lo, hi, this.bins, weight);

--- a/packages/vgplot/src/marks/Density2DMark.js
+++ b/packages/vgplot/src/marks/Density2DMark.js
@@ -1,8 +1,8 @@
-import { isSignal, Signal } from '@uwdata/mosaic-core';
+import { isSignal } from '@uwdata/mosaic-core';
 import { Query, and, gt, sum, expr, isBetween } from '@uwdata/mosaic-sql';
 import { Transient } from '../symbols.js';
 import { dericheConfig, dericheConv2d, grid2d } from './util/density.js';
-import { extentX, extentY } from './util/extent.js';
+import { extentX, extentY, xyext } from './util/extent.js';
 import { Mark } from './Mark.js';
 
 export class Density2DMark extends Mark {
@@ -12,12 +12,12 @@ export class Density2DMark extends Mark {
     const densityStroke = channels.stroke === 'density';
     if (densityFill) delete channels.fill;
     if (densityStroke) delete channels.stroke;
-    super(type, source, channels);
+
+    super(type, source, channels, xyext);
     this.densityFill = densityFill;
     this.densityStroke = densityStroke;
     this.bandwidth = bandwidth;
     this.binScale = binScale;
-    this.request = new Signal();
 
     if (isSignal(bandwidth)) {
       bandwidth.addEventListener('value', value => {

--- a/packages/vgplot/src/marks/HexbinMark.js
+++ b/packages/vgplot/src/marks/HexbinMark.js
@@ -1,12 +1,12 @@
 import { Query, expr, isNotNull } from '@uwdata/mosaic-sql';
 import { Transient } from '../symbols.js';
-import { extentX, extentY } from './util/extent.js';
+import { extentX, extentY, xyext } from './util/extent.js';
 import { Mark } from './Mark.js';
 
 export class HexbinMark extends Mark {
   constructor(source, options) {
-    const { binWidth = 20, ...channels } = options;
-    super('hexagon', source, { r: binWidth / 2, clip: true, ...channels });
+    const { type = 'hexagon', binWidth = 20, ...channels } = options;
+    super(type, source, { r: binWidth / 2, clip: true, ...channels }, xyext);
     this.binWidth = binWidth;
   }
 
@@ -17,11 +17,8 @@ export class HexbinMark extends Mark {
   }
 
   query(filter = []) {
+    if (this.hasOwnData()) return null;
     const { plot, binWidth, channels, source } = this;
-
-    if (source == null || Array.isArray(source)) {
-      return null;
-    }
 
     // get x / y extents, may update plot domainX / domainY
     const [x1, x2] = extentX(this, filter);

--- a/packages/vgplot/src/marks/util/extent.js
+++ b/packages/vgplot/src/marks/util/extent.js
@@ -1,6 +1,10 @@
 import { scaleLinear } from 'd3';
 import { Fixed, Transient } from '../../symbols.js';
 
+export const xext = { x: ['min', 'max'] };
+export const yext = { y: ['min', 'max'] };
+export const xyext = { ...xext, ...yext };
+
 export function plotExtent(mark, filter, channel, domainAttr, niceAttr) {
   const { plot, stats } = mark;
   const domain = plot.getAttribute(domainAttr);
@@ -10,7 +14,7 @@ export function plotExtent(mark, filter, channel, domainAttr, niceAttr) {
     return domain;
   } else {
     const { column } = mark.channelField(channel);
-    const { min, max } = stats.find(s => s.column === column);
+    const { min, max } = stats[column];
     const dom = filteredExtent(filter, column) || (nice
       ? scaleLinear().domain([min, max]).nice().domain()
       : [min, max]);

--- a/packages/vgplot/src/transforms/bin.js
+++ b/packages/vgplot/src/transforms/bin.js
@@ -29,11 +29,12 @@ class BinTransform extends Ref {
   constructor(column, options) {
     super(undefined, column);
     this.options = options;
+    this.stats = ['min', 'max'];
   }
 
   transform(stats) {
     const { column, options } = this;
-    const { min, max } = stats.find(s => s.column === column);
+    const { min, max } = stats[column];
     const b = bins(min, max, options);
     const delta = `(${column} - ${b.min})`;
     const alpha = `${(b.max - b.min) / b.steps}::DOUBLE`;


### PR DESCRIPTION
- Resdesign the initial client `fields`/`fieldStats` lookup to reduce unnecessary queries. Clients must now explicitly request summary stats (`count`, `distinct`, `min`, `max`, `nulls`) for the corresponding queries to run.
- Modify marks and inputs to only request metadata when needed. In some cases this removes the need to query the catalog altogether.
- Simplify mark stats lookup to use an object keyed by field, rather than an array search.