### PR TITLE
Use DESCRIBE instead of PRAGMA table_info.

### DIFF
--- a/packages/core/src/Catalog.js
+++ b/packages/core/src/Catalog.js
@@ -20,20 +20,19 @@ export class Catalog {
     }
 
     const q = this.mc.query(
-      `PRAGMA table_info('${table}')`,
+      `DESCRIBE "${table}"`,
       { type: 'json', cache: false }
     );
 
     return (cache[table] = q.then(result => {
       const columns = object();
-      for (const { name, notnull, type, pk } of result) {
-        columns[name] = {
+      for (const entry of result) {
+        columns[entry.column_name] = {
           table,
-          column: name,
-          sqlType: type,
-          type: jsType(type),
-          notnull,
-          pk
+          column: entry.column_name,
+          sqlType: entry.column_type,
+          type: jsType(entry.column_type),
+          nullable: entry.null === 'YES'
         };
       }
       return columns;


### PR DESCRIPTION
- Use DESCRIBE instead of PRAGMA table_info to get table schema metadata.

In response to discussion in #10, where apparently DuckDB Python can get schema info for Pandas tables using DESCRIBE but not with `PRAGMA table_info`.

In the future we may wish to support schema lookup not just for tables, but also queries with derived/transformed columns, in which case we will need to use `DESCRIBE` anyway.