### PR TITLE
Interactive Resolution

### DIFF
--- a/dev/examples/gaia.js
+++ b/dev/examples/gaia.js
@@ -35,7 +35,7 @@ export default async function(el) {
   const binWidth = 2;
   const binType = 'normal';
   const histScale = 'sqrt';
-  const resolution = 2;
+  const pixelSize = 2;
 
   el.appendChild(
     hconcat(
@@ -45,7 +45,7 @@ export default async function(el) {
             from(table, { filterBy: brush }),
             { x: 'u', y: 'v', fill: 'density', bandwidth, binType, binWidth }
           ),
-          intervalXY({ as: brush, resolution }),
+          intervalXY({ as: brush, pixelSize }),
           domainXY(Fixed),
           scaleColor('sqrt'), schemeColor('viridis'),
           width(700), height(400), marginLeft(25), marginTop(20), marginRight(1)
@@ -78,7 +78,7 @@ export default async function(el) {
           { x: 'bp_rp', y: 'phot_g_mean_mag', fill: 'density', bandwidth, binType, binWidth }
         ),
         scaleColor('sqrt'), schemeColor('viridis'), reverseY(true),
-        intervalXY({ as: brush, resolution }), domainXY(Fixed),
+        intervalXY({ as: brush, pixelSize }), domainXY(Fixed),
         width(400), height(600), marginLeft(25), marginTop(20), marginRight(1)
       )
     )

--- a/dev/specs/gaia.yaml
+++ b/dev/specs/gaia.yaml
@@ -34,7 +34,7 @@ hconcat:
       binWidth: $binWidth
       binType: normal
     - select: intervalXY
-      resolution: 2
+      pixelSize: 2
       as: $brush
     domainXY: Fixed
     scaleColor: $scaleType
@@ -86,7 +86,7 @@ hconcat:
     binWidth: $binWidth
     binType: normal
   - select: intervalXY
-    resolution: 2
+    pixelSize: 2
     as: $brush
   domainXY: Fixed
   scaleColor: $scaleType

--- a/packages/core/src/DataTileIndexer.js
+++ b/packages/core/src/DataTileIndexer.js
@@ -113,11 +113,11 @@ function getActiveView(clause) {
   const { source, schema } = clause;
   let columns = clause.predicate?.columns;
   if (!schema || !columns) return null;
-  const { type, resolution = 1, scales } = schema;
+  const { type, scales, pixelSize = 1 } = schema;
   let predicate;
 
   if (type === 'interval' && scales) {
-    const bins = scales.map(s => binInterval(s, resolution));
+    const bins = scales.map(s => binInterval(s, pixelSize));
     if (bins.some(b => b == null)) return null; // unsupported scale type
 
     if (bins.length === 1) {
@@ -141,7 +141,7 @@ function getActiveView(clause) {
   return { source, columns, predicate };
 }
 
-function binInterval(scale, resolution) {
+function binInterval(scale, pixelSize) {
   const { type, domain, range } = scale;
   let lift, sql;
 
@@ -169,15 +169,16 @@ function binInterval(scale, resolution) {
       sql = c => c instanceof Date ? +c : epoch_ms(asColumn(c));
       break;
   }
-  return lift ? binFunction(domain, range, resolution, lift, sql) : null;
+  return lift ? binFunction(domain, range, pixelSize, lift, sql) : null;
 }
 
-function binFunction(domain, range, res, lift, sql) {
+function binFunction(domain, range, pixelSize, lift, sql) {
   const lo = lift(Math.min(domain[0], domain[1]));
   const hi = lift(Math.max(domain[0], domain[1]));
-  const a = (Math.abs(lift(range[1]) - lift(range[0])) / (hi - lo)) / res;
+  const a = (Math.abs(lift(range[1]) - lift(range[0])) / (hi - lo)) / pixelSize;
+  const s = pixelSize === 1 ? '' : `${pixelSize}::INTEGER * `;
   return value => expr(
-    `${res === 1 ? '' : `${res} * `}FLOOR(${a}::DOUBLE * (${sql(value)} - ${lo}::DOUBLE))`,
+    `${s}FLOOR(${a}::DOUBLE * (${sql(value)} - ${lo}::DOUBLE))::INTEGER`,
     asColumn(value).columns
   );
 }

--- a/packages/vgplot/src/interactors/Interval1D.js
+++ b/packages/vgplot/src/interactors/Interval1D.js
@@ -10,13 +10,13 @@ export class Interval1D {
     channel,
     selection,
     field,
-    resolution = 1,
+    pixelSize = 1,
     peers = true,
     brush: style
   }) {
     this.mark = mark;
     this.channel = channel;
-    this.resolution = resolution || 1;
+    this.pixelSize = pixelSize || 1;
     this.selection = selection;
     this.peers = peers;
     this.field = field || mark.channelField(channel, channel+'1', channel+'2');
@@ -34,7 +34,7 @@ export class Interval1D {
     let range = undefined;
     if (extent) {
       range = extent
-        .map(v => invert(v, this.scale, this.resolution))
+        .map(v => invert(v, this.scale, this.pixelSize))
         .sort((a, b) => a - b);
     }
     if (!closeTo(range, this.value)) {
@@ -45,10 +45,10 @@ export class Interval1D {
   }
 
   clause(value) {
-    const { mark, resolution, field, scale } = this;
+    const { mark, pixelSize, field, scale } = this;
     return {
       source: this,
-      schema: { type: 'interval', resolution, scales: [scale] },
+      schema: { type: 'interval', pixelSize, scales: [scale] },
       clients: this.peers ? mark.plot.markSet : new Set().add(mark),
       value,
       predicate: value ? isBetween(field, value) : null

--- a/packages/vgplot/src/interactors/Interval2D.js
+++ b/packages/vgplot/src/interactors/Interval2D.js
@@ -12,12 +12,12 @@ export class Interval2D {
     selection,
     xfield,
     yfield,
-    resolution = 1,
+    pixelSize = 1,
     peers = true,
     brush: style
   }) {
     this.mark = mark;
-    this.resolution = resolution || 1;
+    this.pixelSize = pixelSize || 1;
     this.selection = selection;
     this.peers = peers;
     this.xfield = xfield || mark.channelField('x', 'x1', 'x2');
@@ -32,13 +32,13 @@ export class Interval2D {
   }
 
   publish(extent) {
-    const { value, resolution, xscale, yscale } = this;
+    const { value, pixelSize, xscale, yscale } = this;
     let xr = undefined;
     let yr = undefined;
     if (extent) {
       const [a, b] = extent;
-      xr = [a[0], b[0]].map(v => invert(v, xscale, resolution)).sort(asc);
-      yr = [a[1], b[1]].map(v => invert(v, yscale, resolution)).sort(asc);
+      xr = [a[0], b[0]].map(v => invert(v, xscale, pixelSize)).sort(asc);
+      yr = [a[1], b[1]].map(v => invert(v, yscale, pixelSize)).sort(asc);
     }
 
     if (!closeTo(xr, value?.[0]) || !closeTo(yr, value?.[1])) {
@@ -49,10 +49,10 @@ export class Interval2D {
   }
 
   clause(value) {
-    const { mark, resolution, xfield, yfield, xscale, yscale } = this;
+    const { mark, pixelSize, xfield, yfield, xscale, yscale } = this;
     return {
       source: this,
-      schema: { type: 'interval', resolution, scales: [xscale, yscale] },
+      schema: { type: 'interval', pixelSize, scales: [xscale, yscale] },
       clients: this.peers ? mark.plot.markSet : new Set().add(mark),
       value,
       predicate: value

--- a/packages/vgplot/src/interactors/util/invert.js
+++ b/packages/vgplot/src/interactors/util/invert.js
@@ -1,3 +1,3 @@
-export function invert(value, scale, resolution = 1) {
-  return scale.invert(resolution * Math.floor(value / resolution));
+export function invert(value, scale, pixelSize = 1) {
+  return scale.invert(pixelSize * Math.floor(value / pixelSize));
 }


### PR DESCRIPTION
- Add `resolution` parameter to 1D and 2D brush interactors, indicating the pixel resolution of the brush. The default is `1`, larger numbers cause brush "pixels" to be larger, reducing the interactive resolution. The `resolution` value is included as part of the selection clause schema.
- Add `resolution` support to the data tile indexer, supporting creation of smaller data cubes when the interactive "pixel" size increases.
- Update Gaia examples to use 2-pixel interactive resolution on 2D rasters.