### PR TITLE
Update data server to support caching.

### DIFF
--- a/packages/core/src/Catalog.js
+++ b/packages/core/src/Catalog.js
@@ -21,7 +21,7 @@ export class Catalog {
 
     const q = this.mc.query(
       `DESCRIBE "${table}"`,
-      { type: 'json', cache: false }
+      { type: 'json', cacheClient: false }
     );
 
     return (cache[table] = q.then(result => {
@@ -49,7 +49,10 @@ export class Catalog {
     // no need for summary statistics
     if (!stats?.length) return colInfo;
 
-    const result = await this.mc.query(summarize(colInfo, stats));
+    const result = await this.mc.query(
+      summarize(colInfo, stats),
+      { cacheServer: true }
+    );
     const info = { ...colInfo, ...(Array.from(result)[0]) };
     return info;
   }

--- a/packages/core/src/Coordinator.js
+++ b/packages/core/src/Coordinator.js
@@ -61,7 +61,7 @@ export class Coordinator {
     }
   }
 
-  query(query, { type = 'arrow', cache = true } = {}) {
+  query(query, { type = 'arrow', cacheClient = true, cacheServer = false } = {}) {
     const sql = String(query);
     const t0 = performance.now();
     const cached = this.cache.get(sql);
@@ -69,8 +69,8 @@ export class Coordinator {
       this._logger.debug('Cache');
       return cached;
     } else {
-      const request = this.db.query({ type, sql });
-      const result = cache ? this.cache.set(sql, request) : request;
+      const request = this.db.query({ type, sql, cache: cacheServer });
+      const result = cacheClient ? this.cache.set(sql, request) : request;
       result.then(() => this._logger.debug(`Query: ${(performance.now() - t0).toFixed(1)}`));
       return result;
     }

--- a/packages/duckdb/src/QueryCache.js
+++ b/packages/duckdb/src/QueryCache.js
@@ -1,0 +1,51 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export function cacheKey(sql) {
+  return createHash('sha256').update(sql).digest('hex');
+}
+
+export class QueryCache {
+  constructor(cacheDir) {
+    this.cacheDir = cacheDir;
+    this.cache = new Map;
+    readData(cacheDir, this.cache);
+  }
+
+  has(key) {
+    return this.cache.has(key);
+  }
+
+  delete(key) {
+    return this.cache.delete(key);
+  }
+
+  get(key) {
+    return this.cache.get(key);
+  }
+
+  set(key, data) {
+    this.cache.set(key, data);
+    writeData(this.cacheDir, key, data);
+    return this;
+  }
+}
+
+async function readData(dir, cache) {
+  await fs.mkdir(dir, { recursive: true });
+  const files = await fs.readdir(dir);
+  await Promise.allSettled(files.map(async file => {
+    const m = file.match(/(.*)\.arrow/);
+    const key = m?.[1] || null;
+    if (key) {
+      const data = await fs.readFile(path.resolve(dir, file));
+      cache.set(key, data);
+    }
+  }));
+}
+
+function writeData(dir, key, buffer) {
+  const name = `${key}.arrow`;
+  fs.writeFile(path.resolve(dir, name), buffer);
+}

--- a/packages/duckdb/src/data-server.js
+++ b/packages/duckdb/src/data-server.js
@@ -78,7 +78,7 @@ function queryHandler(db) {
     }
 
     try {
-      const { sql, type } = query;
+      const { sql, type, ...options } = query;
       console.log('QUERY', sql);
 
       // request the lock to serialize requests
@@ -89,7 +89,7 @@ function queryHandler(db) {
       switch (type) {
         case 'arrow':
           // Apache Arrow response format
-          res.binary(await db.arrow(sql));
+          res.binary(await db.arrow(sql, options));
           break;
         case 'exec':
           // Execute query with no return value


### PR DESCRIPTION
- Add `arrow` method for robust arrow buffer query results.
- Add `binary` (non-stream) server response type.

TODO:
- Add server-side caching support.
- Refactor to remove `arrowBuffer`?
- Refactor for a more centralized DB query method?