### PR TITLE
Fix selection resolution upon active clause removal.

### DIFF
--- a/packages/core/src/Selection.js
+++ b/packages/core/src/Selection.js
@@ -92,7 +92,7 @@ export class Selection extends Param {
    */
   remove(source) {
     const s = this.clone();
-    s._value = s._resolved = this._resolved.filter(c => c.source !== source);
+    s._value = s._resolved = s._resolver.resolve(this._resolved, { source });
     s._value.active = { source };
     return s;
   }
@@ -136,7 +136,7 @@ export class Selection extends Param {
   update(clause) {
     // we maintain an up-to-date list of all resolved clauses
     // this ensures consistent clause state across unemitted event values
-    this._resolved = this._resolver.resolve(this._resolved, clause);
+    this._resolved = this._resolver.resolve(this._resolved, clause, true);
     this._resolved.active = clause;
     return super.update(this._resolved);
   }
@@ -219,11 +219,11 @@ export class SelectionResolver {
    * @param {*} clause A new selection clause to add.
    * @returns {*[]} An updated array of selection clauses.
    */
-  resolve(clauseList, clause) {
+  resolve(clauseList, clause, reset = false) {
     const { source, predicate } = clause;
     const filtered = clauseList.filter(c => source !== c.source);
     const clauses = this.single ? [] : filtered;
-    if (this.single) filtered.forEach(c => c.source?.reset?.());
+    if (this.single && reset) filtered.forEach(c => c.source?.reset?.());
     if (predicate) clauses.push(clause);
     return clauses;
   }


### PR DESCRIPTION
The `DataTileIndexer` creates a new selection with the active clause removed prior to index construction. Previously this simply stripped the active clause from the existing selection's filter clause list. However, this does not take into account other possible resolution strategies. For example, the `single` strategy enforces only a single active filter clause. In this case, we do not want to include extra clauses (that would otherwise be removed) within the created data tiles.

The fix here is to use the selection resolver directly as part of active clause removal. To do this, we also need to add an additional `reset` parameter that controls whether or not selection resolution can trigger `reset()` calls to interactors that support them. With this change, single filtering should now work correctly with data tile indexing.