### PR TITLE
Update to DuckDB 0.8.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4755,6 +4755,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/duckdb": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.8.0.tgz",
+      "integrity": "sha512-hD05w83kdDkmRZoKwFK4PiA2fByczPp49rY6cREh23NoVHXJ3I4VpROsW8vNC9Gx7KP7lZpWvT7rQ/MHvrWI5g==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "node-addon-api": "*",
+        "node-gyp": "^9.3.0"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -11978,19 +11989,8 @@
       "version": "0.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "duckdb": "~0.7.1",
+        "duckdb": "~0.8.0",
         "ws": "^8.13.0"
-      }
-    },
-    "packages/duckdb/node_modules/duckdb": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.7.1.tgz",
-      "integrity": "sha512-RwFqUO83beq68DcK4XnVLNQXa/AGIXtvg5oI1onclfslo5JYnX+5zI5d0iP/WmpjxiUOGl0Z1bcO0pNvhA/CdA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.0",
-        "node-addon-api": "*",
-        "node-gyp": "^9.3.0"
       }
     },
     "packages/inputs": {

--- a/packages/duckdb/package.json
+++ b/packages/duckdb/package.json
@@ -24,7 +24,7 @@
     "prepublishOnly": "npm run test && npm run lint"
   },
   "dependencies": {
-    "duckdb": "~0.7.1",
+    "duckdb": "~0.8.0",
     "ws": "^8.13.0"
   }
 }


### PR DESCRIPTION
This PR updates the Mosaic `duckdb` library to use DuckDB version 0.8.

The good news is that this version no longer crashes when trying to export zero row Arrow tables.

The bad news is that string data now uses the `LargeUTF8` type, which is not supported by ArrowJS. This results in errors when calling `tableFromIPC` within JavaScript.

We appear blocked on either a resolution to https://github.com/apache/arrow/issues/15060 or workarounds to land+release in DuckDB (https://github.com/duckdb/duckdb/pull/7540, https://github.com/duckdblabs/arrow/pull/12). The latter seems more likely to resolve sooner, given the needs of DuckDB-WASM.

cc @domoritz 