### PR TITLE
Update Jupyter widget.

### DIFF
--- a/dev/notebooks/specs.ipynb
+++ b/dev/notebooks/specs.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "93103597-996b-46ec-9804-63164b775896",
    "metadata": {
     "tags": []
@@ -13,13 +13,12 @@
     "import yaml\n",
     "from mosaic_widget import MosaicWidget\n",
     "import ipywidgets as widgets\n",
-    "import pyarrow as pa\n",
     "from pprint import pprint"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "ed9edb9e-4ed2-4e5e-b44c-81a2c7a73af4",
    "metadata": {
     "tags": []
@@ -33,25 +32,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "1cf65425-1df5-41d3-b020-d2b713559c87",
-   "metadata": {
-    "tags": []
-   },
+   "execution_count": null,
+   "id": "71be7064-deb8-4b5e-b86c-7c73c86220cf",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "def load_arrow(con, path, table):\n",
-    "    with pa.memory_map(path) as source:\n",
-    "        my_arrow = pa.ipc.open_stream(source).read_all()\n",
-    "        con.execute(f\"CREATE TABLE {table} AS FROM my_arrow\")\n",
-    "        \n",
-    "def load_csv(con, path, table):\n",
-    "    con.execute(f\"CREATE VIEW {table} AS FROM read_csv_auto('{path}')\")"
+    "# Change working directory to mosaic root\n",
+    "%cd ../.."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "5f46684a-5a00-4db2-9a1e-7b394a84fc21",
    "metadata": {
     "tags": []
@@ -59,19 +51,12 @@
    "outputs": [],
    "source": [
     "con = duckdb.connect()\n",
-    "\n",
-    "load_arrow(con, \"../../data/flights-200k.arrow\", \"flights\")\n",
-    "load_arrow(con, \"../../data/random-walk.arrow\", \"walk\")\n",
-    "load_csv(con, \"../../data/penguins.csv\", \"penguins\")\n",
-    "load_csv(con, \"../../data/athletes.csv\", \"athletes\")\n",
-    "load_csv(con, \"../../data/seattle-weather.csv\", \"weather\")\n",
-    "\n",
     "con.execute(\"LOAD httpfs\");"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "4da7f0fd-ec48-4ca9-b927-cbf9b0a5d8b8",
    "metadata": {
     "tags": []
@@ -83,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "211e4826-c2c6-4af2-a46f-1786d4600c73",
    "metadata": {
     "tags": []
@@ -91,18 +76,44 @@
    "outputs": [],
    "source": [
     "dropdown = widgets.Dropdown(\n",
-    "    options=[(\"Athletes\", \"athletes\"), (\"Cross-Filter\", \"cross-filter\"), (\"Density 1D\", \"density1d\"), (\"Facets\", \"facets\"),\n",
-    "             (\"Flights 10M\", \"flights-10m\"), (\"Gaia Star Catalog\", \"gaia\"), (\"Hexbin\", \"hexbin\"), (\"Mark Gallery\", \"marks\"),\n",
-    "             (\"Line Density\", \"line-density\"), (\"Pan + Zoom\", \"pan-zoom\"), (\"Regression\", \"regression\"), (\"Seattle Weather\", \"weather\")],\n",
+    "    options=[\n",
+    "        (\"Athletes\", \"athletes\"),\n",
+    "        (\"Bias Parameter\", \"bias\"),\n",
+    "        (\"Contours\", \"contours\"),\n",
+    "        (\"Density 1D\", \"density1d\"),\n",
+    "        (\"Density 2D\", \"density2d\"),\n",
+    "        (\"Axes & Gridlines\", \"axes\"),\n",
+    "        (\"Earthquakes\", \"earthquakes\"),\n",
+    "        (\"Flights Density\", \"flights-density\"),\n",
+    "        (\"Flights\", \"flights\"),\n",
+    "        (\"Flights 10M\", \"flights-10m\"),\n",
+    "        (\"Gaia Star Catalog\", \"gaia\"),\n",
+    "        (\"Hexbin\", \"hexbin\"),\n",
+    "        (\"Images\", \"images\"),\n",
+    "        (\"Links\", \"links\"),\n",
+    "        (\"Line Density\", \"line-density\"),\n",
+    "        (\"Mark Types\", \"marks\"),\n",
+    "        (\"Moving Average\", \"moving-average\"),\n",
+    "        (\"Normalize Stocks\", \"normalize\"),\n",
+    "        (\"Overview + Detail\", \"overview-detail\"),\n",
+    "        (\"Pan + Zoom\", \"pan-zoom\"),\n",
+    "        (\"Regression\", \"regression\"),\n",
+    "        (\"Scatter Plot Matrix\", \"splom\"),\n",
+    "        (\"Seattle Weather\", \"weather\"),\n",
+    "        (\"Symbols\", \"symbols\"),\n",
+    "        (\"Table\", \"table\"),\n",
+    "        (\"Voronoi\", \"voronoi\"),\n",
+    "        (\"Wind Map\", \"wind-map\")\n",
+    "    ],\n",
     "    value=\"weather\",\n",
-    "    description=\"Spec:\"\n",
+    "    description=\"Example:\"\n",
     ")\n",
     "\n",
     "def on_change(change):\n",
     "    open_spec(change[\"new\"])\n",
     "\n",
     "def open_spec(spec):\n",
-    "    with open(f\"../specs/{spec}.yaml\") as f:\n",
+    "    with open(f\"dev/yaml/{spec}.yaml\") as f:\n",
     "        mosaic.spec = yaml.safe_load(f)\n",
     "\n",
     "dropdown.observe(on_change, \"value\")\n",
@@ -120,28 +131,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "d192b9ff-2592-4683-b22d-b87994196379",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bfee2784e4694a68974aa44b01b4625e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(Dropdown(description='Spec:', index=11, options=(('Athletes', 'athletes'), ('Cross-Filter', 'cr…"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "widgets.VBox([dropdown, mosaic, output])"
    ]
@@ -163,7 +158,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/dev/notebooks/weather.ipynb
+++ b/dev/notebooks/weather.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "93103597-996b-46ec-9804-63164b775896",
    "metadata": {
     "tags": []
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "ed9edb9e-4ed2-4e5e-b44c-81a2c7a73af4",
    "metadata": {
     "tags": []
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "f6b72efe-e92d-4f72-b2bc-a7fd814cc68d",
    "metadata": {
     "tags": []
@@ -39,34 +39,20 @@
    "source": [
     "weather = pd.read_csv(\"../../data/seattle-weather.csv\", parse_dates=['date'])\n",
     "\n",
-    "with open(\"../specs/weather.yaml\") as f:\n",
-    "    spec = yaml.safe_load(f)"
+    "# Load weather spec, remove data key to ensure load from Pandas\n",
+    "with open(\"../yaml/weather.yaml\") as f:\n",
+    "    spec = yaml.safe_load(f)\n",
+    "    spec.pop(\"data\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "4da7f0fd-ec48-4ca9-b927-cbf9b0a5d8b8",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8bedaa8876744b2985a05e7512c9c20f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "MosaicWidget(spec={'params': {'click': {'select': 'single'}, 'domain': ['sun', 'fog', 'drizzle', 'rain', 'snow…"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "MosaicWidget(spec, data = {\"weather\": weather})"
    ]
@@ -88,7 +74,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -37,13 +37,13 @@ The widget has a `spec` traitlet that can be used to set the Mosaic specificatio
 
 We use [hatch](https://hatch.pypa.io/latest/) to manage our development setup.
 
-To active the environment, run `hatch shell`.
+To activate the environment, run `hatch shell`.
 
 This should install the widget in development mode so you can start Jupyter.
 
 You can start Jupyter with `jupyter lab --notebook-dir=../../dev/notebooks`. If you cannot import the widget module, make sure that your Jupyter uses the right environment. You can add your environment to Jupyter by running `python -m ipykernel install --user --name=mosaic` and then select `mosaic` in the Jupyter environment dropdown.
 
-Run `npm run build` to build the widget JavaScript code. If you want to live edit the widget code, run `npm run dev` in a separate terminal and change `_DEV = False` to `_DEV = False` inside `mosaic_widget/__init__.py`.
+Run `npm run build` to build the widget JavaScript code. If you want to live edit the widget code, run `npm run dev` in a separate terminal and change `_DEV = False` to `_DEV = True` inside `mosaic_widget/__init__.py`.
 
 ## Publishing
 

--- a/packages/widget/src/index.js
+++ b/packages/widget/src/index.js
@@ -56,7 +56,6 @@ export async function render(view) {
         const s = [...selections].map(
           s => s.clauses.map(
             c => ({
-              predicate: c.predicate,
               value: c.value,
               sql: String(c.predicate)
             })


### PR DESCRIPTION
This PR contains a set of updates to match changes elsewhere in the project.

- Update example notebooks to use updated data organization and more recent specs.
- Update widget selection export to avoid crashes, as selection predicates no longer serialize correctly.
- Fix typos in the widget package README.md.

One thing to think about down the road is how to best enable reuse of selected data. When someone selects data in a dashboard, how should that data be made available to downstream notebook cells? A straightforward mechanism may be to export SQL predicate clauses which could then be used to query DuckDB for the desired data.

The parts to iron out are then:

1. Selections do not explicitly target any specific tables (clients do). So we need a way to determine a proper source table.
2. In the case of cross-filtering, a single Selection can represent a _set_ of queries, which differ depending on which client is being filtered. So we need a resolution mechanism. The most obvious seems to be to simply combine all clauses (e.g., a cross-filtered intersection would then reduce to a normal intersection of all clauses).