### PR TITLE
Fix highlighting for usage with cross-filter selection

### DIFF
--- a/packages/vgplot/src/interactors/Highlight.js
+++ b/packages/vgplot/src/interactors/Highlight.js
@@ -55,8 +55,11 @@ async function predicateFunction(mark, selection) {
     return () => true;
   }
 
+  // create a selection with the active source removed
+  const sel = mark.filterBy?.remove(null);
+
   const s = { __: and(pred) };
-  const q = mark.query(mark.filterBy?.predicate(mark));
+  const q = mark.query(sel?.predicate(mark));
   const p = q.groupby().length ? q.select(s) : q.$select(s);
 
   const data = await coordinator().query(p);


### PR DESCRIPTION
Consider following scenario:

```yaml
data:
  athletes: { file: data/athletes.csv }
params:
  query: { select: crossfilter }
  click: { select: single }
vconcat:
- hconcat:
  - input: menu
    label: Sport
    as: $query
    from: athletes
    column: sport
- vspace: 20
- name: total
  plot:
  - mark: barX
    data: { from: athletes, filterBy: $query }
    x: { count: '' }
  xLabel: Total →
  xDomain: Fixed
- vspace: 20
- name: total_by_country
  plot:
  - mark: barY
    data: { from: athletes, filterBy: $query }
    x: nationality
    y: { count: '' }
    sort: { x: -y, limit: 10 }
  - select: toggleX
    as: $query
  - select: toggleX
    as: $click
  - select: highlight
    by: $click
  xLabel: ''
  yLabel: Total
```

<img width="651" alt="Bildschirmfoto 2023-08-04 um 12 35 55" src="https://github.com/uwdata/mosaic/assets/5602551/7f486104-8b3e-4ff5-9d15-1781f536f396">

As soon as a `sport` is selected in menu, highlighting does not work properly when clicking on bars. 

_Reason: Predicate function used for highlighting is based on query which is missing `WHERE` clause, e.g. here `sport = 'athletics'`._

See also https://github.com/uwdata/mosaic/discussions/144#discussioncomment-6629487.

This PR covers a fix for above issue.