### PR TITLE
Fix highlight and toggler interactors.

### DIFF
--- a/packages/core/src/Selection.js
+++ b/packages/core/src/Selection.js
@@ -86,7 +86,7 @@ export class Selection extends Param {
 
   /**
    * Create a clone of this Selection with clauses corresponding
-   * to provided source removed.
+   * to the provided source removed.
    * @param {*} source The clause source to remove.
    * @returns {this} A cloned and updated Selection.
    */
@@ -192,12 +192,16 @@ export class Selection extends Param {
   /**
    * Return a selection query predicate for the given client.
    * @param {*} client The client whose data may be filtered.
+   * @param {boolean} [noSkip=false] Disable skipping of active
+   *  cross-filtered sources. If set true, the source of the active
+   *  clause in a cross-filtered selection will not be skipped.
    * @returns {*} The query predicate for filtering client data,
    *  based on the current state of this selection.
    */
-  predicate(client) {
+  predicate(client, noSkip = false) {
     const { clauses } = this;
-    return this._resolver.predicate(clauses, clauses.active, client);
+    const active = noSkip ? null : clauses.active;
+    return this._resolver.predicate(clauses, active, client);
   }
 }
 

--- a/packages/vgplot/src/interactors/Highlight.js
+++ b/packages/vgplot/src/interactors/Highlight.js
@@ -55,11 +55,16 @@ async function predicateFunction(mark, selection) {
     return () => true;
   }
 
+  // set flag so we do not skip cross-filtered sources
+  const filter = mark.filterBy?.predicate(mark, true);
+
   const s = { __: and(pred) };
-  const q = mark.query(mark.filterBy?.predicate(mark));
+  const q = mark.query(filter);
   const p = q.groupby().length ? q.select(s) : q.$select(s);
 
   const data = await coordinator().query(p);
   const v = data.getChild?.('__');
-  return v ? (i => v.get(i)) : (i => data[i].__);
+  return !(data.numRows || data.length) ? (() => false)
+    : v ? (i => v.get(i))
+    : (i => data[i].__);
 }

--- a/packages/vgplot/src/interactors/Toggle.js
+++ b/packages/vgplot/src/interactors/Toggle.js
@@ -1,4 +1,4 @@
-import { and, or, eq, literal } from '@uwdata/mosaic-sql';
+import { and, or, isNotDistinct, literal } from '@uwdata/mosaic-sql';
 
 export class Toggle {
   constructor(mark, {
@@ -31,7 +31,9 @@ export class Toggle {
 
     if (value) {
       const clauses = value.map(vals => {
-        const list = vals.map((v, i) => eq(channels[i].field, literal(v)));
+        const list = vals.map((v, i) => {
+          return isNotDistinct(channels[i].field, literal(v));
+        });
         return list.length > 1 ? and(list) : list[0];
       });
       predicate = clauses.length > 1 ? or(clauses) : clauses[0];


### PR DESCRIPTION
- Add new `noSkip` parameter to `selection.predicate`, to disable skipping of cross-filter clause source.
- Fix `highlight` interactor to generate predicate without skipping and to handle empty result sets.
- Fix `toggle` interactor to use `IS NOT DISTINCT FROM` for null-safe equality checks.

Fix #145. Close #146.
