### PR TITLE
fix: change binField to use min provided by bins

### DIFF
--- a/packages/vgplot/src/transforms/bin.js
+++ b/packages/vgplot/src/transforms/bin.js
@@ -38,7 +38,7 @@ function binField(mark, column, options) {
       const base = b.min === 0 ? col : `(${col} - ${b.min})`;
       const alpha = `${(b.max - b.min) / b.steps}::DOUBLE`;
       const off = options.offset ? `${options.offset} + ` : '';
-      return `${min} + ${alpha} * (${off}FLOOR(${base} / ${alpha})::INTEGER)`;
+      return `${b.min} + ${alpha} * (${off}FLOOR(${base} / ${alpha})::INTEGER)`;
     }
   };
 }


### PR DESCRIPTION
If I understood `binField` and `bins` functions correctly, `min` provided by `bins` should be used for the output of `binField` since `nice=true` changes the `min`.

This PR replaces `min` to `b.min` 