### PR TITLE
Convert TIMESTAMP sql type to Date object

### DIFF
--- a/packages/vgplot/src/marks/Mark.js
+++ b/packages/vgplot/src/marks/Mark.js
@@ -138,7 +138,19 @@ export class Mark extends MosaicClient {
   }
 
   queryResult(data) {
+    const timestamp_keys = Object.entries(this.stats).filter(([c, s]) => {
+      return s.sqlType === 'TIMESTAMP';
+    }).map(([c, s]) => c);
+    
     this.data = Array.from(data);
+    if (timestamp_keys.length > 0) {
+      this.data = this.data.map(d => {
+        timestamp_keys.forEach(k => {
+          d[k] = new Date(d[k]);
+        });
+        return d;
+      });
+    }
     return this;
   }
 


### PR DESCRIPTION
When using DuckDB TIMESTAMP data types, Arrow serializes to the int64 ms since epoch, but Mosaic never reconverts back into a Javascript Date object before passing the value to Plot. Existing behavior is that we see integers in the axis instead of formatted Date/time. Added a bit of a hack to the Marks class to catch this datatype but I'm not sure if it's best to place it inside queryResult or elsewhere. Also I'm not sure if other timestamp-ish datatypes will cause the same issue. Please let me know if I can be of any help. Thank you!!