### PR TITLE
Add Plot status events to vgplot

### DIFF
--- a/docs/api/vgplot/plot.md
+++ b/docs/api/vgplot/plot.md
@@ -48,6 +48,25 @@ Return the "inner" width of the plot, which is the `width` attribute value minus
 
 Return the "inner" height of the plot, which is the `height` attribute value minus the `topMargin` and `bottomMargin` values.
 
+### status
+
+`plot.status`
+
+Return the `status` of a `Plot` instance (one of `idle`, `pendingQuery` and `pendingRender`).
+
+- Initial `status` is `idle`.
+- When marks are initially connected to coordinator (via `plot.connect()`) or when a mark of a plot has a pending query, status will change to `pendingQuery`.
+- When all pending queries of plot marks are done, status will change to `pendingRender`.
+- After rendering, status will change to `idle` again.
+
+There is a `status` event listener available, see `plot.addEventListener` and `plot.removeEventListener`.
+
+### connect
+
+`plot.connect()`
+
+Connect all [`Mark`](./marks) instances to coordinator.
+
 ### pending
 
 `plot.pending(mark)`
@@ -94,6 +113,12 @@ Adds an event listener _callback_ that is invoked when the attribute with the gi
 
 Removes an event listener _callback_ associated with the given attribute _name_.
 
+### addDirectives
+
+`plot.addDirectives(directives)`
+
+Adds directives to plot.
+
 ### addParams
 
 `plot.addParams(mark, paramSet)`
@@ -128,3 +153,16 @@ Called by [interactor directives](./interactors).
 Add a _legend_ associated with this plot.
 The _include_ flag (default `true`) indicates if the legend should be included within the same container element as the plot.
 Called by [legend directives](./legends).
+
+### addEventListener
+
+`plot.addEventListener(type, callback)`
+
+Add an event listener _callback_ function for the specified event _type_.
+`Plot` supports `"status"` type events only.
+
+### removeEventListener
+
+`plot.removeEventListener(type, callback)`
+
+Remove an event listener _callback_ function for the specified event _type_.

--- a/docs/api/vgplot/specs.md
+++ b/docs/api/vgplot/specs.md
@@ -180,6 +180,14 @@ The supported external _options_ are:
 - _params_: An array (default `[]`) of predefined [`Param`](../core/param) instances. Each entry should have the form `[name, param]`.
 - _datasets_: An array (default `[]`) of preloaded browser-managed datasets (such as GeoJSON data). Each entry should have the form `[name, dataset]`.
 
+## parsePlotSpec
+
+`parsePlotSpec(specification, options, element)`
+
+Parse a JSON _specification_ of a single plot and return corresponding `Plot` instance.
+See `parseSpec` for supported _options_.
+If provided, the input _element_ will be used as the container for the plot, otherwise a new `div` element will be generated.
+
 ## specToModule
 
 `specToModule(spec, options)`

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -11,3 +11,4 @@ export { wasmConnector } from './connectors/wasm.js';
 export { distinct } from './util/distinct.js';
 export { synchronizer } from './util/synchronizer.js';
 export { throttle } from './util/throttle.js';
+export { AsyncDispatch } from './util/AsyncDispatch.js';

--- a/packages/vgplot/src/directives/plot.js
+++ b/packages/vgplot/src/directives/plot.js
@@ -3,8 +3,10 @@ import { Plot } from '../plot.js';
 
 export function plot(...directives) {
   const p = new Plot();
-  directives.flat().forEach(dir => dir(p));
-  p.marks.forEach(mark => coordinator().connect(mark));
+
+  p.addDirectives(directives.flat());
+  p.connect();
+
   return p.element;
 }
 

--- a/packages/vgplot/src/index.js
+++ b/packages/vgplot/src/index.js
@@ -300,6 +300,7 @@ export {
 
 export {
   parseSpec,
+  parsePlotSpec,
   ParseContext
 } from './spec/parse-spec.js';
 


### PR DESCRIPTION
## Why is this pull request necessary?

When using _vgplot_, there is currently no way to keep track of the status of a single plot (e.g. is plot refreshing or already done?). 
Statuses could be helpful for showing a spinner, while data is updating (see example below).
In a component framework, it could make sense to work with a `Plot` class directly (one component renders a single plot). Also, in that way an already existing element (`SVGSVGElement` or `HTMLDivElement`) can be used, instead of a newly generated one of `vg.plot`.

## What does this pull request cover?

This pull request adds more convenience methods for building and working with a `Plot` instance.

- Add following attributes/methods to `Plot` class
  - `status`: attribute (one of `idle`, `pendingQuery` or `pendingRender`)
  - `connect`: method for connecting all `Plot` marks to coordinator
  - `addDirectives`: method for adding directives to `Plot`
  - `addEventListener`: method for adding event listener for `status` value
  - `removeEventListener`: method for removing event listener for `status` value
- Add `parsePlotSpec` to `parse-spec.js` for creating a `Plot` instance from JSON specification
- Add all above attributes/methods to documentation

## How to create a `Plot` instance?

Create a `Plot` instance directly from class

```typescript
import { Plot } from '@uwdata/vgplot';

const plot = new Plot(element);

plot.addDirectives(...);
```

Create a `Plot` instance from JSON specification via `parsePlotSpec` 

```typescript
import { parsePlotSpec, type Spec, type Param } from '@uwdata/vgplot';

const spec: Spec = { plot: [...], width: 800, height: 600 };
const params: [string, Param][] = [...];

const plot = await parsePlotSpec(spec, { params }, element);
```

Then, on an existing `Plot` instance, one can add an event listener for status updates.
Finally, all marks need to be connected to _Mosaic_ coordinator with `connect` method.

```typescript
plot.addEventListener('status', (status: string) => {
  // do something with `status`
});

await plot.connect();
```
   
## Breaking changes

None, as existing API has not changed.

## Example: Rendering a dashboard with several _Mosaic_ plots

When using several single _vgplot_ plots in a dashboard, it is sometimes unclear which plots are still updating and which have already been re-rendered. A small example (more plots → more confusion):

https://github.com/uwdata/mosaic/assets/5602551/5a5fe659-6038-4d80-8d50-3ce4fbff0b6d

Using status events of `Plot`, we can indicate that a plot is outdated (here via spinner and transparency).

https://github.com/uwdata/mosaic/assets/5602551/3b05b136-3efe-4898-9241-99f1b0d841d8

## Note about this pull request

This pull request was created, because of the specific need of embedding _vgplot_ plots in a pure SVG dashboard application. Feel free to do whatever you like with it.
If `Plot` classes should not be used directly in above way or it is against _vgplot_ philosophy, just ignore it.