### PR TITLE
Coerce selected Arrow types in vgplot.

### DIFF
--- a/packages/vgplot/src/marks/Mark.js
+++ b/packages/vgplot/src/marks/Mark.js
@@ -3,6 +3,7 @@ import { Query, Ref, column, isParamLike } from '@uwdata/mosaic-sql';
 import { isColor } from './util/is-color.js';
 import { isConstantOption } from './util/is-constant-option.js';
 import { isSymbol } from './util/is-symbol.js';
+import { toDataArray } from './util/to-data-array.js';
 import { Transform } from '../symbols.js';
 
 const isColorChannel = channel => channel === 'stroke' || channel === 'fill';
@@ -138,7 +139,7 @@ export class Mark extends MosaicClient {
   }
 
   queryResult(data) {
-    this.data = Array.from(data);
+    this.data = toDataArray(data);
     return this;
   }
 

--- a/packages/vgplot/src/marks/RegressionMark.js
+++ b/packages/vgplot/src/marks/RegressionMark.js
@@ -7,6 +7,7 @@ import {
 import { qt } from './util/stats.js';
 import { Mark, channelOption } from './Mark.js';
 import { handleParam } from './util/handle-param.js';
+import { toDataArray } from './util/to-data-array.js';
 
 export class RegressionMark extends Mark {
   constructor(source, options) {
@@ -43,7 +44,7 @@ export class RegressionMark extends Mark {
   }
 
   queryResult(data) {
-    this.modelFit = Array.from(data);
+    this.modelFit = toDataArray(data);
 
     // regression line
     this.lineData = this.modelFit.flatMap(m => linePoints(m));

--- a/packages/vgplot/src/marks/util/grid.js
+++ b/packages/vgplot/src/marks/util/grid.js
@@ -1,3 +1,5 @@
+import { isArrowTable } from './is-arrow-table.js';
+
 export function grid1d(n, values) {
   return valuesToGrid(new Float64Array(n), values);
 }
@@ -6,10 +8,6 @@ export function grid2d(m, n, values, groupby = []) {
   return groupby.length
     ? Object.values(groupedValuesToGrids(m * n, values, groupby))
     : [{ grid: valuesToGrid(new Float64Array(m * n), values) }];
-}
-
-function isArrowTable(values) {
-  return typeof values.getChild === 'function';
 }
 
 function valuesToGrid(grid, values) {

--- a/packages/vgplot/src/marks/util/is-arrow-table.js
+++ b/packages/vgplot/src/marks/util/is-arrow-table.js
@@ -1,0 +1,3 @@
+export function isArrowTable(values) {
+  return typeof values?.getChild === 'function';
+}

--- a/packages/vgplot/src/marks/util/to-data-array.js
+++ b/packages/vgplot/src/marks/util/to-data-array.js
@@ -1,0 +1,58 @@
+import { isArrowTable } from './is-arrow-table.js';
+
+const INTEGER = 2;
+const TIMESTAMP = 10;
+
+export function toDataArray(data) {
+  return isArrowTable(data) ? arrowToObjects(data) : data;
+}
+
+export function arrowToObjects(data) {
+  const { batches, numRows: length } = data;
+
+  // return an empty array for empty tables
+  if (!length) return [];
+
+  // pre-allocate output objects
+  const objects = Array.from({ length }, () => ({}));
+
+  // for each row batch...
+  for (let k = 0, b = 0; b < batches.length; ++b) {
+    const batch = batches[b];
+    const { schema, numRows, numCols } = batch;
+
+    // for each column...
+    for (let j = 0; j < numCols; ++j) {
+      const child = batch.getChildAt(j);
+      const { name, type } = schema.fields[j];
+      const valueOf = convert(type);
+
+      // for each row in the current batch...
+      for (let o = k, i = 0; i < numRows; ++i, ++o) {
+        // extract/convert value from arrow, copy to output object
+        objects[o][name] = valueOf(child.get(i));
+      }
+    }
+
+    k += numRows;
+  }
+
+  return objects;
+}
+
+function convert(type) {
+  const { typeId } = type;
+
+  // map timestamp numbers to date objects
+  if (typeId === TIMESTAMP) {
+    return v => v == null ? v : new Date(v);
+  }
+
+  // map bignum to number
+  if (typeId === INTEGER && type.bitWidth >= 64) {
+    return v => v == null ? v : Number(v);
+  }
+
+  // otherwise use Arrow JS defaults
+  return v => v;
+}


### PR DESCRIPTION
- Map Arrow Timestamp types to JS `Date` objects, rather than numbers.
- Map Arrow Int64 types to JS `Number` instances, rather than `BigInt`. (FWIW, Plot already does this internally.)

These changes apply to unpacking of Arrow tables within vgplot only. We unpack an Arrow table into an array-of-objects format. This was already happening implicitly (using possibly slower Proxy objects); we now do it explicitly with control over type conversions. In the future, if [Plot adds support for columnar data](https://github.com/observablehq/plot/issues/191) we could modify our approach to take advantage of that and reduce data copy costs.

Mosaic client implementations still receive a standard, unaltered Arrow table. This PR targets vgplot mark internals.

Possible future work:
- coerce other types, such as `Time` values?
- refactor coercion support to a utility library for other client implementations to use if desired.

Close #155.
Close #176.
