### PR TITLE
Push orderby criteria to data cube index queries.

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -22,6 +22,7 @@
         <option value="flights-10m">Flights 10M</option>
         <option value="gaia">Gaia Star Catalog</option>
         <option value="hexbin">Hexbin</option>
+        <option value="highlight-cube">Highlight Cube</option>
         <option value="highlight-toggle">Highlight Toggle</option>
         <option value="images">Images</option>
         <option value="links">Links</option>

--- a/dev/yaml/highlight-cube.yaml
+++ b/dev/yaml/highlight-cube.yaml
@@ -1,0 +1,46 @@
+data:
+  athletes: { file: data/athletes.csv }
+params:
+  query: { select: crossfilter }
+  selectNationality: { select: single }
+  selectSport: { select: single }
+vconcat:
+  - plot:
+    - mark: barX
+      data: { from: athletes, filterBy: $query }
+      x: { count: }
+      y: nationality
+      order: nationality
+      sort: {
+        y: '-x',
+        limit: 10
+      }
+    - select: highlight
+      by: $selectNationality
+    - select: toggleY
+      as: $selectNationality
+    - select: toggleY
+      as: $query
+      width: 600
+      height: 400
+    marginLeft: 80
+  - vspace: 10
+  - plot:
+    - mark: barX
+      data: { from: athletes, filterBy: $query }
+      x: { count: }
+      y: sport
+      order: sport
+      sort: {
+        y: '-x',
+        limit: 10
+      }
+    - select: highlight
+      by: $selectSport
+    - select: toggleY
+      as: $selectSport
+    - select: toggleY
+      as: $query
+      width: 600
+      height: 400
+    marginLeft: 80


### PR DESCRIPTION
- Include `orderby` criteria in generated data cube index queries.
- Add dev `highlight-cube` example to test consistent ordering of cube query results. (thanks @spren9er!)

Prior to this PR, any orderby criteria were applied upon data cube creation, but not upon subsequent queries to the resulting data cube index table. This PR reverses the situation: orderby criteria are stripped (ignored) for cube creation, but subsequently applied to all cube index table queries to ensure correct and consistent ordering of result rows.

This change fixes the observed ordering inconsistencies between normal and data cube index query results, fixing known highlight interactor bugs over ordered data. (It does not fix the underlying issue that highlight bit vector queries may have different orderings from other queries if no orderby criteria are given.)

Close #159.