### PR TITLE
Query builder creates wrong where clause when used with disjunctions in subclauses 

### DIFF
--- a/packages/sql/src/Query.js
+++ b/packages/sql/src/Query.js
@@ -323,9 +323,11 @@ export class Query {
     // WHERE
     if (where.length) {
       const clauses = where
-        .map(String)
-        .filter(x => x)
-        .map((clause) => `(${clause})`)
+        .reduce((agg, clause) => {
+          const c = String(clause);
+          if (c) agg.push(clause.op === 'OR' ? `(${c})` : c);
+          return agg;
+        }, [])
         .join(' AND ');
       if (clauses) sql.push(`WHERE ${clauses}`);
     }

--- a/packages/sql/src/Query.js
+++ b/packages/sql/src/Query.js
@@ -322,7 +322,11 @@ export class Query {
 
     // WHERE
     if (where.length) {
-      const clauses = where.map(String).filter(x => x).join(' AND ');
+      const clauses = where
+        .map(String)
+        .filter(x => x)
+        .map((clause) => `(${clause})`)
+        .join(' AND ');
       if (clauses) sql.push(`WHERE ${clauses}`);
     }
 

--- a/packages/sql/test/query-test.js
+++ b/packages/sql/test/query-test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import {
-  column, desc, gt, lt, max, min, relation, sql, Query
+  column, desc, or, eq, gt, lt, max, min, relation, sql, Query
 } from '../src/index.js';
 
 describe('Query', () => {
@@ -234,18 +234,37 @@ describe('Query', () => {
   it('selects filtered rows', () => {
     const foo = column('foo');
     const bar = column('bar');
+    const baz = column('baz');
 
     const query = [
       'SELECT "foo"',
       'FROM "data"',
-      'WHERE ("bar" > 50) AND ("bar" < 100)'
+      'WHERE (("bar" < 50) OR ("bar" > 100)) AND ("baz" = 75)'
     ].join(' ');
 
     assert.strictEqual(
       Query
         .select(foo)
         .from('data')
-        .where(gt(bar, 50), lt(bar, 100))
+        .where(or(lt(bar, 50), gt(bar, 100)), eq(baz, 75))
+        .toString(),
+      query
+    );
+
+    assert.strictEqual(
+      Query.select(foo)
+        .from('data')
+        .where([or(lt(bar, 50), gt(bar, 100)), eq(baz, 75)])
+        .toString(),
+      query,
+    );
+
+    assert.strictEqual(
+      Query
+        .select(foo)
+        .from('data')
+        .where(or(lt(bar, 50), gt(bar, 100)))
+        .where(eq(baz, 75))
         .toString(),
       query
     );
@@ -254,26 +273,7 @@ describe('Query', () => {
       Query
         .select(foo)
         .from('data')
-        .where([gt(bar, 50), lt(bar, 100)])
-        .toString(),
-      query
-    );
-
-    assert.strictEqual(
-      Query
-        .select(foo)
-        .from('data')
-        .where(gt(bar, 50))
-        .where(lt(bar, 100))
-        .toString(),
-      query
-    );
-
-    assert.strictEqual(
-      Query
-        .select(foo)
-        .from('data')
-        .where(sql`("bar" > 50) AND ("bar" < 100)`)
+        .where(sql`(("bar" < 50) OR ("bar" > 100)) AND ("baz" = 75)`)
         .toString(),
       query
     );


### PR DESCRIPTION
This bug occurred while testing toggle interactor with multiple bar charts.

When selecting two bars in one bar chart and a bar in another bar chart, total number of records is not correct (using cross filter selection).

A simple Mosaic client is used for total number of records:

```javascript
export class KPI extends SvelteMosaicClient {
  // ...
  
  public query(filter = []) {
    return Query.from('flights_5m')
      .select({ total_flights: count() })
      .where(filter);
  }
  
  // ...
}
``` 

The resulting query from `mosaic-sql` looks like this:

```sql
SELECT COUNT(*)::INTEGER AS "total_flights"
FROM "flights_5m"
WHERE
  ("flight_no" IS NOT DISTINCT FROM 418) OR ("flight_no" IS NOT DISTINCT FROM 772)
  AND ("origin" IS NOT DISTINCT FROM 'DEN')
```

Above query is not correct as AND binds more tightly than OR.

This pull request fixes above issue and updates an existing tests, which also covers above case now.