### PR TITLE
add configuration options for DuckDB class

### DIFF
--- a/packages/duckdb/src/DuckDB.js
+++ b/packages/duckdb/src/DuckDB.js
@@ -3,7 +3,7 @@ import { mergeBuffers } from './merge-buffers.js';
 
 const TEMP_DIR = '.duckdb';
 
-const CONFIG = [
+const INIT_STATEMENTS = [
   `PRAGMA temp_directory='${TEMP_DIR}'`,
   `INSTALL arrow`,
   `INSTALL httpfs`,
@@ -12,10 +12,14 @@ const CONFIG = [
 ];
 
 export class DuckDB {
-  constructor(path = ':memory:') {
-    this.db = new duckdb.Database(path);
+  constructor(
+    path = ':memory:',
+    config = {},
+    initStatementsOverride = null
+  ) {
+    this.db = new duckdb.Database(path, config);
     this.con = this.db.connect();
-    this.exec(CONFIG.join(';\n'));
+    this.exec((initStatementsOverride ?? INIT_STATEMENTS).join(';\n'));
   }
 
   close() {

--- a/packages/duckdb/src/DuckDB.js
+++ b/packages/duckdb/src/DuckDB.js
@@ -3,23 +3,23 @@ import { mergeBuffers } from './merge-buffers.js';
 
 const TEMP_DIR = '.duckdb';
 
-const INIT_STATEMENTS = [
+const DEFAULT_INIT_STATEMENTS = [
   `PRAGMA temp_directory='${TEMP_DIR}'`,
   `INSTALL arrow`,
   `INSTALL httpfs`,
   `LOAD arrow`,
   `LOAD httpfs`
-];
+].join(';\n');
 
 export class DuckDB {
   constructor(
     path = ':memory:',
     config = {},
-    initStatementsOverride = null
+    initStatements = DEFAULT_INIT_STATEMENTS
   ) {
     this.db = new duckdb.Database(path, config);
     this.con = this.db.connect();
-    this.exec((initStatementsOverride ?? INIT_STATEMENTS).join(';\n'));
+    this.exec(initStatements);
   }
 
   close() {


### PR DESCRIPTION
I need to install unsigned extensions, so when I instantiate my duckdb class I need to pass a [configuration object](https://duckdb.org/docs/sql/configuration#configuration-reference) like so:

```js
new DuckDB.Database(":memory:", {
    allow_unsigned_extensions: "true",
})
```

I also need to be able to install the arrow extension from a `custom_extension_repository` so ideally I'd be able to override the `CONFIG` as well