### PR TITLE
typescript: adding type definitions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
   "module": "src/index.js",
   "jsdelivr": "dist/mosaic-core.min.js",
   "unpkg": "dist/mosaic-core.min.js",
+  "types": "dist/types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/uwdata/mosaic.git"
@@ -25,7 +26,8 @@
     "build": "node ../../esbuild.js mosaic-core",
     "lint": "eslint src test --ext .js",
     "test": "mocha 'test/**/*-test.js'",
-    "prepublishOnly": "npm run test && npm run lint && npm run build"
+    "types": "tsc",
+    "prepublishOnly": "npm run test && npm run lint && npm run build && npm run types"
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "^1.27.0",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/types",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/duckdb/package.json
+++ b/packages/duckdb/package.json
@@ -14,6 +14,7 @@
   "type": "module",
   "main": "src/index.js",
   "module": "src/index.js",
+  "types": "dist/types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/uwdata/mosaic.git"
@@ -27,7 +28,8 @@
     "lint": "eslint src test --ext .js",
     "server": "node bin/run-server.js",
     "test": "mocha 'test/**/*-test.js'",
-    "prepublishOnly": "npm run test && npm run lint"
+    "types": "tsc",
+    "prepublishOnly": "npm run test && npm run lint && npm run types"
   },
   "dependencies": {
     "duckdb": "~0.8.1",

--- a/packages/duckdb/tsconfig.json
+++ b/packages/duckdb/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/types",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/inputs/package.json
+++ b/packages/inputs/package.json
@@ -13,6 +13,7 @@
   "module": "src/index.js",
   "jsdelivr": "dist/mosaic-inputs.min.js",
   "unpkg": "dist/mosaic-inputs.min.js",
+  "types": "dist/types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/uwdata/mosaic.git"
@@ -22,7 +23,8 @@
     "build": "node ../../esbuild.js mosaic-inputs",
     "lint": "eslint src test --ext .js",
     "test": "mocha 'test/**/*-test.js'",
-    "prepublishOnly": "npm run test && npm run lint && npm run build"
+    "types": "tsc",
+    "prepublishOnly": "npm run test && npm run lint && npm run build && npm run types"
   },
   "dependencies": {
     "@uwdata/mosaic-core": "^0.3.4",

--- a/packages/inputs/tsconfig.json
+++ b/packages/inputs/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/types",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -14,6 +14,7 @@
   "module": "src/index.js",
   "jsdelivr": "dist/mosaic-sql.min.js",
   "unpkg": "dist/mosaic-sql.min.js",
+  "types": "dist/types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/uwdata/mosaic.git"
@@ -23,6 +24,7 @@
     "build": "node ../../esbuild.js mosaic-sql",
     "lint": "eslint src test --ext .js",
     "test": "mocha 'test/**/*-test.js'",
-    "prepublishOnly": "npm run test && npm run lint && npm run build"
+    "types": "tsc",
+    "prepublishOnly": "npm run test && npm run lint && npm run build && npm run types"
   }
 }

--- a/packages/sql/tsconfig.json
+++ b/packages/sql/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/types",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/vgplot/package.json
+++ b/packages/vgplot/package.json
@@ -17,6 +17,7 @@
   "module": "src/index.js",
   "jsdelivr": "dist/vgplot.min.js",
   "unpkg": "dist/vgplot.min.js",
+  "types": "dist/types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/uwdata/mosaic.git"
@@ -26,7 +27,8 @@
     "build": "node ../../esbuild.js vgplot",
     "lint": "eslint src test --ext .js",
     "test": "mocha 'test/**/*-test.js'",
-    "prepublishOnly": "npm run test && npm run lint && npm run build"
+    "types": "tsc",
+    "prepublishOnly": "npm run test && npm run lint && npm run build && npm run types"
   },
   "dependencies": {
     "@observablehq/plot": "^0.6.11",

--- a/packages/vgplot/tsconfig.json
+++ b/packages/vgplot/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/types",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Hey folks,

Thanks for putting together this awesome project. I wanted to work with generated typescript types, so those will now be generated in the `dist` folders as part of the `lerna publish` step. If you'd like to verify, you can run...

```sh
$ npx lerna run prepublishOnly
$ find packages/*/dist/types
```

Happy to make other edits, let me know what you think.