### PR TITLE
feat: Generalize Nearest selection to accept array of parameters

### DIFF
--- a/packages/vgplot/src/spec/parse-spec.js
+++ b/packages/vgplot/src/spec/parse-spec.js
@@ -153,6 +153,13 @@ export class ParseContext {
     return this.maybeParam(value, () => Selection.intersect());
   }
 
+  maybeSelections(value) {
+    if (Array.isArray(value)) {
+      return value.map(v => this.maybeSelection(v));
+    }
+    return this.maybeSelection(value);
+  }
+
   maybeTransform(value) {
     if (isObject(value)) {
       return value.expr
@@ -358,7 +365,7 @@ function parseInteractor(spec, ctx) {
     error(`Unrecognized interactor type: ${select}`, spec);
   }
   for (const key in options) {
-    options[key] = ctx.maybeSelection(options[key]);
+    options[key] = ctx.maybeSelections(options[key]);
   }
   return fn(options);
 }

--- a/packages/vgplot/src/spec/to-module.js
+++ b/packages/vgplot/src/spec/to-module.js
@@ -141,6 +141,13 @@ class CodegenContext extends ParseContext {
     return this.maybeParam(value, 'vg.Selection.intersect()');
   }
 
+  maybeSelections(value) {
+    if (Array.isArray(value)) {
+      return `[${value.map(v => this.maybeSelection(v)).join(',')}]`;
+    }
+    return this.maybeSelection(value);
+  }
+
   maybeTransform(value) {
     if (isObject(value)) {
       return value.expr
@@ -458,7 +465,7 @@ function parseInteractor(spec, ctx) {
   }
   const opt = [];
   for (const key in options) {
-    opt.push(`${key}: ${ctx.maybeSelection(options[key])}`);
+    opt.push(`${key}: ${ctx.maybeSelections(options[key])}`);
   }
   return `${ctx.tab()}vg.${select}({ ${opt.join(', ')} })`;
 }


### PR DESCRIPTION
Right now this is only implemented for Nearest (hence why I'm putting this up as a draft), but if this looks ok to people, the idea shouldn't be hard to generalize to the other interactors as well.

Closes #246