### PR TITLE
Fix index column identification with non-string aggregate key.

### DIFF
--- a/packages/core/src/DataCubeIndexer.js
+++ b/packages/core/src/DataCubeIndexer.js
@@ -211,7 +211,7 @@ function getIndexColumns(client) {
   let count;
 
   for (const { as, expr: { aggregate } } of q.select()) {
-    switch (aggregate?.toUpperCase()) {
+    switch (aggregate?.toUpperCase?.()) {
       case 'COUNT':
       case 'SUM':
         aggr.push({ [as]: sql`SUM("${as}")::DOUBLE` });


### PR DESCRIPTION
Aggregate expressions include an `aggregate` key indicating they perform aggregation. For normal aggregation functions, this key is a string value indicating the aggregate operation. However, custom aggregate expressions are also possible, indicated by a boolean `true` value for the `aggregate` key.

The data cube indexer refers to the `aggregate` key to try to identify indexing opportunities. This PR fixes a bug where this process breaks due to assuming a string value. The current fix is to fall through to the default action (which does not perform any indexing) when non-string values are observed.

Fix #263.