### PR TITLE
Use orderby, not order. Allow highlight to automatically set orderby.

### DIFF
--- a/dev/yaml/highlight-cube.yaml
+++ b/dev/yaml/highlight-cube.yaml
@@ -10,7 +10,6 @@ vconcat:
       data: { from: athletes, filterBy: $query }
       x: { count: }
       y: nationality
-      order: nationality
       sort: {
         y: '-x',
         limit: 10
@@ -30,7 +29,6 @@ vconcat:
       data: { from: athletes, filterBy: $query }
       x: { count: }
       y: sport
-      order: sport
       sort: {
         y: '-x',
         limit: 10

--- a/dev/yaml/weather.yaml
+++ b/dev/yaml/weather.yaml
@@ -28,6 +28,7 @@ vconcat:
     colorRange: $colors
     rDomain: Fixed
     rRange: [2, 10]
+    marginLeft: 45
     width: 800
 - plot:
   - mark: barX
@@ -40,7 +41,6 @@ vconcat:
     x: { count: }
     y: weather
     fill: weather
-    order: weather
   - select: toggleY
     as: $click
   - select: highlight
@@ -50,4 +50,5 @@ vconcat:
   yLabel: null
   colorDomain: $domain
   colorRange: $colors
+  marginLeft: 45
   width: 800

--- a/docs/public/specs/esm/weather.js
+++ b/docs/public/specs/esm/weather.js
@@ -36,7 +36,7 @@ export default vg.vconcat(
     ),
     vg.barX(
       vg.from("weather", { filterBy: $range }),
-      { x: vg.count(), y: "weather", fill: "weather", order: "weather" }
+      { x: vg.count(), y: "weather", fill: "weather" }
     ),
     vg.toggleY({ as: $click }),
     vg.highlight({ by: $click }),

--- a/docs/public/specs/json/weather.json
+++ b/docs/public/specs/json/weather.json
@@ -105,8 +105,7 @@
             "count": null
           },
           "y": "weather",
-          "fill": "weather",
-          "order": "weather"
+          "fill": "weather"
         },
         {
           "select": "toggleY",

--- a/docs/public/specs/yaml/weather.yaml
+++ b/docs/public/specs/yaml/weather.yaml
@@ -50,7 +50,6 @@ vconcat:
     x: { count: }
     y: weather
     fill: weather
-    order: weather
   - select: toggleY
     as: $click
   - select: highlight

--- a/packages/vgplot/src/marks/HexbinMark.js
+++ b/packages/vgplot/src/marks/HexbinMark.js
@@ -40,7 +40,7 @@ export class HexbinMark extends Mark {
     const aggr = new Set;
     const cols = {};
     for (const c of channels) {
-      if (c.channel === 'order') {
+      if (c.channel === 'orderby') {
         q.orderby(c.value); // TODO revisit once groupby is added
       } else if (c.channel === 'x') {
         x = c;

--- a/packages/vgplot/src/marks/Mark.js
+++ b/packages/vgplot/src/marks/Mark.js
@@ -174,7 +174,7 @@ export function markQuery(channels, table, skip = []) {
     const { channel, field, as } = c;
     if (skip.includes(channel)) continue;
 
-    if (channel === 'order') {
+    if (channel === 'orderby') {
       q.orderby(c.value);
     } else if (field) {
       if (field.aggregate) {

--- a/packages/vgplot/src/plot-attributes.js
+++ b/packages/vgplot/src/plot-attributes.js
@@ -182,3 +182,30 @@ export const attributeMap = new Map([
   ['projectionInsetBottom', 'projection.insetBottom'],
   ['projectionClip', 'projection.clip']
 ]);
+
+function setProperty(object, path, value) {
+  for (let i = 0; i < path.length; ++i) {
+    const key = path[i];
+    if (i === path.length - 1) {
+      object[key] = value;
+    } else {
+      object = (object[key] || (object[key] = {}));
+    }
+  }
+}
+
+export function setAttributes(attributes, spec, symbols) {
+  // populate top-level and scale properties
+  for (const key in attributes) {
+    const specKey = attributeMap.get(key);
+    if (specKey == null) {
+      throw new Error(`Unrecognized plot attribute: ${key}`);
+    }
+    const value = attributes[key];
+    if (typeof value === 'symbol') {
+      symbols.push(key);
+    } else if (value !== undefined) {
+      setProperty(spec, specKey.split('.'), value);
+    }
+  }
+}

--- a/packages/vgplot/src/plot-renderer.js
+++ b/packages/vgplot/src/plot-renderer.js
@@ -1,5 +1,5 @@
 import * as Plot from '@observablehq/plot';
-import { attributeMap } from './plot-attributes.js';
+import { setAttributes } from './plot-attributes.js';
 import { Fixed } from './symbols.js';
 
 const OPTIONS_ONLY_MARKS = new Set([
@@ -9,38 +9,17 @@ const OPTIONS_ONLY_MARKS = new Set([
   'graticule'
 ]);
 
-function setProperty(object, path, value) {
-  for (let i = 0; i < path.length; ++i) {
-    const key = path[i];
-    if (i === path.length - 1) {
-      object[key] = value;
-    } else {
-      object = (object[key] || (object[key] = {}));
-    }
-  }
-}
+
 
 // construct Plot output
 // see https://github.com/observablehq/plot
 export async function plotRenderer(plot) {
   const spec = { marks: [] };
   const symbols = [];
-
   const { attributes, marks } = plot;
 
   // populate top-level and scale properties
-  for (const key in attributes) {
-    const specKey = attributeMap.get(key);
-    if (specKey == null) {
-      throw new Error(`Unrecognized plot attribute: ${key}`);
-    }
-    const value = attributes[key];
-    if (typeof value === 'symbol') {
-      symbols.push(key);
-    } else if (value !== undefined) {
-      setProperty(spec, specKey.split('.'), value);
-    }
-  }
+  setAttributes(attributes, spec, symbols);
 
   // populate marks
   const indices = [];


### PR DESCRIPTION
This PR fixes a [bug](https://github.com/uwdata/mosaic/issues/248) in which the `highlight` interactor may highlight the wrong items if the data ordering of the visualized data is inconsistent with highlight query results. A workaround was to add sort criteria to ensure consistent ordering. This PR updates the `highlight` interactor to automatically add appropriate orderby criteria to a highlighted mark when needed.

**Breaking change:** This PR also addresses a conflict where the mark-level `order` option (which specified query orderby criteria) can be confused with Observable Plot's `order` option, which parameterizes internal stacking transforms. This update now uses a non-conflicting `orderby` option, leaving `order` as a Plot-specific option. **Any existing specifications which use the `order` option at the mark-level will likely need to update to use `orderby` instead.**

Fix #248.