### PR TITLE
v0.4

### DIFF
--- a/dev/yaml/highlight-cube.yaml
+++ b/dev/yaml/highlight-cube.yaml
@@ -10,7 +10,6 @@ vconcat:
       data: { from: athletes, filterBy: $query }
       x: { count: }
       y: nationality
-      order: nationality
       sort: {
         y: '-x',
         limit: 10
@@ -30,7 +29,6 @@ vconcat:
       data: { from: athletes, filterBy: $query }
       x: { count: }
       y: sport
-      order: sport
       sort: {
         y: '-x',
         limit: 10

--- a/dev/yaml/moving-average.yaml
+++ b/dev/yaml/moving-average.yaml
@@ -12,7 +12,7 @@ vconcat:
   - mark: lineY
     data: { from: cases }
     x: day
-    y: { avg: cases, order: day, rows: $frame }
+    y: { avg: cases, orderby: day, rows: $frame }
     curve: monotone-x
     stroke: black
   width: 1200

--- a/dev/yaml/weather.yaml
+++ b/dev/yaml/weather.yaml
@@ -28,6 +28,7 @@ vconcat:
     colorRange: $colors
     rDomain: Fixed
     rRange: [2, 10]
+    marginLeft: 45
     width: 800
 - plot:
   - mark: barX
@@ -40,7 +41,6 @@ vconcat:
     x: { count: }
     y: weather
     fill: weather
-    order: weather
   - select: toggleY
     as: $click
   - select: highlight
@@ -50,4 +50,5 @@ vconcat:
   yLabel: null
   colorDomain: $domain
   colorRange: $colors
+  marginLeft: 45
   width: 800

--- a/docs/api/sql/window-functions.md
+++ b/docs/api/sql/window-functions.md
@@ -25,7 +25,7 @@ The `label` property provides a descriptive text label.
 `WindowFunction.over(name)`
 
 Provide the _name_ of a window definition for this function and returns a new WindowFunction instance.
-The window should be defined separately in an issued query, for example using the [Query.window](./query#Query.window) method.
+The window should be defined separately in an issued query, for example using the [Query.window](./queries#window) method.
 
 ### partitionby
 

--- a/docs/public/specs/esm/weather.js
+++ b/docs/public/specs/esm/weather.js
@@ -36,7 +36,7 @@ export default vg.vconcat(
     ),
     vg.barX(
       vg.from("weather", { filterBy: $range }),
-      { x: vg.count(), y: "weather", fill: "weather", order: "weather" }
+      { x: vg.count(), y: "weather", fill: "weather" }
     ),
     vg.toggleY({ as: $click }),
     vg.highlight({ by: $click }),

--- a/docs/public/specs/json/moving-average.json
+++ b/docs/public/specs/json/moving-average.json
@@ -39,7 +39,7 @@
           "x": "day",
           "y": {
             "avg": "cases",
-            "order": "day",
+            "orderby": "day",
             "rows": "$frame"
           },
           "curve": "monotone-x",

--- a/docs/public/specs/json/weather.json
+++ b/docs/public/specs/json/weather.json
@@ -105,8 +105,7 @@
             "count": null
           },
           "y": "weather",
-          "fill": "weather",
-          "order": "weather"
+          "fill": "weather"
         },
         {
           "select": "toggleY",

--- a/docs/public/specs/yaml/moving-average.yaml
+++ b/docs/public/specs/yaml/moving-average.yaml
@@ -21,7 +21,7 @@ vconcat:
   - mark: lineY
     data: { from: cases }
     x: day
-    y: { avg: cases, order: day, rows: $frame }
+    y: { avg: cases, orderby: day, rows: $frame }
     curve: monotone-x
     stroke: currentColor
   width: 680

--- a/docs/public/specs/yaml/weather.yaml
+++ b/docs/public/specs/yaml/weather.yaml
@@ -50,7 +50,6 @@ vconcat:
     x: { count: }
     y: weather
     fill: weather
-    order: weather
   - select: toggleY
     as: $click
   - select: highlight

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
         "packages/*"
       ],
       "devDependencies": {
-        "esbuild": "^0.19.10",
+        "esbuild": "^0.19.11",
         "eslint": "^8.56.0",
-        "lerna": "^8.0.1",
+        "lerna": "^8.0.2",
         "mocha": "^10.2.0",
         "nodemon": "^3.0.2",
         "rimraf": "^5.0.5",
         "timezone-mock": "^1.3.6",
         "typescript": "^5.3.3",
-        "vite": "^5.0.10",
-        "vitepress": "1.0.0-rc.34",
+        "vite": "^5.0.11",
+        "vitepress": "1.0.0-rc.36",
         "yaml": "^2.3.4"
       }
     },
@@ -1178,9 +1178,9 @@
       }
     },
     "node_modules/@lerna/create": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.0.1.tgz",
-      "integrity": "sha512-PDYNUF8Nv5j7DbGvVbizEuYuQbNFZ0+wVOtRPvBQOkC2dMNryi3dJjktEd1QeDX6Wa/JkJWvZ5SMHyr+7H3Rtg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-8.0.2.tgz",
+      "integrity": "sha512-AueSlfiYXqEmy9/EIc17mjlaHFuv734dfgVBegyoefIA7hdeoExtsXnACWf8Tw5af6gwyTL3KAp6QQyc1sTuZQ==",
       "dev": true,
       "dependencies": {
         "@npmcli/run-script": "7.0.2",
@@ -1723,9 +1723,9 @@
       }
     },
     "node_modules/@npmcli/git": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.3.tgz",
-      "integrity": "sha512-UZp9NwK+AynTrKvHn5k3KviW/hA5eENmFsu3iAPe7sWRt0lFUdsY/wXIYjpDFe7cdSNwOIzbObfwgt6eL5/2zw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.4.tgz",
+      "integrity": "sha512-nr6/WezNzuYUppzXRaYu/W4aT5rLxdXqEFupbh6e/ovlYFQ8hpu1UUPV3Ir/YTl+74iXl2ZOMlGzudh9ZPUchQ==",
       "dev": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^7.0.0",
@@ -1863,9 +1863,9 @@
       }
     },
     "node_modules/@npmcli/promise-spawn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.0.tgz",
-      "integrity": "sha512-wBqcGsMELZna0jDblGd7UXgOby45TQaMWmbFwWX+SEotk4HV6zG2t6rT9siyLhPk4P6YYqgfL1UO8nMWDBVJXQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.1.tgz",
+      "integrity": "sha512-P4KkF9jX3y+7yFUxgcUdDtLy+t4OlDGuEBLNs57AZsfSfg+uV6MLndqGpnl4831ggaEdXwR50XFoZP4VFtHolg==",
       "dev": true,
       "dependencies": {
         "which": "^4.0.0"
@@ -1924,9 +1924,9 @@
       }
     },
     "node_modules/@npmcli/run-script/node_modules/cacache": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.1.tgz",
-      "integrity": "sha512-g4Uf2CFZPaxtJKre6qr4zqLDOOPU7bNVhWjlNhvzc51xaTOx2noMOLhfFkTAqwtrAZAKQUuDfyjitzilpA8WsQ==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.2.tgz",
+      "integrity": "sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==",
       "dev": true,
       "dependencies": {
         "@npmcli/fs": "^3.1.0",
@@ -3046,39 +3046,39 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.3.tgz",
-      "integrity": "sha512-u8jzgFg0EDtSrb/hG53Wwh1bAOQFtc1ZCegBpA/glyvTlgHl+tq13o1zvRfLbegYUw/E4mSTGOiCnAJ9SJ+lsg==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.10.tgz",
+      "integrity": "sha512-53vxh7K9qbx+JILnGEhrFRyr7H7e4NdT8RuTNU3m6HhJKFvcAqFTNXpYMHnyuAzzRGdsbsYHBgQC3H6xEXTG6w==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.6",
-        "@vue/shared": "3.4.3",
+        "@vue/shared": "3.4.10",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.3.tgz",
-      "integrity": "sha512-oGF1E9/htI6JWj/lTJgr6UgxNCtNHbM6xKVreBWeZL9QhRGABRVoWGAzxmtBfSOd+w0Zi5BY0Es/tlJrN6WgEg==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.10.tgz",
+      "integrity": "sha512-QAALBJksIFpXGYuo74rtMgnwpVZDvd3kYbUa4gYX9s/5QiqEvZSgbKtOdUGydXcxKPt3ifC+0/bhPVHXN2694A==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-core": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/compiler-core": "3.4.10",
+        "@vue/shared": "3.4.10"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.3.tgz",
-      "integrity": "sha512-NuJqb5is9I4uzv316VRUDYgIlPZCG8D+ARt5P4t5UDShIHKL25J3TGZAUryY/Aiy0DsY7srJnZL5ryB6DD63Zw==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.10.tgz",
+      "integrity": "sha512-sTOssaQySgrMjrhZxmAqdp6n+E51VteIVIDaOR537H2P63DyzMmig21U0XXFxiXmMIfrK91lAInnc+bIAYemGw==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.6",
-        "@vue/compiler-core": "3.4.3",
-        "@vue/compiler-dom": "3.4.3",
-        "@vue/compiler-ssr": "3.4.3",
-        "@vue/shared": "3.4.3",
+        "@vue/compiler-core": "3.4.10",
+        "@vue/compiler-dom": "3.4.10",
+        "@vue/compiler-ssr": "3.4.10",
+        "@vue/shared": "3.4.10",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.5",
         "postcss": "^8.4.32",
@@ -3086,13 +3086,13 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.3.tgz",
-      "integrity": "sha512-wnYQtMBkeFSxgSSQbYGQeXPhQacQiog2c6AlvMldQH6DB+gSXK/0F6DVXAJfEiuBSgBhUc8dwrrG5JQcqwalsA==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.10.tgz",
+      "integrity": "sha512-Y90TL1abretWbUiK5rv+9smS1thCHE5sSuhZgiLh6cxgZ2Pcy3BEvDd3reID0iwNcTdMbTeE6NI3Aq4Mux6hqQ==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/compiler-dom": "3.4.10",
+        "@vue/shared": "3.4.10"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -3102,52 +3102,52 @@
       "dev": true
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.3.tgz",
-      "integrity": "sha512-q5f9HLDU+5aBKizXHAx0w4whkIANs1Muiq9R5YXm0HtorSlflqv9u/ohaMxuuhHWCji4xqpQ1eL04WvmAmGnFg==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.10.tgz",
+      "integrity": "sha512-SmGGpo37LzPcAFTopHNIJRNVOQfma9YgyPkAzx9/TJ01lbCCYigS28hEcY1hjiJ1PRK8iVX62Ov5yzmUgYH/pQ==",
       "dev": true,
       "dependencies": {
-        "@vue/shared": "3.4.3"
+        "@vue/shared": "3.4.10"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.3.tgz",
-      "integrity": "sha512-C1r6QhB1qY7D591RCSFhMULyzL9CuyrGc+3PpB0h7dU4Qqw6GNyo4BNFjHZVvsWncrUlKX3DIKg0Y7rNNr06NQ==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.10.tgz",
+      "integrity": "sha512-Ri2Cz9sFr66AEUewGUK8IXhIUAhshTHVUGuJR8pqMbtjIds+zPa8QPO5UZImGMQ8HTY7eEpKwztCct9V3+Iqug==",
       "dev": true,
       "dependencies": {
-        "@vue/reactivity": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/reactivity": "3.4.10",
+        "@vue/shared": "3.4.10"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.3.tgz",
-      "integrity": "sha512-wrsprg7An5Ec+EhPngWdPuzkp0BEUxAKaQtN9dPU/iZctPyD9aaXmVtehPJerdQxQale6gEnhpnfywNw3zOv2A==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.10.tgz",
+      "integrity": "sha512-ROsdi5M2niRDmjXJNZ8KKiGwXyG1FO8l9n6sCN0kaJEHbjWkuigu96YAI3fK/AWUZPSXXEcMEBVPC6rL3mmUuA==",
       "dev": true,
       "dependencies": {
-        "@vue/runtime-core": "3.4.3",
-        "@vue/shared": "3.4.3",
+        "@vue/runtime-core": "3.4.10",
+        "@vue/shared": "3.4.10",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.3.tgz",
-      "integrity": "sha512-BUxt8oVGMKKsqSkM1uU3d3Houyfy4WAc2SpSQRebNd+XJGATVkW/rO129jkyL+kpB/2VRKzE63zwf5RtJ3XuZw==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.10.tgz",
+      "integrity": "sha512-WpCBAhesLq44JKWfdFqb+Bi4ACUW0d8x1z90GnE0spccsAlEDMXV5nm+pwXLyW0OdP2iPrO/n/QMJh4B1v9Ciw==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/compiler-ssr": "3.4.10",
+        "@vue/shared": "3.4.10"
       },
       "peerDependencies": {
-        "vue": "3.4.3"
+        "vue": "3.4.10"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.3.tgz",
-      "integrity": "sha512-rIwlkkP1n4uKrRzivAKPZIEkHiuwY5mmhMJ2nZKCBLz8lTUlE73rQh4n1OnnMurXt1vcUNyH4ZPfdh8QweTjpQ==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.10.tgz",
+      "integrity": "sha512-C0mIVhwW1xQLMFyqMJxnhq6fWyE02lCgcE+TDdtGpg6B3H6kh/0YcqS54qYc76UJNlWegf3VgsLqgk6D9hBmzQ==",
       "dev": true
     },
     "node_modules/@vueuse/core": {
@@ -5632,9 +5632,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "dev": true,
       "funding": [
         {
@@ -6776,12 +6776,12 @@
       }
     },
     "node_modules/lerna": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.0.1.tgz",
-      "integrity": "sha512-ZxFMmOqwkP4e+q6BrMzxkAhixi6n0GVD2jAAnAfDkIFnwumB4/7X5/If6fqTlXXshtB2dQtN5OAtzafqVq8cwA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.0.2.tgz",
+      "integrity": "sha512-nnOIGI5V5Af9gfraNcMVoV1Fry/y7/h3nCQYk0/CMzBYDD+xbNL3DH8+c82AJkNR5ABslmpXjW4DLJ11/1b3CQ==",
       "dev": true,
       "dependencies": {
-        "@lerna/create": "8.0.1",
+        "@lerna/create": "8.0.2",
         "@npmcli/run-script": "7.0.2",
         "@nx/devkit": ">=17.1.2 < 18",
         "@octokit/plugin-enterprise-rest": "6.0.1",
@@ -8010,15 +8010,6 @@
       "resolved": "packages/widget",
       "link": true
     },
-    "node_modules/mrmime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
-      "integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "license": "MIT"
@@ -9088,9 +9079,9 @@
       }
     },
     "node_modules/pacote/node_modules/cacache": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.1.tgz",
-      "integrity": "sha512-g4Uf2CFZPaxtJKre6qr4zqLDOOPU7bNVhWjlNhvzc51xaTOx2noMOLhfFkTAqwtrAZAKQUuDfyjitzilpA8WsQ==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.2.tgz",
+      "integrity": "sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==",
       "dev": true,
       "dependencies": {
         "@npmcli/fs": "^3.1.0",
@@ -9289,9 +9280,9 @@
       }
     },
     "node_modules/pacote/node_modules/npm-packlist": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.1.tgz",
-      "integrity": "sha512-MQpL27ZrsJQ2kiAuQPpZb5LtJwydNRnI15QWXsf3WHERu4rzjRj6Zju/My2fov7tLuu3Gle/uoIX/DDZ3u4O4Q==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.2.tgz",
+      "integrity": "sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==",
       "dev": true,
       "dependencies": {
         "ignore-walk": "^6.0.4"
@@ -9361,9 +9352,9 @@
       }
     },
     "node_modules/pacote/node_modules/tuf-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.1.0.tgz",
-      "integrity": "sha512-eD7YPPjVlMzdggrOeE8zwoegUaG/rt6Bt3jwoQPunRiNVzgcCE009UDFJKJjG+Gk9wFu6W/Vi+P5d/5QpdD9jA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.2.0.tgz",
+      "integrity": "sha512-ZSDngmP1z6zw+FIkIBjvOp/II/mIub/O7Pp12j1WNsiCpg5R5wAc//i555bBQsE44O94btLt0xM/Zr2LQjwdCg==",
       "dev": true,
       "dependencies": {
         "@tufjs/models": "2.0.0",
@@ -9602,9 +9593,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "dev": true,
       "funding": [
         {
@@ -10536,27 +10527,27 @@
       }
     },
     "node_modules/shikiji": {
-      "version": "0.9.16",
-      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.16.tgz",
-      "integrity": "sha512-QeSwiW88gHke9deQ5Av1f6CEVPGW/riRMPT3vMDGPnASCOhBZK4TYk5ZRoa2qYLncPZS5kXKwcggccQvg3+U7Q==",
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.18.tgz",
+      "integrity": "sha512-/tFMIdV7UQklzN13VjF0/XFzmii6C606Jc878hNezvB8ZR8FG8FW9j0I4J9EJre0owlnPntgLVPpHqy27Gs+DQ==",
       "dev": true,
       "dependencies": {
-        "shikiji-core": "0.9.16"
+        "shikiji-core": "0.9.18"
       }
     },
     "node_modules/shikiji-core": {
-      "version": "0.9.16",
-      "resolved": "https://registry.npmjs.org/shikiji-core/-/shikiji-core-0.9.16.tgz",
-      "integrity": "sha512-eJIK8/IpzvAGnbckCE2Qf/fOSfpjVLSosUfI3pQAnbphGXagEqiRcT/gyVtL4llqmBh0nexqRdJKMFZF3A6ayw==",
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/shikiji-core/-/shikiji-core-0.9.18.tgz",
+      "integrity": "sha512-PKTXptbrp/WEDjNHV8OFG9KkfhmR0pSd161kzlDDlgQ0HXAnqJYNDSjqsy1CYZMx5bSvLMy42yJj9oFTqmkNTQ==",
       "dev": true
     },
     "node_modules/shikiji-transformers": {
-      "version": "0.9.16",
-      "resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.9.16.tgz",
-      "integrity": "sha512-DcvhYtLc3Xtme070vgyyeHX0XrNK0zHrKIiPk8wcptFbFUuS65qYDd/UFl68+R8KhdoSFTM9EXlBa9MhrGlbaw==",
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.9.18.tgz",
+      "integrity": "sha512-lvKVfgx1ETDqUNxqiUn+whlnjQiunsAg76DOpzjjxkHE/bLcwa+jrghcMxQhui86SLR1tzCdM4Imh+RxW0LI2Q==",
       "dev": true,
       "dependencies": {
-        "shikiji": "0.9.16"
+        "shikiji": "0.9.18"
       }
     },
     "node_modules/signal-exit": {
@@ -11549,9 +11540,9 @@
       }
     },
     "node_modules/vega": {
-      "version": "5.26.1",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.26.1.tgz",
-      "integrity": "sha512-1IguabCfv5jGUwMg4d8V9Lf/yBxaUc1EXmRwHzV8pMSy6KUB0h7rh9gYU0ja+vOB7b5qygRwppqeL0cATrzLUw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.27.0.tgz",
+      "integrity": "sha512-iYMQZYb2nlJBLCsUZ88pvun2sTcFcLE7GKJWisndLo+KYNMQIRePQ7X2FRuy8yvRRNxfO8XhjImh4OwxZvyYVA==",
       "dependencies": {
         "vega-crossfilter": "~4.1.1",
         "vega-dataflow": "~5.7.5",
@@ -11570,13 +11561,13 @@
         "vega-regression": "~1.2.0",
         "vega-runtime": "~6.1.4",
         "vega-scale": "~7.3.1",
-        "vega-scenegraph": "~4.11.1",
+        "vega-scenegraph": "~4.11.2",
         "vega-statistics": "~1.9.0",
         "vega-time": "~2.1.1",
-        "vega-transforms": "~4.11.0",
-        "vega-typings": "~1.0.1",
+        "vega-transforms": "~4.11.1",
+        "vega-typings": "~1.1.0",
         "vega-util": "~1.17.2",
-        "vega-view": "~5.11.1",
+        "vega-view": "~5.12.0",
         "vega-view-transforms": "~4.5.9",
         "vega-voronoi": "~4.2.2",
         "vega-wordcloud": "~4.1.4"
@@ -11854,7 +11845,8 @@
     },
     "node_modules/vega-runtime": {
       "version": "6.1.4",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.4.tgz",
+      "integrity": "sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==",
       "dependencies": {
         "vega-dataflow": "^5.7.5",
         "vega-util": "^1.17.1"
@@ -11873,9 +11865,9 @@
       }
     },
     "node_modules/vega-scenegraph": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.11.1.tgz",
-      "integrity": "sha512-XXEy8zbLYATj6yuIz6PcSGxO/pob4DEYBHdwoN4tfB2Yz6/eModF0JJdlNsGWNxV27VO6EPtzpJEc5Ql/OOQNw==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.11.2.tgz",
+      "integrity": "sha512-PXSvv/L7Ek+9mwOTPLpzgkXdfGCR+AcWV5aquPGrqCWoiIF49VJkKFNT1HWxj3RZJX0XKo2r7SuXvRBb9EJ1aA==",
       "dependencies": {
         "d3-path": "^3.1.0",
         "d3-shape": "^3.2.0",
@@ -11933,9 +11925,9 @@
       }
     },
     "node_modules/vega-transforms": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.11.0.tgz",
-      "integrity": "sha512-BeDASz7s9pIFjcSBljJJb8Eg0to2VjU0DvS/UjCQQYtqlfmzz78/mZnHyC+mW06h58ZKN+1QrIfqTZ6uMB4ySw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.11.1.tgz",
+      "integrity": "sha512-DDbqEQnvy9/qEvv0bAKPqAuzgaNb7Lh2xKJFom2Yzx4tZHCl8dnKxC1lH9JnJlAMdtZuiNLPARUkf3pCNQ/olw==",
       "dependencies": {
         "d3-array": "^3.2.2",
         "vega-dataflow": "^5.7.5",
@@ -11945,9 +11937,9 @@
       }
     },
     "node_modules/vega-typings": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-1.0.1.tgz",
-      "integrity": "sha512-VYsezOoYU8lDWGX6m5g6+m48Icq5RhZ51ek4Gc2UJkz8WJpYlVeN81Ko/smQMLblcU5NTD4Ffu+Mb3EcnXpMZw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-1.1.0.tgz",
+      "integrity": "sha512-uI6RWlMiGRhsgmw/LzJtjCc0kwhw2f0JpyNMTAnOy90kE4e4CiaZN5nJp8S9CcfcBoPEZHc166AOn2SSNrKn3A==",
       "dependencies": {
         "@types/geojson": "7946.0.4",
         "vega-event-selector": "^3.0.1",
@@ -11960,8 +11952,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-view": {
-      "version": "5.11.1",
-      "license": "BSD-3-Clause",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.12.0.tgz",
+      "integrity": "sha512-T3GY7UJNVZGrCUrAmE/OCrkoJQyOT/2dCgXgy9EvDMVv/sdrn7o1TMKhSV18nIr0m5A7m4mgKwrmguAfROY85g==",
       "dependencies": {
         "d3-array": "^3.2.2",
         "d3-timer": "^3.0.1",
@@ -12004,9 +11997,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.10.tgz",
-      "integrity": "sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
+      "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
@@ -12059,9 +12052,9 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.0.0-rc.34",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.34.tgz",
-      "integrity": "sha512-TUbTiSdAZFni2XlHlpx61KikgkQ5uG4Wtmw2R0SXhIOG6qGqzDJczAFjkMc4i45I9c3KyatwOYe8oEfCnzVYwQ==",
+      "version": "1.0.0-rc.36",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.36.tgz",
+      "integrity": "sha512-2z4dpM9PplN/yvTifhavOIAazlCR6OJ5PvLoRbc+7LdcFeIlCsuDGENLX4HjMW18jQZF5/j7++PNqdBfeazxUA==",
       "dev": true,
       "dependencies": {
         "@docsearch/css": "^3.5.2",
@@ -12074,19 +12067,18 @@
         "focus-trap": "^7.5.4",
         "mark.js": "8.11.1",
         "minisearch": "^6.3.0",
-        "mrmime": "^2.0.0",
-        "shikiji": "^0.9.15",
-        "shikiji-core": "^0.9.15",
-        "shikiji-transformers": "^0.9.15",
-        "vite": "^5.0.10",
-        "vue": "^3.4.3"
+        "shikiji": "^0.9.17",
+        "shikiji-core": "^0.9.17",
+        "shikiji-transformers": "^0.9.17",
+        "vite": "^5.0.11",
+        "vue": "^3.4.5"
       },
       "bin": {
         "vitepress": "bin/vitepress.js"
       },
       "peerDependencies": {
         "markdown-it-mathjax3": "^4.3.2",
-        "postcss": "^8.4.32"
+        "postcss": "^8.4.33"
       },
       "peerDependenciesMeta": {
         "markdown-it-mathjax3": {
@@ -12098,16 +12090,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.3.tgz",
-      "integrity": "sha512-GjN+culMAGv/mUbkIv8zMKItno8npcj5gWlXkSxf1SPTQf8eJ4A+YfHIvQFyL1IfuJcMl3soA7SmN1fRxbf/wA==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.10.tgz",
+      "integrity": "sha512-c+O8qGqdWPF9joTCzMGeDDedViooh6c8RY3+eW5+6GCAIY8YjChmU06LsUu0PnMZbIk1oKUoJTqKzmghYtFypw==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.4.3",
-        "@vue/compiler-sfc": "3.4.3",
-        "@vue/runtime-dom": "3.4.3",
-        "@vue/server-renderer": "3.4.3",
-        "@vue/shared": "3.4.3"
+        "@vue/compiler-dom": "3.4.10",
+        "@vue/compiler-sfc": "3.4.10",
+        "@vue/runtime-dom": "3.4.10",
+        "@vue/server-renderer": "3.4.10",
+        "@vue/shared": "3.4.10"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -12496,7 +12488,7 @@
         "@uwdata/mosaic-core": "^0.3.5",
         "@uwdata/mosaic-sql": "^0.3.5",
         "@uwdata/vgplot": "^0.3.5",
-        "vega": "^5.26.1",
+        "vega": "^5.27.0",
         "vega-embed": "^6.24.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,12 @@
         "eslint": "^8.56.0",
         "lerna": "^8.0.2",
         "mocha": "^10.2.0",
-        "nodemon": "^3.0.2",
+        "nodemon": "^3.0.3",
         "rimraf": "^5.0.5",
         "timezone-mock": "^1.3.6",
         "typescript": "^5.3.3",
         "vite": "^5.0.11",
-        "vitepress": "1.0.0-rc.36",
+        "vitepress": "1.0.0-rc.39",
         "yaml": "^2.3.4"
       }
     },
@@ -3033,9 +3033,9 @@
       "link": true
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.2.tgz",
-      "integrity": "sha512-kEjJHrLb5ePBvjD0SPZwJlw1QTRcjjCA9sB5VyfonoXVBxTS7TMnqL6EkLt1Eu61RDeiuZ/WN9Hf6PxXhPI2uA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.3.tgz",
+      "integrity": "sha512-b8S5dVS40rgHdDrw+DQi/xOM9ed+kSRZzfm1T74bMmBDCd8XO87NKlFYInzCtwvtWwXZvo1QxE2OSspTATWrbA==",
       "dev": true,
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
@@ -3046,53 +3046,53 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.10.tgz",
-      "integrity": "sha512-53vxh7K9qbx+JILnGEhrFRyr7H7e4NdT8RuTNU3m6HhJKFvcAqFTNXpYMHnyuAzzRGdsbsYHBgQC3H6xEXTG6w==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.14.tgz",
+      "integrity": "sha512-ro4Zzl/MPdWs7XwxT7omHRxAjMbDFRZEEjD+2m3NBf8YzAe3HuoSEZosXQo+m1GQ1G3LQ1LdmNh1RKTYe+ssEg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.6",
-        "@vue/shared": "3.4.10",
+        "@vue/shared": "3.4.14",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.10.tgz",
-      "integrity": "sha512-QAALBJksIFpXGYuo74rtMgnwpVZDvd3kYbUa4gYX9s/5QiqEvZSgbKtOdUGydXcxKPt3ifC+0/bhPVHXN2694A==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.14.tgz",
+      "integrity": "sha512-nOZTY+veWNa0DKAceNWxorAbWm0INHdQq7cejFaWM1WYnoNSJbSEKYtE7Ir6lR/+mo9fttZpPVI9ZFGJ1juUEQ==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-core": "3.4.10",
-        "@vue/shared": "3.4.10"
+        "@vue/compiler-core": "3.4.14",
+        "@vue/shared": "3.4.14"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.10.tgz",
-      "integrity": "sha512-sTOssaQySgrMjrhZxmAqdp6n+E51VteIVIDaOR537H2P63DyzMmig21U0XXFxiXmMIfrK91lAInnc+bIAYemGw==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.14.tgz",
+      "integrity": "sha512-1vHc9Kv1jV+YBZC/RJxQJ9JCxildTI+qrhtDh6tPkR1O8S+olBUekimY0km0ZNn8nG1wjtFAe9XHij+YLR8cRQ==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.23.6",
-        "@vue/compiler-core": "3.4.10",
-        "@vue/compiler-dom": "3.4.10",
-        "@vue/compiler-ssr": "3.4.10",
-        "@vue/shared": "3.4.10",
+        "@vue/compiler-core": "3.4.14",
+        "@vue/compiler-dom": "3.4.14",
+        "@vue/compiler-ssr": "3.4.14",
+        "@vue/shared": "3.4.14",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.5",
-        "postcss": "^8.4.32",
+        "postcss": "^8.4.33",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.10.tgz",
-      "integrity": "sha512-Y90TL1abretWbUiK5rv+9smS1thCHE5sSuhZgiLh6cxgZ2Pcy3BEvDd3reID0iwNcTdMbTeE6NI3Aq4Mux6hqQ==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.14.tgz",
+      "integrity": "sha512-bXT6+oAGlFjTYVOTtFJ4l4Jab1wjsC0cfSfOe2B4Z0N2vD2zOBSQ9w694RsCfhjk+bC2DY5Gubb1rHZVii107Q==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.4.10",
-        "@vue/shared": "3.4.10"
+        "@vue/compiler-dom": "3.4.14",
+        "@vue/shared": "3.4.14"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -3102,63 +3102,63 @@
       "dev": true
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.10.tgz",
-      "integrity": "sha512-SmGGpo37LzPcAFTopHNIJRNVOQfma9YgyPkAzx9/TJ01lbCCYigS28hEcY1hjiJ1PRK8iVX62Ov5yzmUgYH/pQ==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.14.tgz",
+      "integrity": "sha512-xRYwze5Q4tK7tT2J4uy4XLhK/AIXdU5EBUu9PLnIHcOKXO0uyXpNNMzlQKuq7B+zwtq6K2wuUL39pHA6ZQzObw==",
       "dev": true,
       "dependencies": {
-        "@vue/shared": "3.4.10"
+        "@vue/shared": "3.4.14"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.10.tgz",
-      "integrity": "sha512-Ri2Cz9sFr66AEUewGUK8IXhIUAhshTHVUGuJR8pqMbtjIds+zPa8QPO5UZImGMQ8HTY7eEpKwztCct9V3+Iqug==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.14.tgz",
+      "integrity": "sha512-qu+NMkfujCoZL6cfqK5NOfxgXJROSlP2ZPs4CTcVR+mLrwl4TtycF5Tgo0QupkdBL+2kigc6EsJlTcuuZC1NaQ==",
       "dev": true,
       "dependencies": {
-        "@vue/reactivity": "3.4.10",
-        "@vue/shared": "3.4.10"
+        "@vue/reactivity": "3.4.14",
+        "@vue/shared": "3.4.14"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.10.tgz",
-      "integrity": "sha512-ROsdi5M2niRDmjXJNZ8KKiGwXyG1FO8l9n6sCN0kaJEHbjWkuigu96YAI3fK/AWUZPSXXEcMEBVPC6rL3mmUuA==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.14.tgz",
+      "integrity": "sha512-B85XmcR4E7XsirEHVqhmy4HPbRT9WLFWV9Uhie3OapV9m1MEN9+Er6hmUIE6d8/l2sUygpK9RstFM2bmHEUigA==",
       "dev": true,
       "dependencies": {
-        "@vue/runtime-core": "3.4.10",
-        "@vue/shared": "3.4.10",
+        "@vue/runtime-core": "3.4.14",
+        "@vue/shared": "3.4.14",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.10.tgz",
-      "integrity": "sha512-WpCBAhesLq44JKWfdFqb+Bi4ACUW0d8x1z90GnE0spccsAlEDMXV5nm+pwXLyW0OdP2iPrO/n/QMJh4B1v9Ciw==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.14.tgz",
+      "integrity": "sha512-pwSKXQfYdJBTpvWHGEYI+akDE18TXAiLcGn+Q/2Fj8wQSHWztoo7PSvfMNqu6NDhp309QXXbPFEGCU5p85HqkA==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.10",
-        "@vue/shared": "3.4.10"
+        "@vue/compiler-ssr": "3.4.14",
+        "@vue/shared": "3.4.14"
       },
       "peerDependencies": {
-        "vue": "3.4.10"
+        "vue": "3.4.14"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.10.tgz",
-      "integrity": "sha512-C0mIVhwW1xQLMFyqMJxnhq6fWyE02lCgcE+TDdtGpg6B3H6kh/0YcqS54qYc76UJNlWegf3VgsLqgk6D9hBmzQ==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.14.tgz",
+      "integrity": "sha512-nmi3BtLpvqXAWoRZ6HQ+pFJOHBU4UnH3vD3opgmwXac7vhaHKA9nj1VeGjMggdB9eLtW83eHyPCmOU1qzdsC7Q==",
       "dev": true
     },
     "node_modules/@vueuse/core": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.7.1.tgz",
-      "integrity": "sha512-74mWHlaesJSWGp1ihg76vAnfVq9NTv1YT0SYhAQ6zwFNdBkkP+CKKJmVOEHcdSnLXCXYiL5e7MaewblfiYLP7g==",
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.7.2.tgz",
+      "integrity": "sha512-AOyAL2rK0By62Hm+iqQn6Rbu8bfmbgaIMXcE3TSr7BdQ42wnSFlwIdPjInO62onYsEMK/yDMU8C6oGfDAtZ2qQ==",
       "dev": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20",
-        "@vueuse/metadata": "10.7.1",
-        "@vueuse/shared": "10.7.1",
+        "@vueuse/metadata": "10.7.2",
+        "@vueuse/shared": "10.7.2",
         "vue-demi": ">=0.14.6"
       },
       "funding": {
@@ -3192,13 +3192,13 @@
       }
     },
     "node_modules/@vueuse/integrations": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.7.1.tgz",
-      "integrity": "sha512-cKo5LEeKVHdBRBtMTOrDPdR0YNtrmN9IBfdcnY2P3m5LHVrsD0xiHUtAH1WKjHQRIErZG6rJUa6GA4tWZt89Og==",
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.7.2.tgz",
+      "integrity": "sha512-+u3RLPFedjASs5EKPc69Ge49WNgqeMfSxFn+qrQTzblPXZg6+EFzhjarS5edj2qAf6xQ93f95TUxRwKStXj/sQ==",
       "dev": true,
       "dependencies": {
-        "@vueuse/core": "10.7.1",
-        "@vueuse/shared": "10.7.1",
+        "@vueuse/core": "10.7.2",
+        "@vueuse/shared": "10.7.2",
         "vue-demi": ">=0.14.6"
       },
       "funding": {
@@ -3284,18 +3284,18 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.7.1.tgz",
-      "integrity": "sha512-jX8MbX5UX067DYVsbtrmKn6eG6KMcXxLRLlurGkZku5ZYT3vxgBjui2zajvUZ18QLIjrgBkFRsu7CqTAg18QFw==",
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.7.2.tgz",
+      "integrity": "sha512-kCWPb4J2KGrwLtn1eJwaJD742u1k5h6v/St5wFe8Quih90+k2a0JP8BS4Zp34XUuJqS2AxFYMb1wjUL8HfhWsQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.7.1.tgz",
-      "integrity": "sha512-v0jbRR31LSgRY/C5i5X279A/WQjD6/JsMzGa+eqt658oJ75IvQXAeONmwvEMrvJQKnRElq/frzBR7fhmWY5uLw==",
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.7.2.tgz",
+      "integrity": "sha512-qFbXoxS44pi2FkgFjPvF4h7c9oMDutpyBdcJdMYIMg9XyXli2meFMuaKn+UMgsClo//Th6+beeCgqweT/79BVA==",
       "dev": true,
       "dependencies": {
         "vue-demi": ">=0.14.6"
@@ -8176,9 +8176,9 @@
       "dev": true
     },
     "node_modules/nodemon": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.2.tgz",
-      "integrity": "sha512-9qIN2LNTrEzpOPBaWHTm4Asy1LxXLSickZStAQ4IZe7zsoIpD/A7LWxhZV3t4Zu352uBcqVnRsDXSMR2Sc3lTA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.3.tgz",
+      "integrity": "sha512-7jH/NXbFPxVaMwmBCC2B9F/V6X1VkEdNgx3iu9jji8WxWcvhMWkmhNWhI5077zknOnZnBzba9hZP6bCPJLSReQ==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.2",
@@ -10527,27 +10527,27 @@
       }
     },
     "node_modules/shikiji": {
-      "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.18.tgz",
-      "integrity": "sha512-/tFMIdV7UQklzN13VjF0/XFzmii6C606Jc878hNezvB8ZR8FG8FW9j0I4J9EJre0owlnPntgLVPpHqy27Gs+DQ==",
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.19.tgz",
+      "integrity": "sha512-Kw2NHWktdcdypCj1GkKpXH4o6Vxz8B8TykPlPuLHOGSV8VkhoCLcFOH4k19K4LXAQYRQmxg+0X/eM+m2sLhAkg==",
       "dev": true,
       "dependencies": {
-        "shikiji-core": "0.9.18"
+        "shikiji-core": "0.9.19"
       }
     },
     "node_modules/shikiji-core": {
-      "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/shikiji-core/-/shikiji-core-0.9.18.tgz",
-      "integrity": "sha512-PKTXptbrp/WEDjNHV8OFG9KkfhmR0pSd161kzlDDlgQ0HXAnqJYNDSjqsy1CYZMx5bSvLMy42yJj9oFTqmkNTQ==",
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/shikiji-core/-/shikiji-core-0.9.19.tgz",
+      "integrity": "sha512-AFJu/vcNT21t0e6YrfadZ+9q86gvPum6iywRyt1OtIPjPFe25RQnYJyxHQPMLKCCWA992TPxmEmbNcOZCAJclw==",
       "dev": true
     },
     "node_modules/shikiji-transformers": {
-      "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.9.18.tgz",
-      "integrity": "sha512-lvKVfgx1ETDqUNxqiUn+whlnjQiunsAg76DOpzjjxkHE/bLcwa+jrghcMxQhui86SLR1tzCdM4Imh+RxW0LI2Q==",
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.9.19.tgz",
+      "integrity": "sha512-lGLI7Z8frQrIBbhZ74/eiJtxMoCQRbpaHEB+gcfvdIy+ZFaAtXncJGnc52932/UET+Y4GyKtwwC/vjWUCp+c/Q==",
       "dev": true,
       "dependencies": {
-        "shikiji": "0.9.18"
+        "shikiji": "0.9.19"
       }
     },
     "node_modules/signal-exit": {
@@ -12052,26 +12052,26 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.0.0-rc.36",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.36.tgz",
-      "integrity": "sha512-2z4dpM9PplN/yvTifhavOIAazlCR6OJ5PvLoRbc+7LdcFeIlCsuDGENLX4HjMW18jQZF5/j7++PNqdBfeazxUA==",
+      "version": "1.0.0-rc.39",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.39.tgz",
+      "integrity": "sha512-EcgoRlAAp37WOxUOYv45oxyhLrcy3Upey+mKpqW3ldsg6Ol4trPndRBk2GO0QiSvEKlb9BMerk49D/bFICN6kg==",
       "dev": true,
       "dependencies": {
         "@docsearch/css": "^3.5.2",
         "@docsearch/js": "^3.5.2",
         "@types/markdown-it": "^13.0.7",
-        "@vitejs/plugin-vue": "^5.0.2",
+        "@vitejs/plugin-vue": "^5.0.3",
         "@vue/devtools-api": "^6.5.1",
-        "@vueuse/core": "^10.7.1",
-        "@vueuse/integrations": "^10.7.1",
+        "@vueuse/core": "^10.7.2",
+        "@vueuse/integrations": "^10.7.2",
         "focus-trap": "^7.5.4",
         "mark.js": "8.11.1",
         "minisearch": "^6.3.0",
-        "shikiji": "^0.9.17",
-        "shikiji-core": "^0.9.17",
-        "shikiji-transformers": "^0.9.17",
+        "shikiji": "^0.9.19",
+        "shikiji-core": "^0.9.19",
+        "shikiji-transformers": "^0.9.19",
         "vite": "^5.0.11",
-        "vue": "^3.4.5"
+        "vue": "^3.4.14"
       },
       "bin": {
         "vitepress": "bin/vitepress.js"
@@ -12090,16 +12090,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.10.tgz",
-      "integrity": "sha512-c+O8qGqdWPF9joTCzMGeDDedViooh6c8RY3+eW5+6GCAIY8YjChmU06LsUu0PnMZbIk1oKUoJTqKzmghYtFypw==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.14.tgz",
+      "integrity": "sha512-Rop5Al/ZcBbBz+KjPZaZDgHDX0kUP4duEzDbm+1o91uxYUNmJrZSBuegsNIJvUGy+epLevNRNhLjm08VKTgGyw==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.4.10",
-        "@vue/compiler-sfc": "3.4.10",
-        "@vue/runtime-dom": "3.4.10",
-        "@vue/server-renderer": "3.4.10",
-        "@vue/shared": "3.4.10"
+        "@vue/compiler-dom": "3.4.14",
+        "@vue/compiler-sfc": "3.4.14",
+        "@vue/runtime-dom": "3.4.14",
+        "@vue/server-renderer": "3.4.14",
+        "@vue/shared": "3.4.14"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -22,16 +22,16 @@
     "release": "npm run test && npm run lint && lerna publish"
   },
   "devDependencies": {
-    "esbuild": "^0.19.10",
+    "esbuild": "^0.19.11",
     "eslint": "^8.56.0",
-    "lerna": "^8.0.1",
+    "lerna": "^8.0.2",
     "mocha": "^10.2.0",
     "nodemon": "^3.0.2",
     "rimraf": "^5.0.5",
     "timezone-mock": "^1.3.6",
     "typescript": "^5.3.3",
-    "vite": "^5.0.10",
-    "vitepress": "1.0.0-rc.34",
+    "vite": "^5.0.11",
+    "vitepress": "1.0.0-rc.36",
     "yaml": "^2.3.4"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "eslint": "^8.56.0",
     "lerna": "^8.0.2",
     "mocha": "^10.2.0",
-    "nodemon": "^3.0.2",
+    "nodemon": "^3.0.3",
     "rimraf": "^5.0.5",
     "timezone-mock": "^1.3.6",
     "typescript": "^5.3.3",
     "vite": "^5.0.11",
-    "vitepress": "1.0.0-rc.36",
+    "vitepress": "1.0.0-rc.39",
     "yaml": "^2.3.4"
   },
   "workspaces": [

--- a/packages/vega-example/package.json
+++ b/packages/vega-example/package.json
@@ -15,7 +15,7 @@
     "@uwdata/mosaic-core": "^0.3.5",
     "@uwdata/mosaic-sql": "^0.3.5",
     "@uwdata/vgplot": "^0.3.5",
-    "vega": "^5.26.1",
+    "vega": "^5.27.0",
     "vega-embed": "^6.24.0"
   }
 }

--- a/packages/vgplot/src/marks/HexbinMark.js
+++ b/packages/vgplot/src/marks/HexbinMark.js
@@ -40,7 +40,7 @@ export class HexbinMark extends Mark {
     const aggr = new Set;
     const cols = {};
     for (const c of channels) {
-      if (c.channel === 'order') {
+      if (c.channel === 'orderby') {
         q.orderby(c.value); // TODO revisit once groupby is added
       } else if (c.channel === 'x') {
         x = c;

--- a/packages/vgplot/src/marks/Mark.js
+++ b/packages/vgplot/src/marks/Mark.js
@@ -174,7 +174,7 @@ export function markQuery(channels, table, skip = []) {
     const { channel, field, as } = c;
     if (skip.includes(channel)) continue;
 
-    if (channel === 'order') {
+    if (channel === 'orderby') {
       q.orderby(c.value);
     } else if (field) {
       if (field.aggregate) {

--- a/packages/vgplot/src/plot-attributes.js
+++ b/packages/vgplot/src/plot-attributes.js
@@ -182,3 +182,30 @@ export const attributeMap = new Map([
   ['projectionInsetBottom', 'projection.insetBottom'],
   ['projectionClip', 'projection.clip']
 ]);
+
+function setProperty(object, path, value) {
+  for (let i = 0; i < path.length; ++i) {
+    const key = path[i];
+    if (i === path.length - 1) {
+      object[key] = value;
+    } else {
+      object = (object[key] || (object[key] = {}));
+    }
+  }
+}
+
+export function setAttributes(attributes, spec, symbols) {
+  // populate top-level and scale properties
+  for (const key in attributes) {
+    const specKey = attributeMap.get(key);
+    if (specKey == null) {
+      throw new Error(`Unrecognized plot attribute: ${key}`);
+    }
+    const value = attributes[key];
+    if (typeof value === 'symbol') {
+      symbols.push(key);
+    } else if (value !== undefined) {
+      setProperty(spec, specKey.split('.'), value);
+    }
+  }
+}

--- a/packages/vgplot/src/plot-renderer.js
+++ b/packages/vgplot/src/plot-renderer.js
@@ -1,5 +1,5 @@
 import * as Plot from '@observablehq/plot';
-import { attributeMap } from './plot-attributes.js';
+import { setAttributes } from './plot-attributes.js';
 import { Fixed } from './symbols.js';
 
 const OPTIONS_ONLY_MARKS = new Set([
@@ -9,38 +9,17 @@ const OPTIONS_ONLY_MARKS = new Set([
   'graticule'
 ]);
 
-function setProperty(object, path, value) {
-  for (let i = 0; i < path.length; ++i) {
-    const key = path[i];
-    if (i === path.length - 1) {
-      object[key] = value;
-    } else {
-      object = (object[key] || (object[key] = {}));
-    }
-  }
-}
+
 
 // construct Plot output
 // see https://github.com/observablehq/plot
 export async function plotRenderer(plot) {
   const spec = { marks: [] };
   const symbols = [];
-
   const { attributes, marks } = plot;
 
   // populate top-level and scale properties
-  for (const key in attributes) {
-    const specKey = attributeMap.get(key);
-    if (specKey == null) {
-      throw new Error(`Unrecognized plot attribute: ${key}`);
-    }
-    const value = attributes[key];
-    if (typeof value === 'symbol') {
-      symbols.push(key);
-    } else if (value !== undefined) {
-      setProperty(spec, specKey.split('.'), value);
-    }
-  }
+  setAttributes(attributes, spec, symbols);
 
   // populate marks
   const indices = [];

--- a/packages/vgplot/src/spec/parse-spec.js
+++ b/packages/vgplot/src/spec/parse-spec.js
@@ -404,12 +404,12 @@ function parseTransform(spec, ctx) {
   const args = name === 'count' || name == null ? [] : toArray(spec[name]);
   let expr = func(...args);
   if (spec.distinct) expr = expr.distinct();
-  if (spec.order) {
-    const p = toArray(spec.order).map(v => ctx.maybeParam(v));
+  if (spec.orderby) {
+    const p = toArray(spec.orderby).map(v => ctx.maybeParam(v));
     expr = expr.orderby(p);
   }
-  if (spec.partition) {
-    const p = toArray(spec.partition).map(v => ctx.maybeParam(v));
+  if (spec.partitionby) {
+    const p = toArray(spec.partitionby).map(v => ctx.maybeParam(v));
     expr = expr.partitionby(p);
   }
   if (spec.rows) {

--- a/packages/vgplot/src/spec/to-module.js
+++ b/packages/vgplot/src/spec/to-module.js
@@ -201,12 +201,12 @@ function parseTransform(spec, ctx) {
   if (spec.distinct) {
     str += '.distinct()'
   }
-  if (spec.order) {
-    const p = toArray(spec.order).map(v => ctx.maybeParam(v));
+  if (spec.orderby) {
+    const p = toArray(spec.orderby).map(v => ctx.maybeParam(v));
     str += `.orderby(${p.join(', ')})`;
   }
-  if (spec.partition) {
-    const p = toArray(spec.partition).map(v => ctx.maybeParam(v));
+  if (spec.partitionby) {
+    const p = toArray(spec.partitionby).map(v => ctx.maybeParam(v));
     str += `.partitionby(${p.join(', ')})`;
   }
   if (spec.rows) {


### PR DESCRIPTION
Staging PR for v0.4.

- **Breaking**: Use mark-level `orderby` (_not_ `order`) to convey query orderby criteria. Avoids conflict with Plot's `order` option for implicit stack transforms.
- **Breaking**: Rename channel window transform keys to `orderby` and `partitionby` (_not_ `order` and `partition`) to more closely match SQL and improve consistency with Mosaic's SQL helpers and mark-level `orderby` criteria.
- Update `highlight` interactor to automatically add mark `orderby` when needed to ensure consistent data order.
- Bump dev dependencies.

Fix #248.