### PR TITLE
Rename YAML/JSON spec window function orderby, partitionby

### DIFF
--- a/dev/yaml/moving-average.yaml
+++ b/dev/yaml/moving-average.yaml
@@ -12,7 +12,7 @@ vconcat:
   - mark: lineY
     data: { from: cases }
     x: day
-    y: { avg: cases, order: day, rows: $frame }
+    y: { avg: cases, orderby: day, rows: $frame }
     curve: monotone-x
     stroke: black
   width: 1200

--- a/docs/public/specs/json/moving-average.json
+++ b/docs/public/specs/json/moving-average.json
@@ -39,7 +39,7 @@
           "x": "day",
           "y": {
             "avg": "cases",
-            "order": "day",
+            "orderby": "day",
             "rows": "$frame"
           },
           "curve": "monotone-x",

--- a/docs/public/specs/yaml/moving-average.yaml
+++ b/docs/public/specs/yaml/moving-average.yaml
@@ -21,7 +21,7 @@ vconcat:
   - mark: lineY
     data: { from: cases }
     x: day
-    y: { avg: cases, order: day, rows: $frame }
+    y: { avg: cases, orderby: day, rows: $frame }
     curve: monotone-x
     stroke: currentColor
   width: 680

--- a/packages/vgplot/src/spec/parse-spec.js
+++ b/packages/vgplot/src/spec/parse-spec.js
@@ -404,12 +404,12 @@ function parseTransform(spec, ctx) {
   const args = name === 'count' || name == null ? [] : toArray(spec[name]);
   let expr = func(...args);
   if (spec.distinct) expr = expr.distinct();
-  if (spec.order) {
-    const p = toArray(spec.order).map(v => ctx.maybeParam(v));
+  if (spec.orderby) {
+    const p = toArray(spec.orderby).map(v => ctx.maybeParam(v));
     expr = expr.orderby(p);
   }
-  if (spec.partition) {
-    const p = toArray(spec.partition).map(v => ctx.maybeParam(v));
+  if (spec.partitionby) {
+    const p = toArray(spec.partitionby).map(v => ctx.maybeParam(v));
     expr = expr.partitionby(p);
   }
   if (spec.rows) {

--- a/packages/vgplot/src/spec/to-module.js
+++ b/packages/vgplot/src/spec/to-module.js
@@ -201,12 +201,12 @@ function parseTransform(spec, ctx) {
   if (spec.distinct) {
     str += '.distinct()'
   }
-  if (spec.order) {
-    const p = toArray(spec.order).map(v => ctx.maybeParam(v));
+  if (spec.orderby) {
+    const p = toArray(spec.orderby).map(v => ctx.maybeParam(v));
     str += `.orderby(${p.join(', ')})`;
   }
-  if (spec.partition) {
-    const p = toArray(spec.partition).map(v => ctx.maybeParam(v));
+  if (spec.partitionby) {
+    const p = toArray(spec.partitionby).map(v => ctx.maybeParam(v));
     str += `.partitionby(${p.join(', ')})`;
   }
   if (spec.rows) {


### PR DESCRIPTION
Previously, the specification for a window transform within an encoding channel used `order` for the window ORDER BY criteria and `partition` for the PARTITION BY criteria. This PR renames those keys to `orderby` and `partitionby`, which more closely matches SQL and improves consistency with Mosaic's SQL helpers and also mark-level `orderby` criteria.

This is a **breaking change**. Any specs that previously used window transforms with `order` or `partition` need to be updated to use `orderby` and `partitionby` instead.