### PR TITLE
feat: allow Menu to select a sql expression

### DIFF
--- a/packages/inputs/src/Menu.js
+++ b/packages/inputs/src/Menu.js
@@ -1,10 +1,21 @@
 import { MosaicClient, isParam, isSelection } from '@uwdata/mosaic-core';
-import { Query, eq, literal } from '@uwdata/mosaic-sql';
+import { Query, eq, literal, sql as sqlFunc} from '@uwdata/mosaic-sql';
 import { input } from './input.js';
 
 const isObject = v => {
   return v && typeof v === 'object' && !Array.isArray(v);
 };
+
+const parseOption = value => {
+  if (!isObject(value)) {
+    return { value };
+  }
+  const { value: { sql }, ...options } = value;
+  if (sql === undefined) {
+    return value;
+  }
+  return {value: sqlFunc`${sql}`, ...options}
+}
 
 export const menu = options => input(Menu, options);
 
@@ -36,7 +47,7 @@ export class Menu extends MosaicClient {
 
     this.select = document.createElement('select');
     if (options) {
-      this.data = options.map(value => isObject(value) ? value : { value });
+      this.data = options.map(parseOption);
       this.update();
     }
     value = value ?? this.selection?.value ?? this.data?.[0]?.value;


### PR DESCRIPTION
Closes #298 

Example usage of this feature,

```
df = pd.DataFrame({"x_val": np.arange(20)}).assign(
    y_val=lambda df: df["x_val"] * df["x_val"],
    noise=np.random.normal(scale=5, size=20),
)

d = {
    "vconcat": [
        {
            "input": "menu",
            "label": 'yCol',
            "options": [
                {"label": "Pure signal", "value": {"sql": "y_val"}},
                {"label": "Small noise", "value": {"sql": "y_val+noise"}},
                {"label": "Medium noise", "value": {"sql": "y_val+2*noise"}},
                {"label": "Large noise", "value": {"sql": "y_val+5*noise"}},
            ],
            "as": "$yCol",
        },
        {
            "plot": [
                {"mark": "lineY", "x": "x_val", "y": {"sql": "$yCol"}, "data": {"from": "df"}}
            ],
        },
    ],
}


MosaicWidget(d, data={'df': df})
```

<img width="711" alt="image" src="https://github.com/uwdata/mosaic/assets/7512971/410aff06-9d5d-41a0-baa5-df4105502469">

<img width="692" alt="image" src="https://github.com/uwdata/mosaic/assets/7512971/15ee21f7-8fb1-4fac-aee9-e7a329572dd1">

