### PR TITLE
v0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -228,12 +228,12 @@
       }
     },
     "node_modules/@anywidget/types": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@anywidget/types/-/types-0.1.5.tgz",
-      "integrity": "sha512-WuZrR/g+HyZ0/tYZSsQfdEdz39EF8khBkERAqQUy7U15LyTUWu5wkNnFB9NKySK+9OQS7y3vyTL6MbwqytZdOg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@anywidget/types/-/types-0.1.6.tgz",
+      "integrity": "sha512-nY1J80Nj0TqCH475ofyXAuS+0p9eeT4ctMinsLMQG9NEVWWR88GzFw7rvbEGESg8BQUKMwRP93jADMCUmxdW1Q==",
       "dev": true,
       "dependencies": {
-        "@jupyter-widgets/base": "^6.0.6"
+        "@jupyter-widgets/base": "^6.0.7"
       }
     },
     "node_modules/@anywidget/vite": {
@@ -484,9 +484,9 @@
       }
     },
     "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.28.1-dev106.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.28.1-dev106.0.tgz",
-      "integrity": "sha512-HcA9q/Yq1t8nAIg2rl8DmOTjKy1tAHSdBGHlCcWAm5StsfAjcm+f0STBEH3hmWPk0qEtOJF30OR+GfeyUOP+hA==",
+      "version": "1.28.1-dev99.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.28.1-dev99.0.tgz",
+      "integrity": "sha512-EgIRjUFAos4oT4QeFLK6g7IDPWFWu8dP/mj2/b0pyiN5dDL+xxKW2KyLbeAs26L6Y6yeYy0O4OJSezFOqTbOmg==",
       "dependencies": {
         "apache-arrow": "^14.0.1"
       }
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/@jupyterlab/coreutils": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-6.1.2.tgz",
-      "integrity": "sha512-YzuKhlviq6/uIazjb2+G9vKPemFfof8z0D0nUnN99aU6oIH40UhtImJf6wvTbKruRmeCferg6AWlKjXxCup6lQ==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-6.1.4.tgz",
+      "integrity": "sha512-0iZDNG1cTcp/Pp3zwr09BzB1VCbp1DjyIUhOPQNiACxbzZlkh6sKO7CkfWYHNsggFFfeo9Uaeb1nyPGPnPMM6g==",
       "dev": true,
       "dependencies": {
         "@lumino/coreutils": "^2.1.2",
@@ -1136,25 +1136,25 @@
       }
     },
     "node_modules/@jupyterlab/nbformat": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-4.1.2.tgz",
-      "integrity": "sha512-geEau0hCQV85JmsQDpjhcmvA7Sl0XfQ1yfZzz+HuolJI83OJYba2nhsaw8JB2Fa/oT0kXBiO90PE/ka2Lsk8+A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-4.1.4.tgz",
+      "integrity": "sha512-QiTgz5Lk1tYjWuWR+kUwyMx6kmYuOfSTecyA5W8v/kV1UBnuVri4CzcBDp/x3mXofxncJ4mVosFc7S7CPHrjCQ==",
       "dev": true,
       "dependencies": {
         "@lumino/coreutils": "^2.1.2"
       }
     },
     "node_modules/@jupyterlab/services": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-7.1.2.tgz",
-      "integrity": "sha512-DFgoc2GN0z20T/cwl7D1xBk3BwkojbsyHXHGv+TKQQmZLEf+tusWiepiUlAvsNDMNkVZpS8rD8gaj0CzCdKsFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-7.1.4.tgz",
+      "integrity": "sha512-xijA1lnFfdT322M1QMB7nufUDgjA1Ldqh3JAb+VFv0NwoAGy6JmS/YNlgJIyDnrfxHJhBihsAaN5ahQMs3K69Q==",
       "dev": true,
       "dependencies": {
         "@jupyter/ydoc": "^1.1.1",
-        "@jupyterlab/coreutils": "^6.1.2",
-        "@jupyterlab/nbformat": "^4.1.2",
-        "@jupyterlab/settingregistry": "^4.1.2",
-        "@jupyterlab/statedb": "^4.1.2",
+        "@jupyterlab/coreutils": "^6.1.4",
+        "@jupyterlab/nbformat": "^4.1.4",
+        "@jupyterlab/settingregistry": "^4.1.4",
+        "@jupyterlab/statedb": "^4.1.4",
         "@lumino/coreutils": "^2.1.2",
         "@lumino/disposable": "^2.1.2",
         "@lumino/polling": "^2.1.2",
@@ -1164,13 +1164,13 @@
       }
     },
     "node_modules/@jupyterlab/settingregistry": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-4.1.2.tgz",
-      "integrity": "sha512-v0lBXo7zV+O9GpuY44RMkJz5rD8PeG/me0HP+UzD6gOaYEOPzdMgkY0n02hY0DDWCe47GLBlHuPi7nOZCqGTMg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-4.1.4.tgz",
+      "integrity": "sha512-9m6iVfIIc6rRrEqtaLP9PX1ZHMFJxxOOukR1JQ+Kxrl279yHEsDUxsHfLCHAVo8NlXZ8kC6Px9+GhoFjz0Do/Q==",
       "dev": true,
       "dependencies": {
-        "@jupyterlab/nbformat": "^4.1.2",
-        "@jupyterlab/statedb": "^4.1.2",
+        "@jupyterlab/nbformat": "^4.1.4",
+        "@jupyterlab/statedb": "^4.1.4",
         "@lumino/commands": "^2.2.0",
         "@lumino/coreutils": "^2.1.2",
         "@lumino/disposable": "^2.1.2",
@@ -1206,9 +1206,9 @@
       "dev": true
     },
     "node_modules/@jupyterlab/statedb": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-4.1.2.tgz",
-      "integrity": "sha512-WXdtOxrtoRMkVmvrxsgu+3VjEmm1Gd4CcbGezTnFMTnfk7vvjkE81XeYfaFnAwzgmaHEJYYfqKzEOpZ9bUFxqg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-4.1.4.tgz",
+      "integrity": "sha512-75BKrhh7/+kQ538JZW9DV+G34Jqab+pJvmvOxqisXVvbVlRBTCYOaIRyIfjWC5ErM9DX3NpWxaTqYlCdiiGXLQ==",
       "dev": true,
       "dependencies": {
         "@lumino/commands": "^2.2.0",
@@ -3695,12 +3695,12 @@
       }
     },
     "node_modules/anywidget": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/anywidget/-/anywidget-0.9.2.tgz",
-      "integrity": "sha512-zeGL2GFMrH5R88yCxzobf/WTFEPWMGlrzmUwWLJe3oQHVe57Z2CGOUzqdhV7DnUHOF8e1mnhFvZYT5EU4lZDyg==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/anywidget/-/anywidget-0.9.3.tgz",
+      "integrity": "sha512-aJ6zFGnGy0jtQDLM6w8vCfNqrUkWHU9me1pldM9W3Jn1+aMCSfkkHX9F44H/9TZxpSIfiGzdk7wVTzEBDGRvtA==",
       "dev": true,
       "dependencies": {
-        "@anywidget/types": "~0.1.5",
+        "@anywidget/types": "~0.1.6",
         "@anywidget/vite": "~0.1.2",
         "@jupyter-widgets/base": "^2 || ^3 || ^4 || ^5 || ^6",
         "solid-js": "^1.8.14"
@@ -7792,14 +7792,15 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.90",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.90.tgz",
-      "integrity": "sha512-iQmk+fThPq1ZTD2cFUu8xN6JLp9gFWnjs8auR6hmI6QQXoy6sSEh85uKcdkqpuEnkhhwQm4GSlKHOYfSCVp0Mw==",
+      "version": "0.2.91",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.91.tgz",
+      "integrity": "sha512-LRcTp8RmdHexL8olb7qErdROnJ2L6Js5Am99WQo0hiTRDWtk6vyUJJjTB6I/RcW8jwNQshM3NqH598DdhSOajA==",
       "dev": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
       "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
         "0gentesthtml": "bin/gentesthtml.js",
         "0serve": "bin/0serve.js"
       },
@@ -12672,9 +12673,9 @@
       "dev": true
     },
     "node_modules/vega": {
-      "version": "5.27.0",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.27.0.tgz",
-      "integrity": "sha512-iYMQZYb2nlJBLCsUZ88pvun2sTcFcLE7GKJWisndLo+KYNMQIRePQ7X2FRuy8yvRRNxfO8XhjImh4OwxZvyYVA==",
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.28.0.tgz",
+      "integrity": "sha512-5EDVhjBUgcVdrA6LZDBLah/nuk4FRUwZqTgP/Yi32qeRCoiN0xkptQ5Sbmj6XfH7wu1SdbAbsCm1Zls+9NC/8Q==",
       "dependencies": {
         "vega-crossfilter": "~4.1.1",
         "vega-dataflow": "~5.7.5",
@@ -12688,7 +12689,7 @@
         "vega-hierarchy": "~4.1.1",
         "vega-label": "~1.2.1",
         "vega-loader": "~4.5.1",
-        "vega-parser": "~6.2.1",
+        "vega-parser": "~6.3.0",
         "vega-projection": "~1.6.0",
         "vega-regression": "~1.2.0",
         "vega-runtime": "~6.1.4",
@@ -12899,9 +12900,9 @@
       }
     },
     "node_modules/vega-parser": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.2.1.tgz",
-      "integrity": "sha512-F79bQXt6fMkACR+TfFl7ueehKO26yCR/3iRZxhU7/pgHerx/d8K8pf2onMguu3NAN4eitT+PPuTgkDZtcqo9Qg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.3.0.tgz",
+      "integrity": "sha512-swS5RuP2imRarMpGWaAZusoKkXc4Z5WxWx349pkqxIAf4F7H8Ya9nThEkSWsFozd75O9nWh0QLifds8Xb7KjUg==",
       "dependencies": {
         "vega-dataflow": "^5.7.5",
         "vega-event-selector": "^3.0.1",
@@ -14000,7 +14001,7 @@
       "version": "0.6.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@duckdb/duckdb-wasm": "^1.28.1-dev106.0",
+        "@duckdb/duckdb-wasm": "^1.28.1-dev109.0",
         "@uwdata/mosaic-sql": "^0.6.0",
         "apache-arrow": "^15.0.0"
       }
@@ -14093,7 +14094,7 @@
         "@uwdata/mosaic-core": "^0.6.1",
         "@uwdata/mosaic-sql": "^0.6.0",
         "@uwdata/vgplot": "^0.6.1",
-        "vega": "^5.27.0",
+        "vega": "^5.28.0",
         "vega-embed": "^6.24.0"
       },
       "devDependencies": {
@@ -14121,7 +14122,7 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "anywidget": "^0.9.2"
+        "anywidget": "^0.9.3"
       }
     },
     "packages/widget/node_modules/@types/command-line-args": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "prepublishOnly": "npm run test && npm run lint && npm run build"
   },
   "dependencies": {
-    "@duckdb/duckdb-wasm": "^1.28.1-dev106.0",
+    "@duckdb/duckdb-wasm": "^1.28.1-dev109.0",
     "@uwdata/mosaic-sql": "^0.6.0",
     "apache-arrow": "^15.0.0"
   }

--- a/packages/vega-example/package.json
+++ b/packages/vega-example/package.json
@@ -15,7 +15,7 @@
     "@uwdata/mosaic-core": "^0.6.1",
     "@uwdata/mosaic-sql": "^0.6.0",
     "@uwdata/vgplot": "^0.6.1",
-    "vega": "^5.27.0",
+    "vega": "^5.28.0",
     "vega-embed": "^6.24.0"
   }
 }

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -22,6 +22,6 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "anywidget": "^0.9.2"
+    "anywidget": "^0.9.3"
   }
 }


### PR DESCRIPTION
- Add `Query.describe(query)` to generate `DESCRIBE ...` queries for metadata.
- Add support for arbitrary SQL expressions (not just column names) as field info metadata.
- Add support to convert Apache Arrow `DECIMAL` values to JavaScript `Number` values.
- Update query consolidator to handle DESCRIBE queries, which require filtering rather than projection.
- Remove table catalog from Coordinator, rely on cache and consolidation instead.
- Refactor `fieldInfo` metadata management within vgplot `Mark` implementations.
- Refactor Apache Arrow utilities to be exports of `@uwdata/mosaic-core`.
- Update dependencies.

As a result of the above, the `catalog` option of `Coordinator.clear` is no longer supported. Clients can still pass the options, but it will have no effect. Instead, clearing the `cache` will now also drop any cached table metadata.

This PR fixes the issue raised here: https://github.com/observablehq/framework/pull/1015#issuecomment-1984603130.
Passing SQL expressions such as ``{x: vg.sql`-ra`}`` should now work.