### PR TITLE
Fixes and refinements

### DIFF
--- a/packages/plot/src/marks/ContourMark.js
+++ b/packages/plot/src/marks/ContourMark.js
@@ -52,9 +52,12 @@ export class ContourMark extends Grid2DMark {
 
     // generate contours
     this.data = kde.flatMap(cell => tz.map(t => {
+      // annotate contour geojson with cell groupby fields
+      // d3-contour already adds a threshold "value" property
+      const { density, ...groupby } = cell;
       return Object.assign(
-        transform(contour.contour(cell.density, t), x, y),
-        { ...cell, density: t }
+        transform(contour.contour(density, t), x, y),
+        { ...groupby }
       );
     }));
 
@@ -70,8 +73,12 @@ export class ContourMark extends Grid2DMark {
         options[channel] = channelOption(c);
       }
     }
-    if (densityMap.fill) options.fill = 'density';
-    if (densityMap.stroke) options.stroke = 'density';
+    // d3-contour adds a threshold "value" property
+    // here we ensure requested density values are encoded
+    for (const channel in densityMap) {
+      if (!densityMap[channel]) continue;
+      options[channel] = channelOption({ channel, as: 'value' });
+    }
     return [{ type, data, options }];
   }
 }

--- a/packages/plot/src/marks/Mark.js
+++ b/packages/plot/src/marks/Mark.js
@@ -7,6 +7,7 @@ import { toDataArray } from './util/to-data-array.js';
 import { Transform } from '../symbols.js';
 
 const isColorChannel = channel => channel === 'stroke' || channel === 'fill';
+const isOpacityChannel = channel => /opacity$/i.test(channel);
 const isSymbolChannel = channel => channel === 'symbol';
 const isFieldObject = (channel, field) => {
   return channel !== 'sort' && channel !== 'tip'
@@ -185,6 +186,7 @@ export function channelOption(c) {
   // https://github.com/observablehq/plot/issues/1593
   return Object.hasOwn(c, 'value') ? c.value
     : isColorChannel(c.channel) ? { value: c.as, scale: 'color' }
+    : isOpacityChannel(c.channel) ? { value: c.as, scale: 'opacity' }
     : c.as;
 }
 

--- a/packages/plot/src/marks/RasterMark.js
+++ b/packages/plot/src/marks/RasterMark.js
@@ -141,9 +141,9 @@ function alphaScale(mark, prop) {
   const domainTransient = domainAttr?.[Transient];
   const domain = (!domainFixed && !domainTransient && domainAttr)
     || gridDomainContinuous(grids, prop);
-  if (domainFixed || domainTransient) {
-    if (domainTransient) domain[Transient] = true;
-    plot.setAttribute('colorDomain', domain);
+  if (domainFixed || domainTransient || !domainAttr) {
+    if (!domainFixed) domain[Transient] = true;
+    plot.setAttribute('opacityDomain', domain);
   }
 
   // generate opacity scale
@@ -177,8 +177,8 @@ function colorScale(mark, prop) {
       : discrete ? gridDomainDiscrete(grids, prop)
       : gridDomainContinuous(grids, prop)
   );
-  if (domainFixed || domainTransient) {
-    if (domainTransient) domain[Transient] = true;
+  if (domainFixed || domainTransient || !domainAttr) {
+    if (!domainFixed) domain[Transient] = true;
     plot.setAttribute('colorDomain', domain);
   }
 

--- a/packages/plot/src/marks/RegressionMark.js
+++ b/packages/plot/src/marks/RegressionMark.js
@@ -72,6 +72,9 @@ export class RegressionMark extends Mark {
         case 'y':
         case 'fill':
           break;
+        case 'tip':
+          aopt.tip = channelOption(c);
+          break;
         case 'stroke':
           lopt.stroke = aopt.fill = channelOption(c);
           break;


### PR DESCRIPTION
- Pass `tip` option to `regression` mark error band only, providing a single informative tooltip.
- Fix `raster` mark transient scale domain updates to get appropriate domain definitions.
- Fix `contour` mark fill/stroke/opacity encoding channel generation for density thresholds.