### PR TITLE
fix: only activate client in intervals when the pointer is up

### DIFF
--- a/packages/plot/src/interactors/Interval1D.js
+++ b/packages/plot/src/interactors/Interval1D.js
@@ -6,7 +6,7 @@ import { getField } from './util/get-field.js';
 import { invert } from './util/invert.js';
 import { patchScreenCTM } from './util/patchScreenCTM.js';
 import { sanitizeStyles } from './util/sanitize-styles.js';
-import { pointerdown } from './util/pointerdown.js';
+import { pointerIsDown } from './util/pointerIsDown.js';
 
 export class Interval1D {
   constructor(mark, {
@@ -86,6 +86,6 @@ export class Interval1D {
       }
     }
 
-    svg.addEventListener('pointerenter', () => pointerdown || this.activate());
+    svg.addEventListener('pointerenter', () => pointerIsDown || this.activate());
   }
 }

--- a/packages/plot/src/interactors/Interval1D.js
+++ b/packages/plot/src/interactors/Interval1D.js
@@ -6,6 +6,7 @@ import { getField } from './util/get-field.js';
 import { invert } from './util/invert.js';
 import { patchScreenCTM } from './util/patchScreenCTM.js';
 import { sanitizeStyles } from './util/sanitize-styles.js';
+import { pointerdown } from './util/pointerdown.js';
 
 export class Interval1D {
   constructor(mark, {
@@ -85,6 +86,6 @@ export class Interval1D {
       }
     }
 
-    svg.addEventListener('pointerenter', () => this.activate());
+    svg.addEventListener('pointerenter', () => pointerdown || this.activate());
   }
 }

--- a/packages/plot/src/interactors/Interval2D.js
+++ b/packages/plot/src/interactors/Interval2D.js
@@ -6,7 +6,7 @@ import { getField } from './util/get-field.js';
 import { invert } from './util/invert.js';
 import { patchScreenCTM } from './util/patchScreenCTM.js';
 import { sanitizeStyles } from './util/sanitize-styles.js';
-import { pointerdown } from './util/pointerdown.js';
+import { pointerIsDown } from './util/pointerIsDown.js';
 
 const asc = (a, b) => a - b;
 
@@ -98,6 +98,6 @@ export class Interval2D {
       this.g.call(brush.moveSilent, [[x1, y1], [x2, y2]]);
     }
 
-    svg.addEventListener('pointerenter', () => pointerdown || this.activate());
+    svg.addEventListener('pointerenter', () => pointerIsDown || this.activate());
   }
 }

--- a/packages/plot/src/interactors/Interval2D.js
+++ b/packages/plot/src/interactors/Interval2D.js
@@ -6,6 +6,7 @@ import { getField } from './util/get-field.js';
 import { invert } from './util/invert.js';
 import { patchScreenCTM } from './util/patchScreenCTM.js';
 import { sanitizeStyles } from './util/sanitize-styles.js';
+import { pointerdown } from './util/pointerdown.js';
 
 const asc = (a, b) => a - b;
 
@@ -97,6 +98,6 @@ export class Interval2D {
       this.g.call(brush.moveSilent, [[x1, y1], [x2, y2]]);
     }
 
-    svg.addEventListener('pointerenter', () => this.activate());
+    svg.addEventListener('pointerenter', () => pointerdown || this.activate());
   }
 }

--- a/packages/plot/src/interactors/util/pointerIsDown.js
+++ b/packages/plot/src/interactors/util/pointerIsDown.js
@@ -1,4 +1,6 @@
 export let pointerIsDown = false;
 
-document.body.addEventListener('pointerdown', () => pointerIsDown = true);
-document.body.addEventListener('pointerup', () => pointerIsDown = false);
+if (typeof document !== 'undefined') {
+  document.body.addEventListener('pointerdown', () => pointerIsDown = true);
+  document.body.addEventListener('pointerup', () => pointerIsDown = false);
+}

--- a/packages/plot/src/interactors/util/pointerIsDown.js
+++ b/packages/plot/src/interactors/util/pointerIsDown.js
@@ -1,0 +1,4 @@
+export let pointerIsDown = false;
+
+document.body.addEventListener('pointerdown', () => pointerIsDown = true);
+document.body.addEventListener('pointerup', () => pointerIsDown = false);

--- a/packages/plot/src/interactors/util/pointerdown.js
+++ b/packages/plot/src/interactors/util/pointerdown.js
@@ -1,0 +1,9 @@
+export let pointerdown = false;
+
+document.body.addEventListener('pointerdown', () => {
+  pointerdown = true;
+});
+
+document.body.addEventListener('pointerup', () => {
+    pointerdown = false;
+});

--- a/packages/plot/src/interactors/util/pointerdown.js
+++ b/packages/plot/src/interactors/util/pointerdown.js
@@ -1,9 +1,0 @@
-export let pointerdown = false;
-
-document.body.addEventListener('pointerdown', () => {
-  pointerdown = true;
-});
-
-document.body.addEventListener('pointerup', () => {
-    pointerdown = false;
-});


### PR DESCRIPTION
fixes #337

The cursor isn't correct while you hover over another chart and we also don't activate a client when the pointer goes up over a chart but those are just small things that would require more substantial changes. 