### PR TITLE
Address AST context and instantiation issues.

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -97,7 +97,6 @@
 
   async function load(name, source) {
     view.replaceChildren();
-    clear(); // reset coordinator and namedPlot state
     if (name === 'none' && location.search) {
       // get example name from query string
       name = location.search.slice(1);
@@ -107,23 +106,28 @@
         await fetch(`../specs/yaml/${name}.yaml`).then(res => res.text())
       );
 
-      // provide options for output generation
-      // if using a local server, use baseURL for client-loaded data only
+      // options for output generation
       const baseURL = location.origin + '/';
       const options = connectorMenu.value === 'wasm' ? { baseURL } : {};
 
+      // parse and load spec
       const ast = parseSpec(spec);
-      const child = source === 'esm'
-        ? await loadModuleView(ast, options)
-        : (await astToDOM(ast, options)).element;
-      view.replaceChildren(child);
+      const el = await (source === 'esm' ? loadESM : loadDOM)(ast, options);
+      view.replaceChildren(el);
     }
   }
 
-  async function loadModuleView(spec, options) {
+  async function loadDOM(ast, options) {
+    clear();
+    const { element } = await astToDOM(ast, { ...options, api: vg });
+    return element;
+  }
+
+  async function loadESM(ast, options) {
     const vgplot = new URL('./setup.js', window.location.href).toString();
-    const imports = new Map([[vgplot, ['vg']]]);
-    const code = astToESM(spec, { ...options, imports });
+    const imports = new Map([[vgplot, ['vg', 'clear']]]);
+    const preamble = 'clear();';
+    const code = astToESM(ast, { ...options, imports, preamble });
     console.log(code);
     const blob = new Blob([code], { type: 'text/javascript' });
     const url = URL.createObjectURL(blob);

--- a/docs/public/specs/esm/aeromagnetic-survey.js
+++ b/docs/public/specs/esm/aeromagnetic-survey.js
@@ -14,10 +14,10 @@ export default vg.vconcat(
       options: ["none", "nearest", "barycentric", "random-walk"],
       as: $interp
     }),
-    vg.hspace(1em),
+    vg.hspace("1em"),
     vg.slider({label: "Blur", min: 0, max: 100, as: $blur})
   ),
-  vg.vspace(1em),
+  vg.vspace("1em"),
   vg.plot(
     vg.raster(
       vg.from("ca55"),

--- a/docs/public/specs/esm/legends.js
+++ b/docs/public/specs/esm/legends.js
@@ -32,7 +32,7 @@ export default vg.vconcat(
     vg.hspace(35),
     vg.symbolLegend({for: "symbol-categorical", label: "Symbol Swatch (External)", as: $toggle})
   ),
-  vg.vspace(1em),
+  vg.vspace("1em"),
   vg.hconcat(
     vg.plot(
       vg.opacityLegend({label: "Opacity Ramp", as: $interval}),
@@ -53,7 +53,7 @@ export default vg.vconcat(
     vg.hspace(30),
     vg.opacityLegend({for: "opacity-linear-no-label"})
   ),
-  vg.vspace(1em),
+  vg.vspace("1em"),
   vg.hconcat(
     vg.plot(
       vg.colorLegend({label: "Linear Color Ramp", as: $interval}),
@@ -74,7 +74,7 @@ export default vg.vconcat(
     vg.hspace(30),
     vg.colorLegend({for: "color-linear-no-label"})
   ),
-  vg.vspace(1em),
+  vg.vspace("1em"),
   vg.hconcat(
     vg.plot(
       vg.colorLegend({label: "Logarithmic Color Ramp", as: $interval}),

--- a/packages/spec/src/ast/HSpaceNode.js
+++ b/packages/spec/src/ast/HSpaceNode.js
@@ -16,7 +16,7 @@ export class HSpaceNode extends ASTNode {
   }
 
   codegen(ctx) {
-    return `${ctx.tab()}${ctx.ns()}${this.type}(${this.value})`;
+    return `${ctx.tab()}${ctx.ns()}${this.type}(${ctx.stringify(this.value)})`;
   }
 
   toJSON() {

--- a/packages/spec/src/ast/InputNode.js
+++ b/packages/spec/src/ast/InputNode.js
@@ -18,8 +18,7 @@ export class InputNode extends ASTNode {
   }
 
   instantiate(ctx) {
-    const fn = ctx.api[this.name];
-    return fn(this.options.instantiate(ctx));
+    return ctx.api[this.name](this.options.instantiate(ctx));
   }
 
   codegen(ctx) {

--- a/packages/spec/src/ast/PlotAttributeNode.js
+++ b/packages/spec/src/ast/PlotAttributeNode.js
@@ -20,8 +20,7 @@ export class PlotAttributeNode extends ASTNode {
 
   instantiate(ctx) {
     const { name, value } = this;
-    const fn = ctx.api[name];
-    return fn(value.instantiate(ctx));
+    return ctx.api[name](value.instantiate(ctx));
   }
 
   codegen(ctx) {

--- a/packages/spec/src/ast/PlotInteractorNode.js
+++ b/packages/spec/src/ast/PlotInteractorNode.js
@@ -18,8 +18,7 @@ export class PlotInteractorNode extends ASTNode {
   }
 
   instantiate(ctx) {
-    const fn = ctx.api[this.name];
-    return fn(this.options.instantiate(ctx));
+    return ctx.api[this.name](this.options.instantiate(ctx));
   }
 
   codegen(ctx) {

--- a/packages/spec/src/ast/PlotLegendNode.js
+++ b/packages/spec/src/ast/PlotLegendNode.js
@@ -20,8 +20,7 @@ export class PlotLegendNode extends ASTNode {
   }
 
   instantiate(ctx) {
-    const fn = ctx.api[this.key];
-    return fn(this.options.instantiate(ctx));
+    return ctx.api[this.key](this.options.instantiate(ctx));
   }
 
   codegen(ctx) {

--- a/packages/spec/src/ast/PlotMarkNode.js
+++ b/packages/spec/src/ast/PlotMarkNode.js
@@ -41,9 +41,10 @@ export class PlotMarkNode extends ASTNode {
 
   instantiate(ctx) {
     const { name, data, options } = this;
-    const fn = ctx.api[name];
     const opt = options.instantiate(ctx);
-    return data ? fn(data.instantiate(ctx), opt) : fn(opt);
+    return data
+      ? ctx.api[name](data.instantiate(ctx), opt)
+      : ctx.api[name](opt);
   }
 
   codegen(ctx) {

--- a/packages/spec/src/ast/TransformNode.js
+++ b/packages/spec/src/ast/TransformNode.js
@@ -41,8 +41,7 @@ export class TransformNode extends ASTNode {
     const { name, args, options } = this;
     const { distinct, orderby, partitionby, rows, range } = options;
 
-    const fn = ctx.api[name];
-    let expr = fn(...args);
+    let expr = ctx.api[name](...args);
     if (distinct) {
       expr = expr.distinct();
     }

--- a/packages/spec/src/ast/VSpaceNode.js
+++ b/packages/spec/src/ast/VSpaceNode.js
@@ -16,7 +16,7 @@ export class VSpaceNode extends ASTNode {
   }
 
   codegen(ctx) {
-    return `${ctx.tab()}${ctx.ns()}${this.type}(${this.value})`;
+    return `${ctx.tab()}${ctx.ns()}${this.type}(${ctx.stringify(this.value)})`;
   }
 
   toJSON() {

--- a/packages/vgplot/src/plot/named-plots.js
+++ b/packages/vgplot/src/plot/named-plots.js
@@ -19,6 +19,10 @@ export class NamedPlots extends Map {
     }
     return super.set(name, plot);
   }
+  clear() {
+    this.waiting?.clear();
+    return super.clear();
+  }
 }
 
 /**

--- a/specs/esm/aeromagnetic-survey.js
+++ b/specs/esm/aeromagnetic-survey.js
@@ -14,10 +14,10 @@ export default vg.vconcat(
       options: ["none", "nearest", "barycentric", "random-walk"],
       as: $interp
     }),
-    vg.hspace(1em),
+    vg.hspace("1em"),
     vg.slider({label: "Blur", min: 0, max: 100, as: $blur})
   ),
-  vg.vspace(1em),
+  vg.vspace("1em"),
   vg.plot(
     vg.raster(
       vg.from("ca55"),

--- a/specs/esm/legends.js
+++ b/specs/esm/legends.js
@@ -32,7 +32,7 @@ export default vg.vconcat(
     vg.hspace(35),
     vg.symbolLegend({for: "symbol-categorical", label: "Symbol Swatch (External)", as: $toggle})
   ),
-  vg.vspace(1em),
+  vg.vspace("1em"),
   vg.hconcat(
     vg.plot(
       vg.opacityLegend({label: "Opacity Ramp", as: $interval}),
@@ -53,7 +53,7 @@ export default vg.vconcat(
     vg.hspace(30),
     vg.opacityLegend({for: "opacity-linear-no-label"})
   ),
-  vg.vspace(1em),
+  vg.vspace("1em"),
   vg.hconcat(
     vg.plot(
       vg.colorLegend({label: "Linear Color Ramp", as: $interval}),
@@ -74,7 +74,7 @@ export default vg.vconcat(
     vg.hspace(30),
     vg.colorLegend({for: "color-linear-no-label"})
   ),
-  vg.vspace(1em),
+  vg.vspace("1em"),
   vg.hconcat(
     vg.plot(
       vg.colorLegend({label: "Logarithmic Color Ramp", as: $interval}),


### PR DESCRIPTION
- Add `preamble` option to `astToESM`.
- Fix `hspace`/`vspace` codegen to properly stringify values.
- Fix `namedPlots.clear()` to also clear queued requests.
- Fix proper context use in AST node `instantiate()` calls.
- Update dev example runner.