### PR TITLE
Only activate selections when the mouse button is up.

### DIFF
--- a/packages/plot/src/interactors/Interval1D.js
+++ b/packages/plot/src/interactors/Interval1D.js
@@ -85,6 +85,8 @@ export class Interval1D {
       }
     }
 
-    svg.addEventListener('pointerenter', () => this.activate());
+    svg.addEventListener('pointerenter', evt => {
+      if (!evt.buttons) this.activate();
+    });
   }
 }

--- a/packages/plot/src/interactors/Interval2D.js
+++ b/packages/plot/src/interactors/Interval2D.js
@@ -97,6 +97,8 @@ export class Interval2D {
       this.g.call(brush.moveSilent, [[x1, y1], [x2, y2]]);
     }
 
-    svg.addEventListener('pointerenter', () => this.activate());
+    svg.addEventListener('pointerenter', evt => {
+      if (!evt.buttons) this.activate();
+    });
   }
 }

--- a/packages/plot/src/interactors/Nearest.js
+++ b/packages/plot/src/interactors/Nearest.js
@@ -46,8 +46,8 @@ export class Nearest {
     });
 
     if (param) return;
-    svg.addEventListener('pointerenter', () => {
-      this.selection.activate(this.clause(0));
+    svg.addEventListener('pointerenter', evt => {
+      if (!evt.buttons) this.selection.activate(this.clause(0));
     });
   }
 }

--- a/packages/plot/src/interactors/PanZoom.js
+++ b/packages/plot/src/interactors/PanZoom.js
@@ -86,8 +86,9 @@ export class PanZoom {
 
     if (panx || pany) {
       let enter = false;
-      element.addEventListener('mouseenter', () => {
+      element.addEventListener('pointerenter', evt => {
         if (enter) return; else enter = true;
+        if (evt.buttons) return; // don't activate if mouse down
         if (panx) {
           const { xscale, xfield } = this;
           xsel.activate(this.clause(xscale.domain, xfield, xscale));
@@ -97,7 +98,7 @@ export class PanZoom {
           ysel.activate(this.clause(yscale.domain, yfield, yscale));
         }
       });
-      element.addEventListener('mouseleave', () => enter = false);
+      element.addEventListener('pointerleave', () => enter = false);
     }
   }
 }

--- a/packages/plot/src/interactors/Toggle.js
+++ b/packages/plot/src/interactors/Toggle.js
@@ -84,7 +84,8 @@ export class Toggle {
       }
     });
 
-    svg.addEventListener('pointerenter', () => {
+    svg.addEventListener('pointerenter', evt => {
+      if (evt.buttons) return;
       this.selection.activate(this.clause([this.channels.map(() => 0)]));
     });
   }


### PR DESCRIPTION
- Fix interactors to avoid firing activate events if the mouse is being dragged.

Supercedes #339.