### PR TITLE
chore: use uv for installing python deps

### DIFF
--- a/packages/duckdb-server/pyproject.toml
+++ b/packages/duckdb-server/pyproject.toml
@@ -31,11 +31,13 @@ dev = [
 [tool.hatch.envs.default]
 python = "3.11"
 features = ["dev"]
+uv = true
 
 [tool.hatch.envs.default.scripts]
 serve = "watchmedo auto-restart --pattern '*.py' --recursive --signal SIGTERM python pkg/__main__.py"
 
 [tool.hatch.envs.test]
+uv = true
 dependencies = [
   "coverage[toml]",
   "pytest",

--- a/packages/widget/pyproject.toml
+++ b/packages/widget/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
 [tool.hatch.envs.default]
 python = "3.11"
 features = ["dev"]
+uv = true
 
 [tool.hatch.version]
 path = "package.json"


### PR DESCRIPTION
uv is way faster than pip for installing dependencies. See https://github.com/pypa/hatch/issues/1268

Needs a new release of hatch to actually work but will not break either.