### PR TITLE
Support partial data cube indexes.

### DIFF
--- a/packages/core/src/FilterGroup.js
+++ b/packages/core/src/FilterGroup.js
@@ -35,7 +35,8 @@ export class FilterGroup {
 
   index(state) {
     const { selection } = this;
-    this.indexer = state
+    const { resolver } = selection;
+    this.indexer = state && (resolver.single || !resolver.union)
       ? new DataCubeIndexer(this.mc, { ...state, selection })
       : null;
   }

--- a/packages/core/src/Selection.js
+++ b/packages/core/src/Selection.js
@@ -98,6 +98,13 @@ export class Selection extends Param {
   }
 
   /**
+   * The selection clause resolver.
+   */
+  get resolver() {
+    return this._resolver;
+  }
+
+  /**
    * The current active (most recently updated) selection clause.
    */
   get active() {


### PR DESCRIPTION
Previously, data cube indexes were constructed only when _all_ filtered clients in a Selection were indexable. This PR relaxes this restriction: we now build data cube index tables for indexable clients while using standard, unoptimized selection update queries for any others.