### PR TITLE
Add selection clause methods and types.

### DIFF
--- a/packages/core/src/DataCubeIndexer.js
+++ b/packages/core/src/DataCubeIndexer.js
@@ -10,7 +10,7 @@ import { indexColumns } from './util/index-columns.js';
  * as temporary database tables that can be queried for rapid updates.
  * Compatible client queries must pull data from the same backing table and
  * must consist of only groupby dimensions and supported aggregates.
- * Compatible selections must contain an active clause that exposes a schema
+ * Compatible selections must contain an active clause that exposes metadata
  * for an interval or point value predicate.
  */
 export class DataCubeIndexer {
@@ -150,10 +150,10 @@ export class DataCubeIndexer {
 }
 
 function getActiveView(clause) {
-  const { source, schema } = clause;
+  const { source, meta } = clause;
   let columns = clause.predicate?.columns;
-  if (!schema || !columns) return null;
-  const { type, scales, pixelSize = 1 } = schema;
+  if (!meta || !columns) return null;
+  const { type, scales, pixelSize = 1 } = meta;
   let predicate;
 
   if (type === 'interval' && scales) {

--- a/packages/core/src/SelectionClause.js
+++ b/packages/core/src/SelectionClause.js
@@ -1,0 +1,144 @@
+import {
+  SQLExpression, and, contains, isBetween, isNotDistinct, literal,
+  or, prefix, regexp_matches, suffix
+} from '@uwdata/mosaic-sql';
+import { MosaicClient } from './MosaicClient.js';
+
+/**
+ * @typedef {import('./util/selection-types.js').SelectionClause} SelectionClause
+ * @typedef {import('./util/selection-types.js').Scale} Scale
+ * @typedef {import('./util/selection-types.js').Extent} Extent
+ * @typedef {import('./util/selection-types.js').MatchMethod} MatchMethod
+ * @typedef {SQLExpression | string} Field
+ */
+
+/**
+ * Generate a selection clause for a single selected point value.
+ * @param {Field} field The table column or expression to select.
+ * @param {*} value The selected value.
+ * @param {object} options Additional clause properties.
+ * @param {*} options.source The source component generating this clause.
+ * @param {Set<MosaicClient>} [options.clients] The Mosaic clients associated
+ *  with this clause. These clients are not filtered by this clause in
+ *  cross-filtering contexts.
+ * @returns {SelectionClause} The generated selection clause.
+ */
+export function point(field, value, { source, clients = undefined }) {
+  /** @type {SQLExpression | null} */
+  const predicate = value !== undefined
+    ? isNotDistinct(field, literal(value))
+    : null;
+  return {
+    meta: { type: 'point' },
+    source,
+    clients,
+    value,
+    predicate
+  };
+}
+
+/**
+ * Generate a selection clause for multiple selected point values.
+ * @param {Field[]} fields The table columns or expressions to select.
+ * @param {any[][]} value The selected values, as an array of arrays where
+ *  each subarray contains values corresponding to each *fields* entry.
+ * @param {object} options Additional clause properties.
+ * @param {*} options.source The source component generating this clause.
+ * @param {Set<MosaicClient>} [options.clients] The Mosaic clients associated
+ *  with this clause. These clients are not filtered by this clause in
+ *  cross-filtering contexts.
+ * @returns {SelectionClause} The generated selection clause.
+ */
+export function points(fields, value, { source, clients = undefined }) {
+  /** @type {SQLExpression | null} */
+  let predicate = null;
+  if (value) {
+    const clauses = value.map(vals => {
+      const list = vals.map((v, i) => isNotDistinct(fields[i], literal(v)));
+      return list.length > 1 ? and(list) : list[0];
+    });
+    predicate = clauses.length > 1 ? or(clauses) : clauses[0];
+  }
+  return {
+    meta: { type: 'point' },
+    source,
+    clients,
+    value,
+    predicate
+  };
+}
+
+/**
+ * Generate a selection clause for a selected 1D interval.
+ * @param {Field} field The table column or expression to select.
+ * @param {Extent} value The selected interval as a [lo, hi] array.
+ * @param {object} options Additional clause properties.
+ * @param {*} options.source The source component generating this clause.
+ * @param {Set<MosaicClient>} [options.clients] The Mosaic clients associated
+ *  with this clause. These clients are not filtered by this clause in
+ *  cross-filtering contexts.
+ * @param {Scale} [options.scale] The scale mapping descriptor.
+ * @param {number} [options.pixelSize=1] The interactive pixel size.
+ * @returns {SelectionClause} The generated selection clause.
+ */
+export function interval(field, value, {
+  source, clients = undefined, scale = null, pixelSize = 1
+}) {
+  /** @type {SQLExpression | null} */
+  const predicate = value != null ? isBetween(field, value) : null;
+  /** @type {import('./util/selection-types.js').IntervalMetadata} */
+  const meta = { type: 'interval', scales: [scale], pixelSize };
+  return { meta, source, clients, value, predicate };
+}
+
+/**
+ * Generate a selection clause for multiple selected intervals.
+ * @param {Field[]} fields The table columns or expressions to select.
+ * @param {Extent[]} value The selected intervals, as an array of extents.
+ * @param {object} options Additional clause properties.
+ * @param {*} options.source The source component generating this clause.
+ * @param {Set<MosaicClient>} [options.clients] The Mosaic clients associated
+ *  with this clause. These clients are not filtered by this clause in
+ *  cross-filtering contexts.
+ * @param {Scale[]} [options.scales] The scale mapping descriptors,
+ *  in an order matching the given *fields* and *value* extents.
+ * @param {number} [options.pixelSize=1] The interactive pixel size.
+ * @returns {SelectionClause} The generated selection clause.
+ */
+export function intervals(fields, value, {
+  source, clients = undefined, scales = [], pixelSize = 1
+}) {
+  /** @type {SQLExpression | null} */
+  const predicate = value != null
+    ? and(fields.map((f, i) => isBetween(f, value[i])))
+    : null;
+  /** @type {import('./util/selection-types.js').IntervalMetadata} */
+  const meta = { type: 'interval', scales, pixelSize };
+  return { meta, source, clients, value, predicate };
+}
+
+const MATCH_METHODS = { contains, prefix, suffix, regexp: regexp_matches };
+
+/**
+ * Generate a selection clause for text search matching.
+ * @param {Field} field The table column or expression to select.
+ * @param {string} value The selected text search query string.
+ * @param {object} options Additional clause properties.
+ * @param {*} options.source The source component generating this clause.
+ * @param {Set<MosaicClient>} [options.clients] The Mosaic clients associated
+ *  with this clause. These clients are not filtered by this clause in
+ *  cross-filtering contexts.
+ * @param {MatchMethod} [options.method] The
+ *  text matching method to use. Defaults to `'contains'`.
+ * @returns {SelectionClause} The generated selection clause.
+ */
+export function match(field, value, {
+  source, clients = undefined, method = 'contains'
+}) {
+  let fn = MATCH_METHODS[method];
+  /** @type {SQLExpression | null} */
+  const predicate = value ? fn(field, literal(value)) : null;
+  /** @type {import('./util/selection-types.js').MatchMetadata} */
+  const meta = { type: 'match', method };
+  return { meta, source, clients, value, predicate };
+}

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -3,6 +3,7 @@ export { Coordinator, coordinator } from './Coordinator.js';
 export { Selection, isSelection } from './Selection.js';
 export { Param, isParam } from './Param.js';
 export { Priority } from './QueryManager.js';
+export { point, points, interval, intervals, match } from './SelectionClause.js';
 
 export { restConnector } from './connectors/rest.js';
 export { socketConnector } from './connectors/socket.js';

--- a/packages/inputs/src/Menu.js
+++ b/packages/inputs/src/Menu.js
@@ -1,5 +1,5 @@
-import { MosaicClient, isParam, isSelection } from '@uwdata/mosaic-core';
-import { Query, eq, literal } from '@uwdata/mosaic-sql';
+import { MosaicClient, isParam, isSelection, point } from '@uwdata/mosaic-core';
+import { Query } from '@uwdata/mosaic-sql';
 import { input } from './input.js';
 
 const isObject = v => {
@@ -82,12 +82,9 @@ export class Menu extends MosaicClient {
   publish(value) {
     const { selection, column } = this;
     if (isSelection(selection)) {
-      selection.update({
-        source: this,
-        schema: { type: 'point' },
-        value,
-        predicate: (value !== '' && value !== undefined) ? eq(column, literal(value)) : null
-      });
+      if (value === '') value = undefined; // 'All' option
+      const clause = point(column, value, { source: this });
+      selection.update(clause);
     } else if (isParam(selection)) {
       selection.update(value);
     }

--- a/packages/inputs/src/Search.js
+++ b/packages/inputs/src/Search.js
@@ -1,10 +1,7 @@
-import { MosaicClient, isParam, isSelection } from '@uwdata/mosaic-core';
-import {
-  Query, regexp_matches, contains, prefix, suffix, literal
-} from '@uwdata/mosaic-sql';
+import { MosaicClient, isParam, isSelection, match } from '@uwdata/mosaic-core';
+import { Query } from '@uwdata/mosaic-sql';
 import { input } from './input.js';
 
-const FUNCTIONS = { contains, prefix, suffix, regexp: regexp_matches };
 let _id = 0;
 
 export const search = options => input(Search, options);
@@ -68,12 +65,8 @@ export class Search extends MosaicClient {
   publish(value) {
     const { selection, column, type } = this;
     if (isSelection(selection)) {
-      selection.update({
-        source: this,
-        schema: { type },
-        value,
-        predicate: value ? FUNCTIONS[type](column, literal(value)) : null
-      });
+      const clause = match(column, value, { source: this, method: type });
+      selection.update(clause);
     } else if (isParam(selection)) {
       selection.update(value);
     }

--- a/packages/inputs/src/Slider.js
+++ b/packages/inputs/src/Slider.js
@@ -1,5 +1,5 @@
-import { MosaicClient, isParam, isSelection } from '@uwdata/mosaic-core';
-import { Query, eq, literal, max, min } from '@uwdata/mosaic-sql';
+import { MosaicClient, isParam, isSelection, point } from '@uwdata/mosaic-core';
+import { Query, max, min } from '@uwdata/mosaic-sql';
 import { input } from './input.js';
 
 let _id = 0;
@@ -91,12 +91,8 @@ export class Slider extends MosaicClient {
   publish(value) {
     const { selection, column } = this;
     if (isSelection(selection)) {
-      selection.update({
-        source: this,
-        schema: { type: 'point' },
-        value,
-        predicate: eq(column, literal(value))
-      });
+      const clause = point(column, value, { source: this });
+      selection.update(clause);
     } else if (isParam(this.selection)) {
       selection.update(value);
     }

--- a/packages/plot/src/interactors/Interval1D.js
+++ b/packages/plot/src/interactors/Interval1D.js
@@ -1,5 +1,5 @@
+import { interval } from '@uwdata/mosaic-core';
 import { select, min, max } from 'd3';
-import { isBetween } from '@uwdata/mosaic-sql';
 import { brushX, brushY } from './util/brush.js';
 import { closeTo } from './util/close-to.js';
 import { getField } from './util/get-field.js';
@@ -52,13 +52,12 @@ export class Interval1D {
 
   clause(value) {
     const { mark, pixelSize, field, scale } = this;
-    return {
+    return interval(field, value, {
       source: this,
-      schema: { type: 'interval', pixelSize, scales: [scale] },
       clients: this.peers ? mark.plot.markSet : new Set().add(mark),
-      value,
-      predicate: value ? isBetween(field, value) : null
-    };
+      scale,
+      pixelSize
+    });
   }
 
   init(svg, root) {

--- a/packages/plot/src/interactors/Interval2D.js
+++ b/packages/plot/src/interactors/Interval2D.js
@@ -1,5 +1,5 @@
+import { intervals } from '@uwdata/mosaic-core';
 import { select, min, max } from 'd3';
-import { and, isBetween } from '@uwdata/mosaic-sql';
 import { brush } from './util/brush.js';
 import { closeTo } from './util/close-to.js';
 import { getField } from './util/get-field.js';
@@ -57,15 +57,12 @@ export class Interval2D {
 
   clause(value) {
     const { mark, pixelSize, xfield, yfield, xscale, yscale } = this;
-    return {
+    return intervals([xfield, yfield], value, {
       source: this,
-      schema: { type: 'interval', pixelSize, scales: [xscale, yscale] },
       clients: this.peers ? mark.plot.markSet : new Set().add(mark),
-      value,
-      predicate: value
-        ? and(isBetween(xfield, value[0]), isBetween(yfield, value[1]))
-        : null
-    };
+      scales: [xscale, yscale],
+      pixelSize
+    });
   }
 
   init(svg) {

--- a/packages/plot/src/interactors/Nearest.js
+++ b/packages/plot/src/interactors/Nearest.js
@@ -1,5 +1,4 @@
-import { isSelection } from '@uwdata/mosaic-core';
-import { eq, literal } from '@uwdata/mosaic-sql';
+import { isSelection, point } from '@uwdata/mosaic-core';
 import { select, pointer } from 'd3';
 import { getField } from './util/get-field.js';
 
@@ -18,14 +17,7 @@ export class Nearest {
 
   clause(value) {
     const { clients, field } = this;
-    const predicate = value ? eq(field, literal(value)) : null;
-    return {
-      source: this,
-      schema: { type: 'point' },
-      clients,
-      value,
-      predicate
-    };
+    return point(field, value, { source: this, clients });
   }
 
   init(svg) {

--- a/packages/plot/src/interactors/PanZoom.js
+++ b/packages/plot/src/interactors/PanZoom.js
@@ -1,6 +1,5 @@
+import { interval, Selection } from '@uwdata/mosaic-core';
 import { select, zoom, ZoomTransform } from 'd3';
-import { Selection } from '@uwdata/mosaic-core';
-import { isBetween } from '@uwdata/mosaic-sql';
 import { getField } from './util/get-field.js';
 
 const asc = (a, b) => a - b;
@@ -49,13 +48,11 @@ export class PanZoom {
   }
 
   clause(value, field, scale) {
-    return {
+    return interval(field, value, {
       source: this,
-      schema: { type: 'interval', scales: [scale] },
       clients: this.mark.plot.markSet,
-      value,
-      predicate: value ? isBetween(field, value) : null
-    };
+      scale
+    });
   }
 
   init(svg) {

--- a/packages/plot/src/interactors/Toggle.js
+++ b/packages/plot/src/interactors/Toggle.js
@@ -1,4 +1,4 @@
-import { and, or, isNotDistinct, literal } from '@uwdata/mosaic-sql';
+import { points } from '@uwdata/mosaic-core';
 
 export class Toggle {
   /**
@@ -14,49 +14,37 @@ export class Toggle {
     this.mark = mark;
     this.selection = selection;
     this.peers = peers;
-    this.channels = channels.map(c => {
+    const fields = this.fields = [];
+    const as = this.as = [];
+    channels.forEach(c => {
       const q = c === 'color' ? ['color', 'fill', 'stroke']
         : c === 'x' ? ['x', 'x1', 'x2']
         : c === 'y' ? ['y', 'y1', 'y2']
         : [c];
       for (let i = 0; i < q.length; ++i) {
         const f = mark.channelField(q[i], { exact: true });
-        if (f) return {
-          field: f.field?.basis || f.field,
-          as: f.as
-        };
+        if (f) {
+          fields.push(f.field?.basis || f.field);
+          as.push(f.as);
+          return;
+        }
       }
       throw new Error(`Missing channel: ${c}`);
     });
   }
 
   clause(value) {
-    const { channels, mark } = this;
-    let predicate = null;
-
-    if (value) {
-      const clauses = value.map(vals => {
-        const list = vals.map((v, i) => {
-          return isNotDistinct(channels[i].field, literal(v));
-        });
-        return list.length > 1 ? and(list) : list[0];
-      });
-      predicate = clauses.length > 1 ? or(clauses) : clauses[0];
-    }
-
-    return {
+    const { fields, mark } = this;
+    return points(fields, value, {
       source: this,
-      schema: { type: 'point' },
-      clients: this.peers ? mark.plot.markSet : new Set().add(mark),
-      value,
-      predicate
-    };
+      clients: this.peers ? mark.plot.markSet : new Set().add(mark)
+    });
   }
 
   init(svg, selector, accessor) {
-    const { mark, channels, selection } = this;
+    const { mark, as, selection } = this;
     const { data: { columns = {} } = {} } = mark;
-    accessor ??= target => channels.map(c => columns[c.as][target.__data__]);
+    accessor ??= target => as.map(name => columns[name][target.__data__]);
     selector ??= `[data-index="${mark.index}"]`;
     const groups = new Set(svg.querySelectorAll(selector));
 
@@ -85,7 +73,7 @@ export class Toggle {
 
     svg.addEventListener('pointerenter', evt => {
       if (evt.buttons) return;
-      this.selection.activate(this.clause([this.channels.map(() => 0)]));
+      this.selection.activate(this.clause([this.fields.map(() => 0)]));
     });
   }
 }

--- a/packages/sql/src/index.js
+++ b/packages/sql/src/index.js
@@ -10,7 +10,8 @@ export {
 export {
   isSQLExpression,
   isParamLike,
-  sql
+  sql,
+  SQLExpression
 } from './expression.js';
 
 export {


### PR DESCRIPTION
- **Breaking**: Rename selection clause `schema` property to `meta`.
- Add selection clause generation methods (`point`, `interval`, etc).
- Add selection clause typings.
- Use selection clause methods in inputs and interactors.
- Export `SQLExpression` from `mosaic-sql` package.