### PR TITLE
Add selection field option to inputs.

### DIFF
--- a/packages/inputs/src/Slider.js
+++ b/packages/inputs/src/Slider.js
@@ -6,38 +6,36 @@ let _id = 0;
 
 export const slider = options => input(Slider, options);
 
-/**
- * Create a new slider input.
- * @param {object} [options] Options object
- * @param {HTMLElement} [options.element] The parent DOM element in which to
- *  place the slider elements. If undefined, a new `div` element is created.
- * @param {Selection} [options.filterBy] A selection to filter the database
- *  table indicated by the `from` property.
- * @param {Param} [options.as] The output param or selection. A selection
- *  clause is added based on the currently selected slider option.
- * @param {'point' | 'interval'} [options.select] The type of selection clause
- *  predicate to generate if the **as** option is a Selection.  If `'point'`
- *  (the default), the selection predicate is an equality check for the slider
- *  value. If `'interval'`, the predicate checks an interval from the minimum
- *  to the current slider value.
- * @param {number} [options.min] The minimum slider value.
- * @param {number} [options.max] The maximum slider value.
- * @param {number} [options.step] The slider step, the amount to increment
- *  between consecutive values.
- * @param {number} [options.value] The initial slider value.
- * @param {string} [options.from] The name of a database table to use as a data
- *  source for this widget. Used in conjunction with the `column` property.
- *  The minimum and maximum values of the column determine the slider range.
- * @param {string} [options.column] The name of a database column whose values
- *  determine the slider range. Used in conjunction with the `from` property.
- *  The minimum and maximum values of the column determine the slider range.
- * @param {string} [options.label] A text label for this input.
- * @param {number} [options.width] The width of the slider in screen pixels.
- */
 export class Slider extends MosaicClient {
   /**
-   * Create a new Slider instance.
-   * @param {object} options Options object
+   * Create a new slider input.
+   * @param {object} [options] Options object
+   * @param {HTMLElement} [options.element] The parent DOM element in which to
+   *  place the slider elements. If undefined, a new `div` element is created.
+   * @param {Selection} [options.filterBy] A selection to filter the database
+   *  table indicated by the *from* option.
+   * @param {Param} [options.as] The output param or selection. A selection
+   *  clause is added based on the currently selected slider option.
+   * @param {string} [options.field] The database column name to use within
+   *  generated selection clause predicates. Defaults to the *column* option.
+   * @param {'point' | 'interval'} [options.select] The type of selection clause
+   *  predicate to generate if the **as** option is a Selection.  If `'point'`
+   *  (the default), the selection predicate is an equality check for the slider
+   *  value. If `'interval'`, the predicate checks an interval from the minimum
+   *  to the current slider value.
+   * @param {number} [options.min] The minimum slider value.
+   * @param {number} [options.max] The maximum slider value.
+   * @param {number} [options.step] The slider step, the amount to increment
+   *  between consecutive values.
+   * @param {number} [options.value] The initial slider value.
+   * @param {string} [options.from] The name of a database table to use as a data
+   *  source for this widget. Used in conjunction with the *column* option.
+   *  The minimum and maximum values of the column determine the slider range.
+   * @param {string} [options.column] The name of a database column whose values
+   *  determine the slider range. Used in conjunction with the *from* option.
+   *  The minimum and maximum values of the column determine the slider range.
+   * @param {string} [options.label] A text label for this input.
+   * @param {number} [options.width] The width of the slider in screen pixels.
    */
   constructor({
     element,
@@ -51,6 +49,7 @@ export class Slider extends MosaicClient {
     label = column,
     value = as?.value,
     select = 'point',
+    field = column,
     width
   } = {}) {
     super(filterBy);
@@ -59,13 +58,14 @@ export class Slider extends MosaicClient {
     this.column = column || 'value';
     this.selection = as;
     this.selectionType = select;
+    this.field = field;
     this.min = min;
     this.max = max;
     this.step = step;
 
     this.element = element || document.createElement('div');
     this.element.setAttribute('class', 'input');
-    this.element.value = this;
+    Object.defineProperty(this.element, 'value', { value: this });
 
     if (label) {
       const desc = document.createElement('label');
@@ -78,9 +78,9 @@ export class Slider extends MosaicClient {
     this.slider.setAttribute('id', this.id);
     this.slider.setAttribute('type', 'range');
     if (width != null) this.slider.style.width = `${+width}px`;
-    if (min != null) this.slider.setAttribute('min', min);
-    if (max != null) this.slider.setAttribute('max', max);
-    if (step != null) this.slider.setAttribute('step', step);
+    if (min != null) this.slider.setAttribute('min', `${min}`);
+    if (max != null) this.slider.setAttribute('max', `${max}`);
+    if (step != null) this.slider.setAttribute('step', `${step}`);
     this.element.appendChild(this.slider);
 
     this.curval = document.createElement('label');
@@ -90,7 +90,7 @@ export class Slider extends MosaicClient {
 
     // handle initial value
     if (value != null) {
-      this.slider.setAttribute('value', value);
+      this.slider.setAttribute('value', `${value}`);
       if (this.selection?.value === undefined) this.publish(value);
     }
     this.curval.innerText = this.slider.value;
@@ -126,33 +126,33 @@ export class Slider extends MosaicClient {
     const { min, max } = Array.from(data)[0];
     if (this.min == null) {
       this.min = min;
-      this.slider.setAttribute('min', min);
+      this.slider.setAttribute('min', `${min}`);
     }
     if (this.max == null) {
       this.max = max;
-      this.slider.setAttribute('max', max);
+      this.slider.setAttribute('max', `${max}`);
     }
     if (this.step == null) {
-      this.step = String((max - min) / 500);
-      this.slider.setAttribute('step', this.step);
+      this.step = (max - min) / 500;
+      this.slider.setAttribute('step', `${this.step}`);
     }
     return this;
   }
 
   publish(value) {
-    const { column, selectionType, selection } = this;
+    const { field, selectionType, selection } = this;
     if (isSelection(selection)) {
       if (selectionType === 'interval') {
         /** @type {[number, number]} */
         const domain = [this.min ?? 0, value];
-        selection.update(interval(column, domain, {
+        selection.update(interval(field, domain, {
           source: this,
           bin: 'ceil',
           scale: { type: 'identity', domain },
           pixelSize: this.step
         }));
       } else {
-        selection.update(point(column, value, { source: this }));
+        selection.update(point(field, value, { source: this }));
       }
     } else if (isParam(this.selection)) {
       selection.update(value);

--- a/packages/inputs/src/Table.js
+++ b/packages/inputs/src/Table.js
@@ -42,7 +42,7 @@ export class Table extends MosaicClient {
 
     this.element = element || document.createElement('div');
     this.element.setAttribute('id', this.id);
-    this.element.value = this;
+    Object.defineProperty(this.element, 'value', { value: this });
     if (typeof width === 'number') this.element.style.width = `${width}px`;
     if (maxWidth) this.element.style.maxWidth = `${maxWidth}px`;
     this.element.style.maxHeight = `${height}px`;

--- a/packages/spec/src/spec/Input.ts
+++ b/packages/spec/src/spec/Input.ts
@@ -12,6 +12,11 @@ export interface Menu {
    */
   as?: ParamRef;
   /**
+   * The database column name to use within generated selection clause
+   * predicates. Defaults to the `column` property.
+   */
+  field?: string;
+  /**
    * The name of a database table to use as a data source for this widget.
    * Used in conjunction with the `column` property.
    */
@@ -33,11 +38,11 @@ export interface Menu {
   /**
    * An array of menu options, as literal values or option objects.
    * Option objects have a `value` property and an optional `label` property.
-   * If no label is provided, the (string-coerced) value is used.
+   * If no label is provided, the string-coerced value is used.
    */
-  options?: Array<any>;
+  options?: Array<any | { value: any, label?: string }>;
   /**
-   * The initial selected menu option.
+   * The initial selected menu value.
    */
   value?: any;
 }
@@ -53,6 +58,11 @@ export interface Search {
    * current text search query.
    */
   as?: ParamRef;
+  /**
+   * The database column name to use within generated selection clause
+   * predicates. Defaults to the `column` property.
+   */
+  field?: string;
   /**
    * The type of text search query to perform. One of:
    * - `"contains"` (default): the query string may appear anywhere in the text
@@ -93,6 +103,11 @@ export interface Slider {
    * currently selected slider option.
    */
   as?: ParamRef;
+  /**
+   * The database column name to use within generated selection clause
+   * predicates. Defaults to the `column` property.
+   */
+  field?: string;
   /**
    * The type of selection clause predicate to generate if the **as** option
    * is a Selection. If `'point'` (the default), the selection predicate is an


### PR DESCRIPTION
- Add `field` option to inputs (menu, slider, search) to control the column referenced in selection clause predicates.
- Update input documentation and types.

Addresses #406.