### PR TITLE
Add empty selection and Table input support.

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -18,3 +18,4 @@ export {
 export { distinct } from './util/distinct.js';
 export { synchronizer } from './util/synchronizer.js';
 export { throttle } from './util/throttle.js';
+export { toDataColumns } from './util/to-data-columns.js'

--- a/packages/core/src/util/to-data-columns.js
+++ b/packages/core/src/util/to-data-columns.js
@@ -1,4 +1,4 @@
-import { convertArrowColumn, isArrowTable } from '@uwdata/mosaic-core';
+import { convertArrowColumn, isArrowTable } from './convert-arrow.js';
 
 /**
  * @typedef {Array | Int8Array | Uint8Array | Uint8ClampedArray

--- a/packages/inputs/src/Table.js
+++ b/packages/inputs/src/Table.js
@@ -78,7 +78,9 @@ export class Table extends MosaicClient {
 
     if (this.selection) {
       this.body.addEventListener('pointerover', evt => {
+        // @ts-ignore
         if (evt.target?.tagName === 'TD') {
+          // @ts-ignore
           const row = +evt.target.parentElement.__row__;
           if (row !== this.currentRow) {
             this.currentRow = row;
@@ -181,7 +183,7 @@ export class Table extends MosaicClient {
     const cols = schema.map(s => columns[s.column]);
     for (let i = 0; i < numRows; ++i) {
       const tr = document.createElement('tr');
-      tr.__row__ = rowCount + i;
+      Object.assign(tr, { __row__: rowCount + i });
       for (let j = 0; j < nf; ++j) {
         const value = cols[j][i];
         const td = document.createElement('td');

--- a/packages/plot/src/marks/Density1DMark.js
+++ b/packages/plot/src/marks/Density1DMark.js
@@ -1,3 +1,4 @@
+import { toDataColumns } from '@uwdata/mosaic-core';
 import { Query, gt, isBetween, sql, sum } from '@uwdata/mosaic-sql';
 import { Transient } from '../symbols.js';
 import { binExpr } from './util/bin-expr.js';
@@ -6,7 +7,6 @@ import { extentX, extentY, xext, yext } from './util/extent.js';
 import { grid1d } from './util/grid.js';
 import { handleParam } from './util/handle-param.js';
 import { Mark, channelOption, markQuery } from './Mark.js';
-import { toDataColumns } from './util/to-data-columns.js';
 
 export class Density1DMark extends Mark {
   constructor(type, source, options) {

--- a/packages/plot/src/marks/ErrorBarMark.js
+++ b/packages/plot/src/marks/ErrorBarMark.js
@@ -1,8 +1,8 @@
+import { toDataColumns } from '@uwdata/mosaic-core';
 import { avg, count, stddev } from '@uwdata/mosaic-sql';
 import { erfinv } from './util/stats.js';
 import { Mark, markPlotSpec, markQuery } from './Mark.js';
 import { handleParam } from './util/handle-param.js';
-import { toDataColumns } from './util/to-data-columns.js';
 
 export class ErrorBarMark extends Mark {
   constructor(type, source, options) {

--- a/packages/plot/src/marks/Grid2DMark.js
+++ b/packages/plot/src/marks/Grid2DMark.js
@@ -1,4 +1,5 @@
 import { interpolatorBarycentric, interpolateNearest, interpolatorRandomWalk } from '@observablehq/plot';
+import { toDataColumns } from '@uwdata/mosaic-core';
 import { Query, count, isBetween, lt, lte, neq, sql, sum } from '@uwdata/mosaic-sql';
 import { Transient } from '../symbols.js';
 import { binExpr } from './util/bin-expr.js';
@@ -6,7 +7,6 @@ import { dericheConfig, dericheConv2d } from './util/density.js';
 import { extentX, extentY, xyext } from './util/extent.js';
 import { grid2d } from './util/grid.js';
 import { handleParam } from './util/handle-param.js';
-import { toDataColumns } from './util/to-data-columns.js';
 import { Mark } from './Mark.js';
 
 export const DENSITY = 'density';

--- a/packages/plot/src/marks/Mark.js
+++ b/packages/plot/src/marks/Mark.js
@@ -1,9 +1,8 @@
-import { MosaicClient } from '@uwdata/mosaic-core';
+import { MosaicClient, toDataColumns } from '@uwdata/mosaic-core';
 import { Query, Ref, column, isParamLike } from '@uwdata/mosaic-sql';
 import { isColor } from './util/is-color.js';
 import { isConstantOption } from './util/is-constant-option.js';
 import { isSymbol } from './util/is-symbol.js';
-import { toDataColumns } from './util/to-data-columns.js';
 import { Transform } from '../symbols.js';
 
 const isColorChannel = channel => channel === 'stroke' || channel === 'fill';

--- a/packages/plot/src/marks/RegressionMark.js
+++ b/packages/plot/src/marks/RegressionMark.js
@@ -1,4 +1,5 @@
 import { range } from 'd3';
+import { toDataColumns } from '@uwdata/mosaic-core';
 import {
   Query, max, min, castDouble, isNotNull,
   regrIntercept, regrSlope, regrCount,
@@ -7,7 +8,6 @@ import {
 import { qt } from './util/stats.js';
 import { Mark, channelOption } from './Mark.js';
 import { handleParam } from './util/handle-param.js';
-import { toDataColumns } from './util/to-data-columns.js';
 
 export class RegressionMark extends Mark {
   constructor(source, options) {

--- a/packages/spec/src/ast/ParamNode.js
+++ b/packages/spec/src/ast/ParamNode.js
@@ -7,13 +7,13 @@ const paramTypes = new Set([VALUE, SINGLE, CROSSFILTER, INTERSECT, UNION]);
 
 export function parseParam(spec, ctx) {
   const param = isObject(spec) ? spec : { value: spec };
-  const { select = VALUE, cross, date, value } = param;
+  const { select = VALUE, cross, empty, date, value } = param;
   if (!paramTypes.has(select)) {
     ctx.error(`Unrecognized param type: ${select}`, param);
   }
 
   if (select !== VALUE) {
-    return new SelectionNode(select, cross);
+    return new SelectionNode(select, cross, empty);
   } else if (isArray(value)) {
     return new ParamNode(value.map(v => ctx.maybeParam(v)));
   } else {

--- a/packages/spec/src/ast/SelectionNode.js
+++ b/packages/spec/src/ast/SelectionNode.js
@@ -2,25 +2,29 @@ import { ASTNode } from './ASTNode.js';
 import { INTERSECT, SELECTION } from '../constants.js';
 
 export class SelectionNode extends ASTNode {
-  constructor(select = INTERSECT, cross) {
+  constructor(select = INTERSECT, cross, empty) {
     super(SELECTION);
     this.select = select;
     this.cross = cross;
+    this.empty = empty;
   }
 
   instantiate(ctx) {
-    const { select, cross } = this;
-    return ctx.api.Selection[select]({ cross });
+    const { select, cross, empty } = this;
+    return ctx.api.Selection[select]({ cross, empty });
   }
 
   codegen(ctx) {
-    const { select, cross } = this;
-    const arg = cross != null ? `{ cross: ${cross} }` : '';
+    const { select, cross, empty } = this;
+    const args = [['cross', cross], ['empty', empty]]
+      .filter(a => a[1] != null)
+      .map(a => `${a[0]}: ${a[1]}`);
+    const arg = args.length ? `{ ${args.join(', ')} }` : '';
     return `${ctx.ns()}Selection.${select}(${arg})`;
   }
 
   toJSON() {
-    const { select, cross } = this;
-    return { select, cross };
+    const { select, cross, empty } = this;
+    return { select, cross, empty };
   }
 }

--- a/packages/spec/src/spec/Input.ts
+++ b/packages/spec/src/spec/Input.ts
@@ -164,6 +164,11 @@ export interface Table {
    */
   input: 'table';
   /**
+   * The output selection. A selection clause is added for each
+   * currently selected table row.
+   */
+  as?: ParamRef;
+  /**
    * The name of a database table to use as a data source for this widget.
    */
   from: string;

--- a/packages/spec/src/spec/Param.ts
+++ b/packages/spec/src/spec/Param.ts
@@ -58,6 +58,13 @@ export interface Selection {
    * but not oneself (default `false`, except for `crossfilter` selections).
    */
   cross?: boolean;
+
+  /**
+   * A flag for setting an initial empty selection state. If true, a selection
+   * with no clauses corresponds to an empty selection with no records. If
+   * false, a selection with no clauses selects all values.
+   */
+  empty?: boolean;
 }
 
 /** A Param or Selection definition. */


### PR DESCRIPTION
- Add `empty` flag to selections. If true, selections with no clauses will not select any values. If false (the default), selections with no clauses select all data values.
- Add `as` selection option to `Table` input, for clauses corresponding to selected table row values.
- Move the `toDataColumns` utility from `mosaic-plot` to `mosaic-core`. This method maps Apache Arrow data to a set of native JS values.

TODO in future PRs
- [ ] Add toggle (click/shift-click) support for table selections
- [ ] Add support for targeted table selections that involve only a subset of columns
- [ ] Maybe support retrieval of non-visualized table columns (e.g., primary key) for use in selections