### PR TITLE
Reset table offset upon external update.

### DIFF
--- a/packages/inputs/src/Table.js
+++ b/packages/inputs/src/Table.js
@@ -163,6 +163,7 @@ export class Table extends MosaicClient {
       this.loaded = false;
       this.data = [];
       this.body.replaceChildren();
+      this.offset = 0;
     }
     this.data.push(toDataColumns(data));
     return this;


### PR DESCRIPTION
- Fix `table` offset reset upon external updates.

Fixes #363.