### PR TITLE
Add date/time binning support.

### DIFF
--- a/packages/plot/src/transforms/bin-step.js
+++ b/packages/plot/src/transforms/bin-step.js
@@ -1,0 +1,43 @@
+export function binStep(span, steps, minstep = 0, logb = Math.LN10) {
+  let v;
+
+  const level = Math.ceil(Math.log(steps) / logb);
+  let step = Math.max(
+    minstep,
+    Math.pow(10, Math.round(Math.log(span) / logb) - level)
+  );
+
+  // increase step size if too many bins
+  while (Math.ceil(span / step) > steps) { step *= 10; }
+
+  // decrease step size if allowed
+  const div = [5, 2];
+  for (let i = 0, n = div.length; i < n; ++i) {
+    v = step / div[i];
+    if (v >= minstep && span / v <= steps) step = v;
+  }
+
+  return step;
+}
+
+export function bins(min, max, options) {
+  let { step, steps, minstep = 0, nice = true } = options;
+
+  if (nice !== false) {
+    // use span to determine step size
+    const span = max - min;
+    const logb = Math.LN10;
+    step = step || binStep(span, steps || 25, minstep, logb);
+
+    // adjust min/max relative to step
+    let v = Math.log(step);
+    const precision = v >= 0 ? 0 : ~~(-v / logb) + 1;
+    const eps = Math.pow(10, -precision - 1);
+    v = Math.floor(min / step + eps) * step;
+    min = min < v ? v - step : v;
+    max = Math.ceil(max / step) * step;
+    steps = Math.round((max - min) / step);
+  }
+
+  return { min, max, steps };
+}

--- a/packages/plot/src/transforms/bin.js
+++ b/packages/plot/src/transforms/bin.js
@@ -1,13 +1,20 @@
+import { dateBin } from '@uwdata/mosaic-sql';
 import { Transform } from '../symbols.js';
 import { channelScale } from '../marks/util/channel-scale.js';
+import { bins } from './bin-step.js';
+import { timeInterval } from './time-interval.js';
 
 const EXTENT = new Set([
   'rectY-x', 'rectX-y', 'rect-x', 'rect-y', 'ruleY-x', 'ruleX-y'
 ]);
 
-export function bin(field, options = { steps: 25 }) {
+export function hasExtent(mark, channel) {
+  return EXTENT.has(`${mark.type}-${channel}`);
+}
+
+export function bin(field, options = {}) {
   const fn = (mark, channel) => {
-    if (EXTENT.has(`${mark.type}-${channel}`)) {
+    if (hasExtent(mark, channel)) {
       return {
         [`${channel}1`]: binField(mark, channel, field, options),
         [`${channel}2`]: binField(mark, channel, field, { ...options, offset: 1 })
@@ -26,56 +33,39 @@ function binField(mark, channel, column, options) {
   return {
     column,
     label: column,
-    get stats() { return { column, stats: ['min', 'max'] }; },
     get columns() { return [column]; },
     get basis() { return column; },
+    get stats() { return { column, stats: ['min', 'max'] }; },
     toString() {
-      const { apply, sqlApply, sqlInvert } = channelScale(mark, channel);
-      const { min, max } = mark.channelField(channel);
-      const b = bins(apply(min), apply(max), options);
-      const col = sqlApply(column);
-      const base = b.min === 0 ? col : `(${col} - ${b.min})`;
-      const alpha = `${(b.max - b.min) / b.steps}::DOUBLE`;
-      const off = options.offset ? `${options.offset} + ` : '';
-      const expr = `${b.min} + ${alpha} * (${off}FLOOR(${base} / ${alpha}))`;
-      return `${sqlInvert(expr)}`;
+      const { type, min, max } = mark.channelField(channel);
+      const { interval: i, steps, offset = 0 } = options;
+      const interval = i ?? (
+        type === 'date' || hasTimeScale(mark, channel) ? 'date' : 'number'
+      );
+
+      if (interval === 'number') {
+        // perform number binning
+        const { apply, sqlApply, sqlInvert } = channelScale(mark, channel);
+        const b = bins(apply(min), apply(max), options);
+        const col = sqlApply(column);
+        const base = b.min === 0 ? col : `(${col} - ${b.min})`;
+        const alpha = `${(b.max - b.min) / b.steps}::DOUBLE`;
+        const off = offset ? `${offset} + ` : '';
+        const expr = `${b.min} + ${alpha} * (${off}FLOOR(${base} / ${alpha}))`;
+        return `${sqlInvert(expr)}`;
+      } else {
+        // perform date/time binning
+        const { interval: unit, step = 1 } = interval === 'date'
+          ? timeInterval(min, max, steps || 40)
+          : options;
+        const off = offset ? ` + INTERVAL ${offset * step} ${unit}` : '';
+        return `(${dateBin(column, unit, step)}${off})`;
+      }
     }
   };
 }
 
-export function bins(min, max, options) {
-  let { steps = 25, minstep = 0, nice = true } = options;
-
-  if (nice !== false) {
-    // use span to determine step size
-    const span = max - min;
-    const maxb = steps;
-    const logb = Math.LN10;
-    const level = Math.ceil(Math.log(maxb) / logb);
-    let step = Math.max(
-      minstep,
-      Math.pow(10, Math.round(Math.log(span) / logb) - level)
-    );
-
-    // increase step size if too many bins
-    while (Math.ceil(span / step) > maxb) { step *= 10; }
-
-    // decrease step size if allowed
-    const div = [5, 2];
-    let v;
-    for (let i = 0, n = div.length; i < n; ++i) {
-      v = step / div[i];
-      if (v >= minstep && span / v <= maxb) step = v;
-    }
-
-    v = Math.log(step);
-    const precision = v >= 0 ? 0 : ~~(-v / logb) + 1;
-    const eps = Math.pow(10, -precision - 1);
-    v = Math.floor(min / step + eps) * step;
-    min = min < v ? v - step : v;
-    max = Math.ceil(max / step) * step;
-    steps = Math.round((max - min) / step);
-  }
-
-  return { min, max, steps };
+function hasTimeScale(mark, channel) {
+  const scale = mark.plot.getAttribute(`${channel}Scale`);
+  return scale === 'utc' || scale === 'time';
 }

--- a/packages/plot/src/transforms/time-interval.js
+++ b/packages/plot/src/transforms/time-interval.js
@@ -1,0 +1,52 @@
+import { bisector } from 'd3';
+import { binStep } from './bin-step.js';
+
+const YEAR = 'year';
+const MONTH = 'month';
+const DAY = 'day';
+const HOUR = 'hour';
+const MINUTE = 'minute';
+const SECOND = 'second';
+const MILLISECOND = 'millisecond';
+
+const durationSecond = 1000;
+const durationMinute = durationSecond * 60;
+const durationHour = durationMinute * 60;
+const durationDay = durationHour * 24;
+const durationWeek = durationDay * 7;
+const durationMonth = durationDay * 30;
+const durationYear = durationDay * 365;
+
+const intervals = [
+  [SECOND,  1,      durationSecond],
+  [SECOND,  5,  5 * durationSecond],
+  [SECOND, 15, 15 * durationSecond],
+  [SECOND, 30, 30 * durationSecond],
+  [MINUTE,  1,      durationMinute],
+  [MINUTE,  5,  5 * durationMinute],
+  [MINUTE, 15, 15 * durationMinute],
+  [MINUTE, 30, 30 * durationMinute],
+  [  HOUR,  1,      durationHour  ],
+  [  HOUR,  3,  3 * durationHour  ],
+  [  HOUR,  6,  6 * durationHour  ],
+  [  HOUR, 12, 12 * durationHour  ],
+  [   DAY,  1,      durationDay   ],
+  [   DAY,  7,      durationWeek  ],
+  [ MONTH,  1,      durationMonth ],
+  [ MONTH,  3,  3 * durationMonth ],
+  [  YEAR,  1,      durationYear  ]
+];
+
+export function timeInterval(min, max, steps) {
+  const span = max - min;
+  const target = span / steps;
+  let i = bisector(i => i[2]).right(intervals, target);
+  if (i === intervals.length) {
+    return { interval: YEAR, step: binStep(span, steps) };
+  } else if (i) {
+    i = intervals[target / intervals[i - 1][2] < intervals[i][2] / target ? i - 1 : i];
+    return { interval: i[0], step: i[1] };
+  } else {
+    return { interval: MILLISECOND, step: binStep(span, steps, 1) };
+  }
+}

--- a/packages/plot/src/transforms/time-interval.js
+++ b/packages/plot/src/transforms/time-interval.js
@@ -17,6 +17,7 @@ const durationWeek = durationDay * 7;
 const durationMonth = durationDay * 30;
 const durationYear = durationDay * 365;
 
+/** @type {[string, number, number][]} */
 const intervals = [
   [SECOND,  1,      durationSecond],
   [SECOND,  5,  5 * durationSecond],

--- a/packages/spec/src/spec/Transform.ts
+++ b/packages/spec/src/spec/Transform.ts
@@ -41,20 +41,58 @@ type Arg2Opt = Arg | [Arg, Arg?];
  */
 type Arg3Opt = Arg | [Arg, Arg?, Arg?];
 
-/** Bin transform options. */
-export interface BinOptions {
+/** Binning interval names. */
+export type BinInterval =
+  | 'date'
+  | 'number'
+  | 'millisecond'
+  | 'second'
+  | 'minute'
+  | 'hour'
+  | 'day'
+  | 'month'
+  | 'year';
+
+/* A bin transform. */
+export interface Bin {
+  /**
+   * Bin a continuous variable into discrete intervals. The bin argument
+   * specifies a data column or expression to bin. Both numerical and
+   * temporal (date/time) values are supported.
+   */
+  bin: Arg | [Arg];
+  /**
+   * The interval bin unit to use, typically used to indicate a date/time
+   * unit for binning temporal values, such as `hour`, `day`, or `month`.
+   * If `date`, the extent of data values is used to automatically select
+   * an interval for temporal data. The value `number` enforces normal
+   * numerical binning, even over temporal data. If unspecified, defaults
+   * to `number` for numerical data and `date` for temporal data.
+   */
+  interval?: BinInterval;
+  /**
+   * The step size to use between bins. When binning numerical values (or
+   * interval type `number`), this setting specifies the numerical step size.
+   * For data/time intervals, this indicates the number of steps of that unit,
+   * such as hours, days, or years.
+   */
+  step?: number;
   /**
    * The target number of binning steps to use. To accommodate human-friendly
-   * bin boundaries, the actual number of bins may diverge from this exact number.
+   * ("nice") bin boundaries, the actual number of bins may diverge from this
+   * exact value. This option is ignored when **step** is specified.
    */
   steps?: number;
   /**
-   * The minimum allowed bin step size (default `0`).
-   * For example, a setting of `1` will prevent step sizes less than 1.
+   * The minimum allowed bin step size (default `0`) when performing numerical
+   * binning. For example, a setting of `1` prevents step sizes less than 1.
+   * This option is ignored when **step** is specified.
    */
   minstep?: number;
   /**
-   * A flag requesting "nice" human-friendly step sizes (default `true`).
+   * A flag (default `true`) requesting "nice" human-friendly end points and
+   * step sizes when performing numerical binning. When **step** is specified,
+   * this option affects the binning end points (e.g., origin) only.
    */
   nice?: true;
   /**
@@ -62,15 +100,6 @@ export interface BinOptions {
    * result in using the next consecutive bin boundary.
    */
   offset?: number;
-}
-
-/* A bin transform. */
-export interface Bin {
-  /**
-   * Bin a continuous variable into discrete intervals. This transform accepts
-   * a data column to bin over as well as an optional bin options object.
-   */
-  bin: Arg | [Arg] | [Arg, BinOptions];
 }
 
 /* A dateMonth transform. */

--- a/packages/sql/src/datetime.js
+++ b/packages/sql/src/datetime.js
@@ -5,6 +5,13 @@ export const epoch_ms = expr => {
   return sql`epoch_ms(${asColumn(expr)})`;
 };
 
+export function dateBin(expr, interval, steps = 1) {
+  const i = `INTERVAL ${steps} ${interval}`;
+  const d = asColumn(expr);
+  return sql`TIME_BUCKET(${i}, ${d})`
+    .annotate({ label: interval });
+}
+
 export const dateMonth = expr => {
   const d = asColumn(expr);
   return sql`MAKE_DATE(2012, MONTH(${d}), 1)`

--- a/packages/sql/src/index.js
+++ b/packages/sql/src/index.js
@@ -88,6 +88,7 @@ export {
 
 export {
   epoch_ms,
+  dateBin,
   dateMonth,
   dateMonthDay,
   dateDay


### PR DESCRIPTION
- **Breaking**: Update declarative spec for `bin` transform to support top-level option properties, remove options object as second argument.
- Add date interval support to `bin` transform. A new `interval` option specifies a desired date/time unit (`hour`, `day`, `month`, etc) or forces standard numerical binning (`number`). If not specified, a reasonable date/time interval and step size will be determined automatically for temporal data.
- Add `dateBin` SQL helper method.

Close #427.
