### PR TITLE
chore: enable `uv` via `installer` key

### DIFF
--- a/packages/duckdb-server/pyproject.toml
+++ b/packages/duckdb-server/pyproject.toml
@@ -31,13 +31,13 @@ dev = [
 [tool.hatch.envs.default]
 python = "3.11"
 features = ["dev"]
-uv = true
+installer = "uv"
 
 [tool.hatch.envs.default.scripts]
 serve = "watchmedo auto-restart --pattern '*.py' --recursive --signal SIGTERM python pkg/__main__.py"
 
 [tool.hatch.envs.test]
-uv = true
+installer = "uv"
 dependencies = [
   "coverage[toml]",
   "pytest",

--- a/packages/widget/pyproject.toml
+++ b/packages/widget/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
 [tool.hatch.envs.default]
 python = "3.11"
 features = ["dev"]
-uv = true
+installer = "uv"
 
 [tool.hatch.version]
 path = "package.json"


### PR DESCRIPTION
As I took a more thorough look at this project, inspecting how `hatch` is being used in a monorepo setting, I noticed that the creation of the Python virtual environments take longer than I would have expected, given that `uv` is supposed to be used.
Running `hatch env create` with `export HATCH_VERBOSE=1` confirmed that plain `pip` was used instead of `uv` for dependency installation.

Based on the latest docs (https://hatch.pypa.io/dev/how-to/environment/select-installer/#enabling-uv), `uv` needs to be enabled via `installer = "uv"` instead of `uv = true`. This PR adds the necessary changes.