### PR TITLE
Add selection relays to publish clauses to multiple selections.

### DIFF
--- a/docs/examples/athletes.md
+++ b/docs/examples/athletes.md
@@ -5,7 +5,7 @@
 
 # Olympic Athletes
 
-An interactive dashboard of athlete statistics. The input menus and searchbox filter the display and are automatically populated by backing data columns.
+An interactive dashboard of athlete statistics. The menus and searchbox filter the display and are automatically populated by backing data columns.
 
 <Example spec="/specs/yaml/athletes.yaml" />
 

--- a/docs/public/specs/esm/athletes.js
+++ b/docs/public/specs/esm/athletes.js
@@ -4,15 +4,20 @@ await vg.coordinator().exec([
   vg.loadParquet("athletes", "data/athletes.parquet")
 ]);
 
+const $category = vg.Selection.intersect();
 const $query = vg.Selection.intersect();
+const $hover = vg.Selection.intersect({empty: true});
+
+$category.relay($query);
 
 export default vg.hconcat(
   vg.vconcat(
     vg.hconcat(
-      vg.menu({label: "Sport", as: $query, from: "athletes", column: "sport"}),
-      vg.menu({label: "Sex", as: $query, from: "athletes", column: "sex"}),
+      vg.menu({label: "Sport", as: $category, from: "athletes", column: "sport"}),
+      vg.menu({label: "Sex", as: $category, from: "athletes", column: "sex"}),
       vg.search({
         label: "Name",
+        filterBy: $category,
         as: $query,
         from: "athletes",
         column: "name",
@@ -30,6 +35,17 @@ export default vg.hconcat(
         {x: "weight", y: "height", stroke: "sex"}
       ),
       vg.intervalXY({as: $query, brush: {fillOpacity: 0, stroke: "black"}}),
+      vg.dot(
+        vg.from("athletes", {filterBy: $hover}),
+        {
+          x: "weight",
+          y: "height",
+          fill: "sex",
+          stroke: "currentColor",
+          strokeWidth: 1,
+          r: 3
+        }
+      ),
       vg.xyDomain(vg.Fixed),
       vg.colorDomain(vg.Fixed),
       vg.margins({left: 35, top: 20, right: 1}),
@@ -42,6 +58,7 @@ export default vg.hconcat(
       maxWidth: 570,
       height: 250,
       filterBy: $query,
+      as: $hover,
       columns: ["name", "nationality", "sex", "height", "weight", "sport"],
       width: {name: 180, nationality: 100, sex: 50, height: 50, weight: 50, sport: 100}
     })

--- a/docs/public/specs/json/athletes.json
+++ b/docs/public/specs/json/athletes.json
@@ -1,12 +1,27 @@
 {
   "meta": {
     "title": "Olympic Athletes",
-    "description": "An interactive dashboard of athlete statistics. The input menus and searchbox filter the display and are automatically populated by backing data columns.\n"
+    "description": "An interactive dashboard of athlete statistics. The menus and searchbox filter the display and are automatically populated by backing data columns.\n"
   },
   "data": {
     "athletes": {
       "file": "data/athletes.parquet"
     }
+  },
+  "params": {
+    "category": {
+      "select": "intersect"
+    },
+    "query": {
+      "select": "intersect"
+    },
+    "hover": {
+      "select": "intersect",
+      "empty": true
+    }
+  },
+  "relay": {
+    "category": "$query"
   },
   "hconcat": [
     {
@@ -16,20 +31,21 @@
             {
               "input": "menu",
               "label": "Sport",
-              "as": "$query",
+              "as": "$category",
               "from": "athletes",
               "column": "sport"
             },
             {
               "input": "menu",
               "label": "Sex",
-              "as": "$query",
+              "as": "$category",
               "from": "athletes",
               "column": "sex"
             },
             {
               "input": "search",
               "label": "Name",
+              "filterBy": "$category",
               "as": "$query",
               "from": "athletes",
               "column": "name",
@@ -71,6 +87,19 @@
                 "fillOpacity": 0,
                 "stroke": "black"
               }
+            },
+            {
+              "mark": "dot",
+              "data": {
+                "from": "athletes",
+                "filterBy": "$hover"
+              },
+              "x": "weight",
+              "y": "height",
+              "fill": "sex",
+              "stroke": "currentColor",
+              "strokeWidth": 1,
+              "r": 3
             }
           ],
           "xyDomain": "Fixed",
@@ -92,6 +121,7 @@
           "maxWidth": 570,
           "height": 250,
           "filterBy": "$query",
+          "as": "$hover",
           "columns": [
             "name",
             "nationality",

--- a/docs/public/specs/yaml/athletes.yaml
+++ b/docs/public/specs/yaml/athletes.yaml
@@ -1,25 +1,32 @@
 meta:
   title: Olympic Athletes
   description: >
-    An interactive dashboard of athlete statistics.
-    The input menus and searchbox filter the display and are automatically populated by backing data columns.
+    An interactive dashboard of athlete statistics. The menus and searchbox
+    filter the display and are automatically populated by backing data columns.
 data:
   athletes: { file: data/athletes.parquet }
+params:
+  category: { select: intersect }
+  query: { select: intersect }
+  hover: { select: intersect, empty: true } # select nothing when empty
+relay:
+  category: $query # relay clauses from category selection to query selection
 hconcat:
 - vconcat:
   - hconcat:
     - input: menu
       label: Sport
-      as: $query
+      as: $category
       from: athletes
       column: sport
     - input: menu
       label: Sex
-      as: $query
+      as: $category
       from: athletes
       column: sex
     - input: search
       label: Name
+      filterBy: $category
       as: $query
       from: athletes
       column: name
@@ -41,6 +48,14 @@ hconcat:
     - select: intervalXY
       as: $query
       brush: { fillOpacity: 0, stroke: black }
+    - mark: dot
+      data: { from: athletes, filterBy: $hover }
+      x: weight
+      y: height
+      fill: sex
+      stroke: currentColor
+      strokeWidth: 1
+      r: 3
     xyDomain: Fixed
     colorDomain: Fixed
     margins: { left: 35, top: 20, right: 1 }
@@ -52,5 +67,6 @@ hconcat:
     maxWidth: 570
     height: 250
     filterBy: $query
+    as: $hover
     columns: [name, nationality, sex, height, weight, sport]
     width: { name: 180, nationality: 100, sex: 50, height: 50, weight: 50, sport: 100 }

--- a/packages/core/src/Selection.js
+++ b/packages/core/src/Selection.js
@@ -85,6 +85,18 @@ export class Selection extends Param {
     super([]);
     this._resolved = this._value;
     this._resolver = resolver;
+    /** @type {Selection[]} */
+    this._relay = [];
+  }
+
+  /**
+   * Downstream selections to relay clauses to. Any clauses published to
+   * this selection are published (relayed) in turn to these selections.
+   * @param {...(Selection|Selection[])} selections
+   */
+  relay(...selections) {
+    this._relay = selections.flat();
+    return this;
   }
 
   /**
@@ -161,6 +173,7 @@ export class Selection extends Param {
    */
   activate(clause) {
     this.emit('activate', clause);
+    this._relay.forEach(sel => sel.activate(clause));
   }
 
   /**
@@ -173,6 +186,7 @@ export class Selection extends Param {
     // this ensures consistent clause state across unemitted event values
     this._resolved = this._resolver.resolve(this._resolved, clause, true);
     this._resolved.active = clause;
+    this._relay.forEach(sel => sel.update(clause));
     return super.update(this._resolved);
   }
 

--- a/packages/spec/src/ast-to-dom.js
+++ b/packages/spec/src/ast-to-dom.js
@@ -18,7 +18,7 @@ import { error } from './util.js';
  *  DOM element, and a map of named parameters (Param and Selection instances).
  */
 export async function astToDOM(ast, options) {
-  const { data, params, plotDefaults } = ast;
+  const { data, params, relay, plotDefaults } = ast;
   const ctx = new InstantiateContext({ plotDefaults, ...options });
 
   const queries = [];
@@ -45,6 +45,10 @@ export async function astToDOM(ast, options) {
       const param = node.instantiate(ctx);
       ctx.activeParams.set(name, param);
     }
+  }
+
+  if (relay) {
+    relay.instantiate(ctx);
   }
 
   return {

--- a/packages/spec/src/ast-to-esm.js
+++ b/packages/spec/src/ast-to-esm.js
@@ -19,7 +19,7 @@ import { error, isArray, isObject, isString, toArray, toParamRef } from './util.
  * @returns {string} Generated ESM code using the vgplot API.
  */
 export function astToESM(ast, options = {}) {
-  const { root, data, params, plotDefaults } = ast;
+  const { root, data, params, relay, plotDefaults } = ast;
   const { preamble, ...ctxOptions } = options;
   const ctx = new CodegenContext({ plotDefaults, ...ctxOptions });
 
@@ -74,6 +74,10 @@ export function astToESM(ast, options = {}) {
     paramCode.push(`const ${toParamRef(key)} = ${value.codegen(ctx)};`);
   }
 
+  // generate selection relays
+  const relayCode = [];
+  if (relay) relayCode.push(relay.codegen(ctx));
+
   // generate default attributes
   let defaultCode = [];
   const defaultList = plotDefaults;
@@ -101,6 +105,8 @@ export function astToESM(ast, options = {}) {
     ...maybeNewline(dataCode),
     ...paramCode,
     ...maybeNewline(paramCode),
+    ...relayCode,
+    ...maybeNewline(relayCode),
     ...defaultCode,
     ...maybeNewline(defaultCode),
     ...specCode

--- a/packages/spec/src/ast/ParamNode.js
+++ b/packages/spec/src/ast/ParamNode.js
@@ -1,19 +1,18 @@
 import { isArray, isObject, isoparse } from '../util.js';
 import { ASTNode } from './ASTNode.js';
+import { parseSelection } from './SelectionNode.js';
 import { CROSSFILTER, INTERSECT, PARAM, SINGLE, UNION, VALUE } from '../constants.js';
-import { SelectionNode } from './SelectionNode.js';
 
 const paramTypes = new Set([VALUE, SINGLE, CROSSFILTER, INTERSECT, UNION]);
 
 export function parseParam(spec, ctx) {
   const param = isObject(spec) ? spec : { value: spec };
-  const { select = VALUE, cross, empty, date, value } = param;
+  const { select = VALUE, value, date } = param;
   if (!paramTypes.has(select)) {
     ctx.error(`Unrecognized param type: ${select}`, param);
   }
-
   if (select !== VALUE) {
-    return new SelectionNode(select, cross, empty);
+    return parseSelection(spec, ctx);
   } else if (isArray(value)) {
     return new ParamNode(value.map(v => ctx.maybeParam(v)));
   } else {

--- a/packages/spec/src/ast/ParamRefNode.js
+++ b/packages/spec/src/ast/ParamRefNode.js
@@ -12,7 +12,7 @@ export class ParamRefNode extends ASTNode {
     return ctx.activeParams?.get(this.name);
   }
 
-  codegen() {
+  codegen(ctx) { // eslint-disable-line no-unused-vars
     return toParamRef(this.name);
   }
 

--- a/packages/spec/src/ast/RelayNode.js
+++ b/packages/spec/src/ast/RelayNode.js
@@ -1,0 +1,52 @@
+import { paramRef, toArray } from '../util.js';
+import { ASTNode } from './ASTNode.js';
+import { RELAY } from '../constants.js';
+
+function selectionRef(name, ctx) {
+  return ctx.selectionRef(name, true) ?? ctx.error(
+    `Parameter "${name}" is not a selection and can not be in a relay.`
+  );
+}
+
+export function parseRelay(spec, ctx) {
+  return spec && new RelayNode(new Map(
+    Object.entries(spec).map(([name, refs]) => {
+      return [
+        selectionRef(name, ctx),
+        toArray(refs).map(name => selectionRef(paramRef(name), ctx))
+      ];
+    })
+  ));
+}
+
+export class RelayNode extends ASTNode {
+  constructor(relays) {
+    super(RELAY);
+    this.relays = relays;
+  }
+
+  instantiate(ctx) {
+    for (const [src, refs] of this.relays) {
+      const sel = src.instantiate(ctx);
+      const to = refs.map(ref => ref.instantiate(ctx));
+      sel.relay(to);
+    }
+  }
+
+  codegen(ctx) {
+    return Array.from(this.relays, ([src, refs]) => {
+      const sel = src.codegen(ctx);
+      const to = refs.map(ref => ref.codegen(ctx));
+      const arg = to.length > 1 ? `[${to.join(', ')}]` : to[0];
+      return `${ctx.tab()}${sel}.relay(${arg});`
+    }).join('\n');
+  }
+
+  toJSON() {
+    const json = {};
+    for (const [src, refs] of this.relays) {
+      json[src.name] = refs.map(ref => ref.toJSON());
+    }
+    return json;
+  }
+}

--- a/packages/spec/src/ast/SpecNode.js
+++ b/packages/spec/src/ast/SpecNode.js
@@ -2,18 +2,19 @@ import { SPEC } from '../constants.js';
 import { ASTNode } from './ASTNode.js';
 
 export class SpecNode extends ASTNode {
-  constructor(root, meta, config, data, params, plotDefaults) {
+  constructor(root, meta, config, data, params, relay, plotDefaults) {
     super(SPEC, [root]);
     this.root = root;
     this.meta = meta;
     this.config = config;
     this.data = data;
     this.params = params;
+    this.relay = relay;
     this.plotDefaults = plotDefaults;
   }
 
   toJSON() {
-    const { root, meta, config, plotDefaults } = this;
+    const { root, meta, config, relay, plotDefaults } = this;
     const dataDefs = new Map(Object.entries(this.data));
     const paramDefs = new Map(Object.entries(this.params));
     const spec = {};
@@ -34,6 +35,8 @@ export class SpecNode extends ASTNode {
         params[name] = node.toJSON();
       }
     }
+
+    if (relay) spec.relay = relay.toJSON();
 
     if (plotDefaults?.length) {
       const defaults = spec.plotDefaults = {};

--- a/packages/spec/src/constants.js
+++ b/packages/spec/src/constants.js
@@ -14,6 +14,7 @@ export const OPTIONS = 'options';
 export const SELECTION = 'selection';
 export const PARAMREF = 'paramref';
 export const PARAM = 'param';
+export const RELAY = 'relay';
 
 // param and selection types
 export const SELECT = 'select';

--- a/packages/spec/src/spec/Spec.ts
+++ b/packages/spec/src/spec/Spec.ts
@@ -1,5 +1,5 @@
 import { DataDefinition } from './Data.js';
-import { ParamDefinition } from './Param.js';
+import { ParamDefinition, ParamRef } from './Param.js';
 import { HConcat } from './HConcat.js';
 import { VConcat } from './VConcat.js';
 import { HSpace } from './HSpace.js';
@@ -31,6 +31,9 @@ export type Data = Record<string, DataDefinition>;
 /** Top-level Param and Selection definitions. */
 export type Params = Record<string, ParamDefinition>;
 
+/** Top-level Selection relay definitions. */
+export type Relay = Record<string, ParamRef | ParamRef[]>;
+
 /** Top-level specification properties. */
 export interface SpecHead {
   /**
@@ -48,6 +51,8 @@ export interface SpecHead {
   data?: Data;
   /** Param and Selection definitions. */
   params?: Params;
+  /** Selection relay definitions. */
+  relay?: Relay;
   /** A default set of attributes to apply to all plot components. */
   plotDefaults?: PlotAttributes;
 }

--- a/specs/esm/athletes.js
+++ b/specs/esm/athletes.js
@@ -4,15 +4,20 @@ await vg.coordinator().exec([
   vg.loadParquet("athletes", "data/athletes.parquet")
 ]);
 
+const $category = vg.Selection.intersect();
 const $query = vg.Selection.intersect();
+const $hover = vg.Selection.intersect({empty: true});
+
+$category.relay($query);
 
 export default vg.hconcat(
   vg.vconcat(
     vg.hconcat(
-      vg.menu({label: "Sport", as: $query, from: "athletes", column: "sport"}),
-      vg.menu({label: "Sex", as: $query, from: "athletes", column: "sex"}),
+      vg.menu({label: "Sport", as: $category, from: "athletes", column: "sport"}),
+      vg.menu({label: "Sex", as: $category, from: "athletes", column: "sex"}),
       vg.search({
         label: "Name",
+        filterBy: $category,
         as: $query,
         from: "athletes",
         column: "name",
@@ -30,6 +35,17 @@ export default vg.hconcat(
         {x: "weight", y: "height", stroke: "sex"}
       ),
       vg.intervalXY({as: $query, brush: {fillOpacity: 0, stroke: "black"}}),
+      vg.dot(
+        vg.from("athletes", {filterBy: $hover}),
+        {
+          x: "weight",
+          y: "height",
+          fill: "sex",
+          stroke: "currentColor",
+          strokeWidth: 1,
+          r: 3
+        }
+      ),
       vg.xyDomain(vg.Fixed),
       vg.colorDomain(vg.Fixed),
       vg.margins({left: 35, top: 20, right: 1}),
@@ -42,6 +58,7 @@ export default vg.hconcat(
       maxWidth: 570,
       height: 250,
       filterBy: $query,
+      as: $hover,
       columns: ["name", "nationality", "sex", "height", "weight", "sport"],
       width: {name: 180, nationality: 100, sex: 50, height: 50, weight: 50, sport: 100}
     })

--- a/specs/json/athletes.json
+++ b/specs/json/athletes.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "Olympic Athletes",
-    "description": "An interactive dashboard of athlete statistics. The input menus and searchbox filter the display and are automatically populated by backing data columns.\n"
+    "description": "An interactive dashboard of athlete statistics. The menus and searchbox filter the display and are automatically populated by backing data columns.\n"
   },
   "data": {
     "athletes": {
@@ -10,9 +10,21 @@
     }
   },
   "params": {
+    "category": {
+      "select": "intersect"
+    },
     "query": {
       "select": "intersect"
+    },
+    "hover": {
+      "select": "intersect",
+      "empty": true
     }
+  },
+  "relay": {
+    "category": [
+      "$query"
+    ]
   },
   "hconcat": [
     {
@@ -22,20 +34,21 @@
             {
               "input": "menu",
               "label": "Sport",
-              "as": "$query",
+              "as": "$category",
               "from": "athletes",
               "column": "sport"
             },
             {
               "input": "menu",
               "label": "Sex",
-              "as": "$query",
+              "as": "$category",
               "from": "athletes",
               "column": "sex"
             },
             {
               "input": "search",
               "label": "Name",
+              "filterBy": "$category",
               "as": "$query",
               "from": "athletes",
               "column": "name",
@@ -77,6 +90,19 @@
                 "fillOpacity": 0,
                 "stroke": "black"
               }
+            },
+            {
+              "mark": "dot",
+              "data": {
+                "from": "athletes",
+                "filterBy": "$hover"
+              },
+              "x": "weight",
+              "y": "height",
+              "fill": "sex",
+              "stroke": "currentColor",
+              "strokeWidth": 1,
+              "r": 3
             }
           ],
           "xyDomain": "Fixed",
@@ -98,6 +124,7 @@
           "maxWidth": 570,
           "height": 250,
           "filterBy": "$query",
+          "as": "$hover",
           "columns": [
             "name",
             "nationality",

--- a/specs/ts/athletes.ts
+++ b/specs/ts/athletes.ts
@@ -3,12 +3,27 @@ import { Spec } from '@uwdata/mosaic-spec';
 export const spec : Spec = {
   "meta": {
     "title": "Olympic Athletes",
-    "description": "An interactive dashboard of athlete statistics. The input menus and searchbox filter the display and are automatically populated by backing data columns.\n"
+    "description": "An interactive dashboard of athlete statistics. The menus and searchbox filter the display and are automatically populated by backing data columns.\n"
   },
   "data": {
     "athletes": {
       "file": "data/athletes.parquet"
     }
+  },
+  "params": {
+    "category": {
+      "select": "intersect"
+    },
+    "query": {
+      "select": "intersect"
+    },
+    "hover": {
+      "select": "intersect",
+      "empty": true
+    }
+  },
+  "relay": {
+    "category": "$query"
   },
   "hconcat": [
     {
@@ -18,20 +33,21 @@ export const spec : Spec = {
             {
               "input": "menu",
               "label": "Sport",
-              "as": "$query",
+              "as": "$category",
               "from": "athletes",
               "column": "sport"
             },
             {
               "input": "menu",
               "label": "Sex",
-              "as": "$query",
+              "as": "$category",
               "from": "athletes",
               "column": "sex"
             },
             {
               "input": "search",
               "label": "Name",
+              "filterBy": "$category",
               "as": "$query",
               "from": "athletes",
               "column": "name",
@@ -73,6 +89,19 @@ export const spec : Spec = {
                 "fillOpacity": 0,
                 "stroke": "black"
               }
+            },
+            {
+              "mark": "dot",
+              "data": {
+                "from": "athletes",
+                "filterBy": "$hover"
+              },
+              "x": "weight",
+              "y": "height",
+              "fill": "sex",
+              "stroke": "currentColor",
+              "strokeWidth": 1,
+              "r": 3
             }
           ],
           "xyDomain": "Fixed",
@@ -94,6 +123,7 @@ export const spec : Spec = {
           "maxWidth": 570,
           "height": 250,
           "filterBy": "$query",
+          "as": "$hover",
           "columns": [
             "name",
             "nationality",

--- a/specs/yaml/athletes.yaml
+++ b/specs/yaml/athletes.yaml
@@ -1,25 +1,32 @@
 meta:
   title: Olympic Athletes
   description: >
-    An interactive dashboard of athlete statistics.
-    The input menus and searchbox filter the display and are automatically populated by backing data columns.
+    An interactive dashboard of athlete statistics. The menus and searchbox
+    filter the display and are automatically populated by backing data columns.
 data:
   athletes: { file: data/athletes.parquet }
+params:
+  category: { select: intersect }
+  query: { select: intersect }
+  hover: { select: intersect, empty: true } # select nothing when empty
+relay:
+  category: $query # relay clauses from category selection to query selection
 hconcat:
 - vconcat:
   - hconcat:
     - input: menu
       label: Sport
-      as: $query
+      as: $category
       from: athletes
       column: sport
     - input: menu
       label: Sex
-      as: $query
+      as: $category
       from: athletes
       column: sex
     - input: search
       label: Name
+      filterBy: $category
       as: $query
       from: athletes
       column: name
@@ -41,6 +48,14 @@ hconcat:
     - select: intervalXY
       as: $query
       brush: { fillOpacity: 0, stroke: black }
+    - mark: dot
+      data: { from: athletes, filterBy: $hover }
+      x: weight
+      y: height
+      fill: sex
+      stroke: currentColor
+      strokeWidth: 1
+      r: 3
     xyDomain: Fixed
     colorDomain: Fixed
     margins: { left: 35, top: 20, right: 1 }
@@ -52,5 +67,6 @@ hconcat:
     maxWidth: 570
     height: 250
     filterBy: $query
+    as: $hover
     columns: [name, nationality, sex, height, weight, sport]
     width: { name: 180, nationality: 100, sex: 50, height: 50, weight: 50, sport: 100 }


### PR DESCRIPTION
- Add `Selection.relay(...)` method to let a selection publish (relay) clauses to downstream selections.
- Add `relay` property to top-level of declarative specifications.
- Update `athletes` example to filter athlete auto-complete, use relays, and highlight hovered table row.

This relay mechanism allows a single interactor / clause source to populate more than one downstream selection, while still ensuring a "primary" selection is provided as the interactor's output (e.g., for two-way value binding). Close #246.

### Relay Syntax

The `relay` syntax in JavaScript takes one or more target selections (or arrays thereof) as arguments:

```js
sourceSelection.relay(targetSelection1, targetSelection2, ...)
```

The `relay` syntax in a declarative spec uses the source selection name as a key (mirroring `params` definitions) and one or more target selection references (with `$` prefix, mirroring other param references in a spec):

```yaml
relay:
  sourceSelection: [$targetSelection1, $targetSelection2]
```

### Other Options to Consider

The syntax added in this PR separates selection definition from relay network specification. An alternative approach could be to include relay specification as part of selection definition within declarative specs. For example, if defined relative to the source selection:

```yaml
params:
  sourceSelection: { select: intersect, relay: [$targetSelection1, $targetSelection2] }
```

This has the advantage of keeping selection specification more consolidated, but also has the perhaps unintuitive requirement that logically prior "source" selection definitions must reference downstream selections as part of their definition.

A flipped approach would be for target selections to instead specify source selections, like so:

```yaml
params:
  targetSelection: { select: intersect, includes: $sourceSelection }
```

This feels cleaner to me, but also cuts against the grain of the underlying JS implementation, in which targets are registered with sources. If we ultimately prefer this target->source style of specification, we could update the external JS  API to use a consistent style.

Comments / opinions welcomed!