### PR TITLE
Refactor clause generator methods.

### DIFF
--- a/packages/core/src/SelectionClause.js
+++ b/packages/core/src/SelectionClause.js
@@ -24,7 +24,7 @@ import { MosaicClient } from './MosaicClient.js';
  *  cross-filtering contexts.
  * @returns {SelectionClause} The generated selection clause.
  */
-export function point(field, value, {
+export function clausePoint(field, value, {
   source,
   clients = source ? new Set([source]) : undefined
 }) {
@@ -53,7 +53,7 @@ export function point(field, value, {
  *  cross-filtering contexts.
  * @returns {SelectionClause} The generated selection clause.
  */
-export function points(fields, value, {
+export function clausePoints(fields, value, {
   source,
   clients = source ? new Set([source]) : undefined
 }) {
@@ -89,7 +89,7 @@ export function points(fields, value, {
  * @param {number} [options.pixelSize=1] The interactive pixel size.
  * @returns {SelectionClause} The generated selection clause.
  */
-export function interval(field, value, {
+export function clauseInterval(field, value, {
   source,
   clients = source ? new Set([source]) : undefined,
   bin,
@@ -118,7 +118,7 @@ export function interval(field, value, {
  * @param {number} [options.pixelSize=1] The interactive pixel size.
  * @returns {SelectionClause} The generated selection clause.
  */
-export function intervals(fields, value, {
+export function clauseIntervals(fields, value, {
   source,
   clients = source ? new Set([source]) : undefined,
   bin,
@@ -149,7 +149,7 @@ const MATCH_METHODS = { contains, prefix, suffix, regexp: regexp_matches };
  *  text matching method to use. Defaults to `'contains'`.
  * @returns {SelectionClause} The generated selection clause.
  */
-export function match(field, value, {
+export function clauseMatch(field, value, {
   source, clients = undefined, method = 'contains'
 }) {
   let fn = MATCH_METHODS[method];

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -3,11 +3,18 @@ export { Coordinator, coordinator } from './Coordinator.js';
 export { Selection, isSelection } from './Selection.js';
 export { Param, isParam } from './Param.js';
 export { Priority } from './QueryManager.js';
-export { point, points, interval, intervals, match } from './SelectionClause.js';
 
 export { restConnector } from './connectors/rest.js';
 export { socketConnector } from './connectors/socket.js';
 export { wasmConnector } from './connectors/wasm.js';
+
+export {
+  clauseInterval,
+  clauseIntervals,
+  clausePoint,
+  clausePoints,
+  clauseMatch
+} from './SelectionClause.js';
 
 export {
   isArrowTable,
@@ -15,6 +22,7 @@ export {
   convertArrowValue,
   convertArrowColumn
 } from './util/convert-arrow.js'
+
 export { distinct } from './util/distinct.js';
 export { synchronizer } from './util/synchronizer.js';
 export { throttle } from './util/throttle.js';

--- a/packages/core/src/util/AsyncDispatch.js
+++ b/packages/core/src/util/AsyncDispatch.js
@@ -1,8 +1,7 @@
 /**
- * Event dispatcher supporting asynchronous updates.
- * If an event handler callback returns a Promise, this dispatcher will
- * wait for all such Promises to settle before dispatching future events
- * of the same type.
+ * Event dispatcher supporting asynchronous updates. If an event handler
+ * callback returns a Promise, the dispatcher waits for all such Promises
+ * to settle before dispatching future events of the same type.
  */
 export class AsyncDispatch {
 
@@ -63,7 +62,7 @@ export class AsyncDispatch {
    * queue of unemitted event values prior to enqueueing a new value.
    * This default implementation simply returns null, indicating that
    * any other unemitted event values should be dropped (that is, all
-   * queued events are filtered)
+   * queued events are filtered).
    * @param {string} type The event type.
    * @param {*} value The new event value that will be enqueued.
    * @returns {(value: *) => boolean|null} A dispatch queue filter
@@ -81,6 +80,17 @@ export class AsyncDispatch {
   cancel(type) {
     const entry = this._callbacks.get(type);
     entry?.queue.clear();
+  }
+
+  /**
+   * Returns a promise that resolves when any pending updates complete for
+   * the event of the given type currently being processed. The Promise will
+   * resolve immediately if the queue for the given event type is empty.
+   * @param {string} type The event type to wait for.
+   * @returns {Promise} A pending event promise.
+   */
+  async pending(type) {
+    await this._callbacks.get(type)?.pending;
   }
 
   /**

--- a/packages/core/test/client-test.js
+++ b/packages/core/test/client-test.js
@@ -1,0 +1,127 @@
+import assert from 'node:assert';
+import { Query, count } from '@uwdata/mosaic-sql';
+import { nodeConnector } from './util/node-connector.js';
+import { Coordinator, MosaicClient, Selection, clauseInterval } from '../src/index.js';
+import { QueryResult } from '../src/util/query-result.js';
+
+describe('MosaicClient', () => {
+  it('is filtered by selections', async () => {
+    // instantiate coordinator to use node.js DuckDB
+    // disable logging and data cube indexes
+    const coord = new Coordinator(nodeConnector(), {
+      logger: null,
+      indexes: { enabled: false }
+    });
+
+    // load test data
+    await coord.exec(
+      `CREATE TABLE testData AS (
+        SELECT 12 AS HourOfDay, 1 AS DayOfWeek UNION ALL
+        SELECT 10 AS HourOfDay, 3 AS DayOfWeek
+      )`
+    );
+
+    // pending query results
+    let pending = [];
+
+    // test client class
+    class TestClient extends MosaicClient {
+      constructor(tableName, columnName, filterBy) {
+        super(filterBy);
+        this.tableName = tableName;
+        this.columnName = columnName;
+      }
+      query(filter = []) {
+        const { tableName, columnName } = this;
+        return Query.from(tableName)
+          .select({ key: columnName, value: count() })
+          .groupby(columnName)
+          .where(filter);
+      }
+      queryPending() {
+        // add result promise to global pending queue
+        this.pending = new QueryResult();
+        pending.push(this.pending);
+      }
+      queryResult(data) {
+        // fulfill pending promise with sorted data
+        this.pending.fulfill(
+          data.toArray()
+            .map(row => row.toJSON())
+            .sort((a, b) => a.key - b.key)
+        );
+        return this;
+      }
+    }
+
+    // -- INITIALIZE CLIENTS --
+
+    const selection = Selection.crossfilter();
+    const client1 = new TestClient('testData', 'HourOfDay', selection);
+    const client2 = new TestClient('testData', 'DayOfWeek', selection);
+    coord.connect(client1);
+    coord.connect(client2);
+
+    // initial results with empty selection
+    assert.deepStrictEqual(
+      await Promise.all(pending),
+      [
+        [ {key: 10, value: 1}, {key: 12, value: 1} ],
+        [ {key: 1, value: 1}, {key: 3, value: 1} ]
+      ]
+    );
+    pending = [];
+
+    // selection should produce empty arrays (no where clauses)
+    assert.deepStrictEqual(selection.predicate(client1), []);
+    assert.deepStrictEqual(selection.predicate(client2), []);
+
+    // -- UPDATE SELECTION FROM CLIENT 1 --
+
+    // update first selection with client1 as source
+    // crossfilter should skip client1, indicated by undefined result
+    // client2 should be filtered by HourOfDay
+    selection.update(
+      clauseInterval('HourOfDay', [0, 24], { source: client1 })
+    );
+    assert.strictEqual(selection.active?.source, client1);
+    assert.strictEqual(selection.predicate(client1), undefined);
+    assert.strictEqual(
+      selection.predicate(client2)+'',
+      `("HourOfDay" BETWEEN 0 AND 24)`
+    );
+
+    // only client 2 should get a data update
+    assert.deepStrictEqual(
+      await Promise.all(pending),
+      [ [ {key: 1, value: 1}, {key: 3, value: 1} ] ]
+    );
+    pending = [];
+
+    // wait for internal selection update to complete
+    // pending data promises may resolve before selection event queue advances
+    await selection.pending('value');
+
+    // -- UPDATE SELECTION FROM CLIENT 2 --
+
+    // update second selection with client2 as source
+    // client1 should be filtered by DayOfWeek
+    // crossfilter should skip client2, indicated by undefined result
+    selection.update(
+      clauseInterval('DayOfWeek', [0, 7], { source: client2 })
+    );
+    assert.strictEqual(selection.active?.source, client2);
+    assert.strictEqual(
+      selection.predicate(client1)+'',
+      `("DayOfWeek" BETWEEN 0 AND 7)`
+    );
+    assert.strictEqual(selection.predicate(client2), undefined);
+
+    // only client 1 should get a data update
+    assert.deepStrictEqual(
+      await Promise.all(pending),
+      [ [ {key: 10, value: 1}, {key: 12, value: 1} ] ]
+    );
+    pending = [];
+  });
+});

--- a/packages/inputs/src/Menu.js
+++ b/packages/inputs/src/Menu.js
@@ -1,4 +1,4 @@
-import { MosaicClient, Param, isParam, isSelection, point } from '@uwdata/mosaic-core';
+import { MosaicClient, Param, isParam, isSelection, clausePoint } from '@uwdata/mosaic-core';
 import { Query } from '@uwdata/mosaic-sql';
 import { input } from './input.js';
 
@@ -122,7 +122,7 @@ export class Menu extends MosaicClient {
     const { selection, field } = this;
     if (isSelection(selection)) {
       if (value === '') value = undefined; // 'All' option
-      const clause = point(field, value, { source: this });
+      const clause = clausePoint(field, value, { source: this });
       selection.update(clause);
     } else if (isParam(selection)) {
       selection.update(value);

--- a/packages/inputs/src/Search.js
+++ b/packages/inputs/src/Search.js
@@ -1,4 +1,4 @@
-import { MosaicClient, Param, isParam, isSelection, match } from '@uwdata/mosaic-core';
+import { MosaicClient, Param, isParam, isSelection, clauseMatch } from '@uwdata/mosaic-core';
 import { Query } from '@uwdata/mosaic-sql';
 import { input } from './input.js';
 
@@ -88,7 +88,7 @@ export class Search extends MosaicClient {
   publish(value) {
     const { selection, field, type } = this;
     if (isSelection(selection)) {
-      const clause = match(field, value, { source: this, method: type });
+      const clause = clauseMatch(field, value, { source: this, method: type });
       selection.update(clause);
     } else if (isParam(selection)) {
       selection.update(value);

--- a/packages/inputs/src/Slider.js
+++ b/packages/inputs/src/Slider.js
@@ -1,4 +1,4 @@
-import { MosaicClient, Param, interval, isParam, isSelection, point } from '@uwdata/mosaic-core';
+import { MosaicClient, Param, clauseInterval, clausePoint, isParam, isSelection } from '@uwdata/mosaic-core';
 import { Query, max, min } from '@uwdata/mosaic-sql';
 import { input } from './input.js';
 
@@ -145,14 +145,14 @@ export class Slider extends MosaicClient {
       if (selectionType === 'interval') {
         /** @type {[number, number]} */
         const domain = [this.min ?? 0, value];
-        selection.update(interval(field, domain, {
+        selection.update(clauseInterval(field, domain, {
           source: this,
           bin: 'ceil',
           scale: { type: 'identity', domain },
           pixelSize: this.step
         }));
       } else {
-        selection.update(point(field, value, { source: this }));
+        selection.update(clausePoint(field, value, { source: this }));
       }
     } else if (isParam(this.selection)) {
       selection.update(value);

--- a/packages/inputs/src/Table.js
+++ b/packages/inputs/src/Table.js
@@ -1,4 +1,4 @@
-import { MosaicClient, coordinator, points, toDataColumns } from '@uwdata/mosaic-core';
+import { MosaicClient, clausePoints, coordinator, toDataColumns } from '@uwdata/mosaic-core';
 import { Query, column, desc } from '@uwdata/mosaic-sql';
 import { formatDate, formatLocaleAuto, formatLocaleNumber } from './util/format.js';
 import { input } from './input.js';
@@ -101,7 +101,7 @@ export class Table extends MosaicClient {
       const { columns } = data[~~(row / limit)];
       return fields.map(f => columns[f][row % limit]);
     });
-    return points(fields, values, { source: this });
+    return clausePoints(fields, values, { source: this });
   }
 
   requestData(offset = 0) {

--- a/packages/plot/src/interactors/Interval1D.js
+++ b/packages/plot/src/interactors/Interval1D.js
@@ -1,4 +1,4 @@
-import { interval } from '@uwdata/mosaic-core';
+import { clauseInterval } from '@uwdata/mosaic-core';
 import { ascending, min, max, select } from 'd3';
 import { brushX, brushY } from './util/brush.js';
 import { closeTo } from './util/close-to.js';
@@ -52,7 +52,7 @@ export class Interval1D {
 
   clause(value) {
     const { mark, pixelSize, field, scale } = this;
-    return interval(field, value, {
+    return clauseInterval(field, value, {
       source: this,
       clients: this.peers ? mark.plot.markSet : new Set().add(mark),
       scale,

--- a/packages/plot/src/interactors/Interval2D.js
+++ b/packages/plot/src/interactors/Interval2D.js
@@ -1,4 +1,4 @@
-import { intervals } from '@uwdata/mosaic-core';
+import { clauseIntervals } from '@uwdata/mosaic-core';
 import { ascending, min, max, select } from 'd3';
 import { brush } from './util/brush.js';
 import { closeTo } from './util/close-to.js';
@@ -55,7 +55,7 @@ export class Interval2D {
 
   clause(value) {
     const { mark, pixelSize, xfield, yfield, xscale, yscale } = this;
-    return intervals([xfield, yfield], value, {
+    return clauseIntervals([xfield, yfield], value, {
       source: this,
       clients: this.peers ? mark.plot.markSet : new Set().add(mark),
       scales: [xscale, yscale],

--- a/packages/plot/src/interactors/Nearest.js
+++ b/packages/plot/src/interactors/Nearest.js
@@ -1,4 +1,4 @@
-import { isSelection, points } from '@uwdata/mosaic-core';
+import { clausePoints, isSelection } from '@uwdata/mosaic-core';
 import { select, pointer } from 'd3';
 import { getField } from './util/get-field.js';
 
@@ -24,7 +24,10 @@ export class Nearest {
 
   clause(value) {
     const { clients, fields } = this;
-    return points(fields, value ? [value] : value, { source: this, clients });
+    return clausePoints(fields, value ? [value] : value, {
+      source: this,
+      clients
+    });
   }
 
   init(svg) {

--- a/packages/plot/src/interactors/PanZoom.js
+++ b/packages/plot/src/interactors/PanZoom.js
@@ -1,4 +1,4 @@
-import { interval, Selection } from '@uwdata/mosaic-core';
+import { Selection, clauseInterval } from '@uwdata/mosaic-core';
 import { select, zoom, ZoomTransform } from 'd3';
 import { getField } from './util/get-field.js';
 
@@ -48,7 +48,7 @@ export class PanZoom {
   }
 
   clause(value, field, scale) {
-    return interval(field, value, {
+    return clauseInterval(field, value, {
       source: this,
       clients: this.mark.plot.markSet,
       scale

--- a/packages/plot/src/interactors/Toggle.js
+++ b/packages/plot/src/interactors/Toggle.js
@@ -1,4 +1,4 @@
-import { points } from '@uwdata/mosaic-core';
+import { clausePoints } from '@uwdata/mosaic-core';
 
 export class Toggle {
   /**
@@ -35,7 +35,7 @@ export class Toggle {
 
   clause(value) {
     const { fields, mark } = this;
-    return points(fields, value, {
+    return clausePoints(fields, value, {
       source: this,
       clients: this.peers ? mark.plot.markSet : new Set().add(mark)
     });


### PR DESCRIPTION
- Refactor clause generators for better clarity (`clauseInterval` instead of just `interval`).
- Add `pending()` method to `AsyncDispatch` to track param/selection event processing.
- Add test cases for client and selection lifecycle methods. (h/t @matys1)