### PR TITLE
Fix missing index errors and updates that stop emitting

### DIFF
--- a/packages/core/src/DataCubeIndexer.js
+++ b/packages/core/src/DataCubeIndexer.js
@@ -53,12 +53,9 @@ export class DataCubeIndexer {
 
   /**
    * Clear the cache of data cube index table entries for the current active
-   * selection clause. This method will also cancel any queued data cube table
-   * creation queries that have not yet been submitted to the database. This
-   * method does _not_ drop any existing data cube tables.
+   * selection clause. This method does _not_ drop any existing data cube tables.
    */
   clear() {
-    this.mc.cancel(Array.from(this.indexes.values(), info => info?.result));
     this.indexes.clear();
     this.active = null;
   }

--- a/packages/core/src/QueryManager.js
+++ b/packages/core/src/QueryManager.js
@@ -109,7 +109,13 @@ export class QueryManager {
   cancel(requests) {
     const set = new Set(requests);
     if (set.size) {
-      this.queue.remove(({ result }) => set.has(result));
+      this.queue.remove(({ result }) => {
+        if(set.has(result)) {
+          result.reject('Canceled');
+          return true;
+        }
+        return false;
+      });
     }
   }
 

--- a/packages/core/src/util/throttle.js
+++ b/packages/core/src/util/throttle.js
@@ -6,7 +6,7 @@ export function throttle(callback, debounce = false) {
   let pending = NIL;
 
   function invoke(event) {
-    curr = callback(event).then(() => {
+    curr = callback(event).finally(() => {
       if (next) {
         const { value } = next;
         next = null;

--- a/packages/core/test/throttle-test.js
+++ b/packages/core/test/throttle-test.js
@@ -1,0 +1,53 @@
+import assert from 'node:assert';
+import { throttle } from '../src/util/throttle.js';
+import { QueryResult } from '../src/util/query-result.js';
+
+async function wait() {
+    return new Promise(setTimeout);
+}
+
+describe('throttle', () => {
+    it('should throttle successful query results', async () => {
+        const requests = [];
+        const throttled = throttle(() => {
+            const req = new QueryResult();
+            requests.push(req);
+            return req;
+        });
+        
+        throttled();
+        await wait();
+        assert.equal(requests.length, 1);
+
+        throttled();
+        await wait();
+        assert.equal(requests.length, 1);
+
+        requests[0].fulfill('done');
+        await wait();
+
+        assert.equal(requests.length, 2);
+    });
+
+    it('should throttle unsuccessful query results', async () => {
+        const requests = [];
+        const throttled = throttle(() => {
+            const req = new QueryResult();
+            requests.push(req);
+            return req;
+        });
+        
+        throttled();
+        await wait();
+        assert.equal(requests.length, 1);
+
+        throttled();
+        await wait();
+        assert.equal(requests.length, 1);
+
+        requests[0].reject('done');
+        await wait();
+
+        assert.equal(requests.length, 2);
+    });
+});


### PR DESCRIPTION
- Make throttle utility resilient to callback rejections
- Reject canceled queries rather than leaving them pending
- Index creation queries are no longer canceled when clearing the data cube indexes since the indexes may already be used in other queued requests

Fixes #458 