### PR TITLE
chore: use only-packages in jupyter widget

### DIFF
--- a/packages/widget/pyproject.toml
+++ b/packages/widget/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 homepage = "https://github.com/uwdata/mosaic"
 
 [tool.hatch.build]
+only-packages = true
 artifacts = [
   "mosaic_widget/static/"
 ]


### PR DESCRIPTION
this removes unnecessary files from the build

learned from https://github.com/manzt/quak/blob/main/pyproject.toml by @manzt