### PR TITLE
fix: Don't consolidate aggregated and non-aggregated queries without a groupby

### DIFF
--- a/packages/core/src/QueryConsolidator.js
+++ b/packages/core/src/QueryConsolidator.js
@@ -108,6 +108,10 @@ function consolidationKey(query, cache) {
       // @ts-ignore
       q.$groupby(groupby.map(e => (e instanceof Ref && map[e.column]) || e));
     }
+    // @ts-ignore
+    else if(query.select().some(({ expr }) => expr.aggregate)) {
+      q.$groupby('*');
+    }
 
     // key is just the transformed query as SQL
     return `${q}`;

--- a/packages/core/test/query-consolidator-test.js
+++ b/packages/core/test/query-consolidator-test.js
@@ -1,0 +1,46 @@
+import assert from 'node:assert';
+import { Query } from '@uwdata/mosaic-sql/src/Query.js';
+import { count, sum } from '@uwdata/mosaic-sql/src/aggregates.js';
+import { consolidator } from '../src/QueryConsolidator.js';
+import { Priority } from '../src/QueryManager.js';
+import { voidCache } from '../src/util/cache.js';
+
+describe('QueryConsolidation', () => {
+    async function getConsolidatedQueries(...qs) {
+        const consolidated = [];
+        const c = consolidator(q => consolidated.push(q.request.query.toString()), voidCache(), () => {/*ignore*/});
+        for(const q of qs) {
+            c.add({request: { type: 'arrow', query: q }}, Priority.Normal);
+        }
+        await new Promise(resolve => setImmediate(resolve));
+        return consolidated;
+    }
+
+    it('should consolidate non-grouped aggregated queries', async () => {
+        const q1 = Query.from({ source: 'table' }).select({ c: count() });
+        const q2 = Query.from({ source: 'table' }).select({ c: sum() });
+        const consolidated = await getConsolidatedQueries(q1, q2);
+        assert.deepEqual(consolidated, [
+            Query.from({ source: 'table' }).select({ col0: count(), col1: sum() }).toString(),
+        ]);
+    });
+
+    it('should consolidate non-grouped non-aggregated queries', async () => {
+        const q1 = Query.from({ source: 'table' }).select({ c: 'x' });
+        const q2 = Query.from({ source: 'table' }).select({ c: 'y' });
+        const consolidated = await getConsolidatedQueries(q1, q2);
+        assert.deepEqual(consolidated, [
+            Query.from({ source: 'table' }).select({ col0: 'x', col1: 'y' }).toString(),
+        ]);
+    });
+
+    it('should not consolidate non-grouped aggregated and non-aggregated queries', async () => {
+        const q1 = Query.from({ source: 'table' }).select({ c: 'x' });
+        const q2 = Query.from({ source: 'table' }).select({ c: count() });
+        const consolidated = await getConsolidatedQueries(q1, q2);
+        assert.deepEqual(consolidated, [
+            q1.toString(),
+            q2.toString(),
+        ]);
+    });
+});


### PR DESCRIPTION
In the `QueryConsolidator`, make sure `SELECT x FROM table` is not consolidated with `SELECT count() FROM table` since the aggregation in the latter query implies an implicit grouping which the former doesn't.

Implemented the fix by adding a GROUP BY * to the query's consolidation key where aggregates are present in the select.

Fixes #478 