### PR TITLE
Stream Arrow RecordBatches using mpsc channel and tokio_streams

### DIFF
--- a/packages/duckdb-server-rust/Cargo.lock
+++ b/packages/duckdb-server-rust/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "tokio-stream",
  "tower",
  "tower-http",
  "tracing",

--- a/packages/duckdb-server-rust/Cargo.toml
+++ b/packages/duckdb-server-rust/Cargo.toml
@@ -29,6 +29,7 @@ axum-streams = { version = "0.18", features=["arrow"] }
 async-stream = "0.3"
 deadpool = { version = "0.12", features = ["managed"] }
 deadpool-r2d2 = {version = "0.4.1"}
+tokio-stream = "0.1"
 
 [dev-dependencies]
 http-body-util = "0.1.0"


### PR DESCRIPTION
Fixes compilation of https://github.com/uwdata/mosaic/pull/462 by using an mpsc channel and tokio_streams.

The reason this is more complicated that what you were trying @domoritz , is that the `Arrow` type provided by the duckdb crate is not [Send](https://doc.rust-lang.org/nomicon/send-and-sync.html).  This means that it (and objects that depend on it) cannot be transferred across threads.  This is why it doesn't work to build a stream using the `stream!` macro and return it from inside the `conn.interact` closure.

Using mpsc channels like I am here is a common workaround for dealing with non-send objects. Here the Arrow object stays in the thread that constructed it, and pushes the record batches through the channel back to the main thread. This channel is wrapped into a stream using the `ReceiverStream` from the `tokio_stream` crate.

I didn't actually test this, just got it compiling, so give it a try and see if it works the way you want.