### PR TITLE
Add client initialize, fix data cube avg generator.

### DIFF
--- a/packages/core/src/Coordinator.js
+++ b/packages/core/src/Coordinator.js
@@ -212,16 +212,22 @@ export class Coordinator {
     clients.add(client); // mark as connected
     client.coordinator = this;
 
+    // initialize client lifecycle
+    this.initializeClient(client);
+
+    // connect filter selection
+    connectSelection(this, client.filterBy, client);
+  }
+
+  async initializeClient(client) {
     // retrieve field statistics
     const fields = client.fields();
     if (fields?.length) {
       client.fieldInfo(await queryFieldInfo(this, fields));
     }
 
-    // connect filter selection
-    connectSelection(this, client.filterBy, client);
-
-    client.requestQuery();
+    // request data query
+    return client.requestQuery();
   }
 
   /**

--- a/packages/core/src/MosaicClient.js
+++ b/packages/core/src/MosaicClient.js
@@ -103,6 +103,7 @@ export class MosaicClient {
    * Request the coordinator to execute a query for this client.
    * If an explicit query is not provided, the client query method will
    * be called, filtered by the current filterBy selection.
+   * @returns {Promise}
    */
   requestQuery(query) {
     const q = query || this.query(this.filterBy?.predicate(this));
@@ -117,6 +118,14 @@ export class MosaicClient {
    */
   requestUpdate() {
     this._requestUpdate();
+  }
+
+  /**
+   * Reset this client, initiating new field info and query requests.
+   * @returns {Promise}
+   */
+  initialize() {
+    return this._coordinator.initializeClient(this);
   }
 
   /**

--- a/packages/plot/src/plot.js
+++ b/packages/plot/src/plot.js
@@ -132,7 +132,7 @@ export class Plot {
         params.set(param, [mark]);
         param.addEventListener('value', () => {
           return Promise.allSettled(
-            params.get(param).map(mark => mark.requestQuery())
+            params.get(param).map(mark => mark.initialize())
           );
         });
       }


### PR DESCRIPTION
- Add client `initialize` method. This method supports dynamic client re-initialization, issuing new field info and client query requests.
- Update `Plot` to re-initialize mark clients upon dynamic field updates.
- Fix data cube indexer to generate correct averages in variance and covariance calculations. (#487)

Together, these changes allow vgplot to properly support dynamic fields, where the underlying database column for an encoding channel may change due to interactive updates.

Close #487.