### PR TITLE
Export shared IPC decoder, revise widget.

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -16,11 +16,9 @@ export {
   clauseMatch
 } from './SelectionClause.js';
 
-export {
-  isArrowTable
-} from './util/is-arrow-table.js'
-
+export { decodeIPC } from './util/decode-ipc.js';
 export { distinct } from './util/distinct.js';
+export { isArrowTable } from './util/is-arrow-table.js';
 export { synchronizer } from './util/synchronizer.js';
 export { throttle } from './util/throttle.js';
-export { toDataColumns } from './util/to-data-columns.js'
+export { toDataColumns } from './util/to-data-columns.js';

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -19,7 +19,7 @@
     "release": "npm run prepublishOnly && npm run publish"
   },
   "dependencies": {
-    "@uwdata/flechette": "~0.0.8",
+    "@uwdata/mosaic-core": "^0.10.0",
     "@uwdata/mosaic-spec": "^0.10.0",
     "@uwdata/vgplot": "^0.10.0",
     "uuid": "^10.0.0"

--- a/packages/widget/src/index.js
+++ b/packages/widget/src/index.js
@@ -1,7 +1,5 @@
-import { coordinator, namedPlots } from '@uwdata/vgplot';
-import { isSelection } from '@uwdata/mosaic-core';
+import { coordinator, decodeIPC, isSelection } from '@uwdata/mosaic-core';
 import { parseSpec, astToDOM } from '@uwdata/mosaic-spec';
-import { tableFromIPC } from '@uwdata/flechette';
 import './style.css';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -57,7 +55,6 @@ export default {
 
     function reset() {
       coordinator().clear();
-      namedPlots.clear();
     }
 
     async function updateSpec() {
@@ -113,7 +110,7 @@ export default {
       } else {
         switch (msg.type) {
           case 'arrow': {
-            const table = tableFromIPC(buffers[0].buffer);
+            const table = decodeIPC(buffers[0].buffer);
             logger.log('table', table);
             query.resolve(table);
             break;
@@ -144,6 +141,8 @@ export default {
 };
 
 function instantiateSpec(spec) {
-  const ast = parseSpec(spec);
-  return astToDOM(ast);
+  // parse specification, and instantiate it
+  // astToDOM creates a new vgplot API context with the
+  // standard coordinator and a custom namedPlots map
+  return astToDOM(parseSpec(spec));
 }


### PR DESCRIPTION
- Add `decodeIPC` for parsing Arrow data to `mosaic-core` exports.
- Update Jupyter widget to reflect latest updates and use `decodeIPC`.

Fix #499.
