### PR TITLE
Use param-compatible clause for single-field nearest selection.

### DIFF
--- a/packages/plot/src/interactors/Nearest.js
+++ b/packages/plot/src/interactors/Nearest.js
@@ -1,4 +1,4 @@
-import { clausePoints, isSelection } from '@uwdata/mosaic-core';
+import { clausePoint, clausePoints, isSelection } from '@uwdata/mosaic-core';
 import { select, pointer } from 'd3';
 import { getField } from './util/get-field.js';
 
@@ -24,10 +24,12 @@ export class Nearest {
 
   clause(value) {
     const { clients, fields } = this;
-    return clausePoints(fields, value ? [value] : value, {
-      source: this,
-      clients
-    });
+    const opt = { source: this, clients };
+    // if only one field, use a simpler clause that passes the value
+    // this allows a single field selection value to act like a param
+    return fields.length > 1
+      ? clausePoints(fields, value ? [value] : value, opt)
+      : clausePoint(fields[0], value?.[0], opt);
   }
 
   init(svg) {


### PR DESCRIPTION
- Fix `nearest` interactor to use a `Param`-compatible clause for single-field selections.

Fix #502 