### PR TITLE
docs(widget): Clarify multi-dataframe/Arrow support for DuckDB

### DIFF
--- a/packages/widget/mosaic_widget/__init__.py
+++ b/packages/widget/mosaic_widget/__init__.py
@@ -31,8 +31,8 @@ class MosaicWidget(anywidget.AnyWidget):
     def __init__(
         self,
         spec: dict | None = None,
-        con=None,
-        data=None,
+        con: duckdb.DuckDBPyConnection | None = None,
+        data: dict | None = None,
         *args,
         **kwargs,
     ):
@@ -42,8 +42,10 @@ class MosaicWidget(anywidget.AnyWidget):
             spec (dict, optional): The initial Mosaic specification. Defaults to {}.
             con (connection, optional): A DuckDB connection.
                 Defaults to duckdb.connect().
-            data (dict, optional): Pandas DataFrames to add to DuckDB.
-                The keys are used as the names of the tables. Defaults to {}.
+            data (dict, optional): DataFrames/Arrow objects to "register" with DuckDB.
+                Defaults to {}. Keys are table names, values are objects to register as
+                virtual tables (similar to SQL VIEWs). Supports pandas/polars DataFrames
+                and other Arrow objects.
         """
         if data is None:
             data = {}


### PR DESCRIPTION
The Mosaic widget not only supports Pandas data frames but any Arrow object (including other dataframes like polars).

re: https://github.com/manzt/quak/issues/54#issuecomment-2353416672

ref: https://duckdb.org/docs/api/python/data_ingestion#directly-accessing-dataframes-and-arrow-objects