### PR TITLE
ts-ignore on import in selection-types.ts

### DIFF
--- a/packages/core/src/util/selection-types.d.ts
+++ b/packages/core/src/util/selection-types.d.ts
@@ -1,5 +1,4 @@
 import { SQLExpression } from '@uwdata/mosaic-sql';
-// @ts-ignore Could not find a declaration file for module '../MosaicClient.js'.
 import { MosaicClient } from '../MosaicClient.js';
 
 /**

--- a/packages/core/src/util/selection-types.ts
+++ b/packages/core/src/util/selection-types.ts
@@ -1,4 +1,5 @@
 import { SQLExpression } from '@uwdata/mosaic-sql';
+// @ts-expect-error Could not find a declaration file for module '@uwdata/mosaic-core'.
 import { MosaicClient } from '../MosaicClient.js';
 
 /**

--- a/packages/core/src/util/selection-types.ts
+++ b/packages/core/src/util/selection-types.ts
@@ -1,5 +1,5 @@
 import { SQLExpression } from '@uwdata/mosaic-sql';
-// @ts-expect-error Could not find a declaration file for module '@uwdata/mosaic-core'.
+// @ts-ignore Could not find a declaration file for module '../MosaicClient.js'.
 import { MosaicClient } from '../MosaicClient.js';
 
 /**


### PR DESCRIPTION
This needs to be added otherwise I have to disable `noImplicitAny` in my tsconfig.json which can hide other errors.
This wouldn't be needed either if the file were a compiled declaration file (.d.ts) because of `skipLibCheck` in the tsconfig.json so this seems like the simplest solution