### PR TITLE
feat: return dataServer on creation (#553)

### DIFF
--- a/packages/duckdb/src/data-server.js
+++ b/packages/duckdb/src/data-server.js
@@ -19,10 +19,11 @@ export function dataServer(db, {
   const app = createHTTPServer(handleQuery, rest);
   if (socket) createSocketServer(app, handleQuery);
 
-  app.listen(port);
+  const server = app.listen(port);
   console.log(`Data server running on port ${port}`);
   if (rest) console.log(`  http://localhost:${port}/`);
   if (socket) console.log(`  ws://localhost:${port}/`);
+  return server;
 }
 
 function createHTTPServer(handleQuery, rest) {


### PR DESCRIPTION
As discussed in https://github.com/uwdata/mosaic/issues/553, this returns the server so that the user can subsequently do things with it such as close it. 

I didn't see an existing test for booting up the server where it would make sense to add this scenario but if I missed something, let me know. 