### PR TITLE
Use currentColor for multi-series label.

### DIFF
--- a/docs/public/specs/esm/line-multi-series.js
+++ b/docs/public/specs/esm/line-multi-series.js
@@ -28,7 +28,7 @@ export default vg.plot(
       y: "unemployment",
       z: "division",
       r: 2,
-      fill: "black",
+      fill: "currentColor",
       select: "nearestX"
     }
   ),
@@ -38,7 +38,7 @@ export default vg.plot(
       x: "date",
       y: "unemployment",
       text: "division",
-      fill: "black",
+      fill: "currentColor",
       dy: -8,
       select: "nearestX"
     }

--- a/docs/public/specs/json/line-multi-series.json
+++ b/docs/public/specs/json/line-multi-series.json
@@ -49,7 +49,7 @@
       "y": "unemployment",
       "z": "division",
       "r": 2,
-      "fill": "black",
+      "fill": "currentColor",
       "select": "nearestX"
     },
     {
@@ -60,7 +60,7 @@
       "x": "date",
       "y": "unemployment",
       "text": "division",
-      "fill": "black",
+      "fill": "currentColor",
       "dy": -8,
       "select": "nearestX"
     }

--- a/docs/public/specs/yaml/line-multi-series.yaml
+++ b/docs/public/specs/yaml/line-multi-series.yaml
@@ -30,14 +30,14 @@ plot:
     y: unemployment
     z: division
     r: 2
-    fill: black
+    fill: currentColor
     select: nearestX
   - mark: text
     data: { from: bls_unemp }
     x: date
     y: unemployment
     text: division
-    fill: black
+    fill: currentColor
     dy: -8
     select: nearestX
 marginLeft: 24

--- a/specs/esm/line-multi-series.js
+++ b/specs/esm/line-multi-series.js
@@ -28,7 +28,7 @@ export default vg.plot(
       y: "unemployment",
       z: "division",
       r: 2,
-      fill: "black",
+      fill: "currentColor",
       select: "nearestX"
     }
   ),
@@ -38,7 +38,7 @@ export default vg.plot(
       x: "date",
       y: "unemployment",
       text: "division",
-      fill: "black",
+      fill: "currentColor",
       dy: -8,
       select: "nearestX"
     }

--- a/specs/json/line-multi-series.json
+++ b/specs/json/line-multi-series.json
@@ -55,7 +55,7 @@
       "y": "unemployment",
       "z": "division",
       "r": 2,
-      "fill": "black",
+      "fill": "currentColor",
       "select": "nearestX"
     },
     {
@@ -66,7 +66,7 @@
       "x": "date",
       "y": "unemployment",
       "text": "division",
-      "fill": "black",
+      "fill": "currentColor",
       "dy": -8,
       "select": "nearestX"
     }

--- a/specs/ts/line-multi-series.ts
+++ b/specs/ts/line-multi-series.ts
@@ -51,7 +51,7 @@ export const spec : Spec = {
       "y": "unemployment",
       "z": "division",
       "r": 2,
-      "fill": "black",
+      "fill": "currentColor",
       "select": "nearestX"
     },
     {
@@ -62,7 +62,7 @@ export const spec : Spec = {
       "x": "date",
       "y": "unemployment",
       "text": "division",
-      "fill": "black",
+      "fill": "currentColor",
       "dy": -8,
       "select": "nearestX"
     }

--- a/specs/yaml/line-multi-series.yaml
+++ b/specs/yaml/line-multi-series.yaml
@@ -30,14 +30,14 @@ plot:
     y: unemployment
     z: division
     r: 2
-    fill: black
+    fill: currentColor
     select: nearestX
   - mark: text
     data: { from: bls_unemp }
     x: date
     y: unemployment
     text: division
-    fill: black
+    fill: currentColor
     dy: -8
     select: nearestX
 marginLeft: 24


### PR DESCRIPTION
- Fix `line-multi-series` example to use `currentColor` for text and point annotations upon hover.