### PR TITLE
feat: export selection types

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -22,3 +22,16 @@ export { isArrowTable } from './util/is-arrow-table.js';
 export { synchronizer } from './util/synchronizer.js';
 export { throttle } from './util/throttle.js';
 export { toDataColumns } from './util/to-data-columns.js';
+
+/**
+ * @typedef {import('./util/selection-types.js').ClauseMetadata} ClauseMetadata
+ * @typedef {import('./util/selection-types.js').PointMetadata} PointMetadata
+ * @typedef {import('./util/selection-types.js').MatchMethod} MatchMethod
+ * @typedef {import('./util/selection-types.js').MatchMetadata} MatchMetadata
+ * @typedef {import('./util/selection-types.js').ScaleType} ScaleType
+ * @typedef {import('./util/selection-types.js').Extent} Extent
+ * @typedef {import('./util/selection-types.js').Scale} Scale
+ * @typedef {import('./util/selection-types.js').BinMethod} BinMethod
+ * @typedef {import('./util/selection-types.js').IntervalMetadata} IntervalMetadata
+ * @typedef {import('./util/selection-types.js').SelectionClause} SelectionClause
+ */


### PR DESCRIPTION
Currently, the generated type declaration file (`index.d.ts`) for `mosaic-core` does not include the types defined in `selection-types.ts`

This PR makes to include the types defined in `selection-types.ts` in the generated `index.d.ts` for `mosaic-core`

`index.d.ts` before this change
```typescript
export { MosaicClient } from "./MosaicClient.js";
export { Priority } from "./QueryManager.js";
export { restConnector } from "./connectors/rest.js";
export { socketConnector } from "./connectors/socket.js";
export { wasmConnector } from "./connectors/wasm.js";
export { decodeIPC } from "./util/decode-ipc.js";
export { distinct } from "./util/distinct.js";
export { isArrowTable } from "./util/is-arrow-table.js";
export { synchronizer } from "./util/synchronizer.js";
export { throttle } from "./util/throttle.js";
export { toDataColumns } from "./util/to-data-columns.js";
export { Coordinator, coordinator } from "./Coordinator.js";
export { Selection, isSelection } from "./Selection.js";
export { Param, isParam } from "./Param.js";
export { clauseInterval, clauseIntervals, clausePoint, clausePoints, clauseMatch } from "./SelectionClause.js";
```

After the change
```typescript
export { MosaicClient } from "./MosaicClient.js";
export { Priority } from "./QueryManager.js";
export { restConnector } from "./connectors/rest.js";
export { socketConnector } from "./connectors/socket.js";
export { wasmConnector } from "./connectors/wasm.js";
export { decodeIPC } from "./util/decode-ipc.js";
export { distinct } from "./util/distinct.js";
export { isArrowTable } from "./util/is-arrow-table.js";
export { synchronizer } from "./util/synchronizer.js";
export { throttle } from "./util/throttle.js";
export { toDataColumns } from "./util/to-data-columns.js";
export type ClauseMetadata = import("./util/selection-types.js").ClauseMetadata;
export type PointMetadata = import("./util/selection-types.js").PointMetadata;
export type MatchMethod = import("./util/selection-types.js").MatchMethod;
export type MatchMetadata = import("./util/selection-types.js").MatchMetadata;
export type ScaleType = import("./util/selection-types.js").ScaleType;
export type Extent = import("./util/selection-types.js").Extent;
export type Scale = import("./util/selection-types.js").Scale;
export type BinMethod = import("./util/selection-types.js").BinMethod;
export type IntervalMetadata = import("./util/selection-types.js").IntervalMetadata;
export type SelectionClause = import("./util/selection-types.js").SelectionClause;
export { Coordinator, coordinator } from "./Coordinator.js";
export { Selection, isSelection } from "./Selection.js";
export { Param, isParam } from "./Param.js";
export { clauseInterval, clauseIntervals, clausePoint, clausePoints, clauseMatch } from "./SelectionClause.js";

```


For reference, something like below caused a build error:
```javascript
export { SelectionClause } './util/selection-types.js'
```
```
> npm run build

> build
> lerna run build

lerna notice cli v8.1.8

   ✔  @uwdata/mosaic-sql:build (2s)

———————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
   ✖  @uwdata/mosaic-core:build
      > @uwdata/mosaic-core@0.12.0 prebuild
      > rimraf dist && mkdir dist
      
      
      > @uwdata/mosaic-core@0.12.0 build
      > npm run types && node ../../esbuild.js mosaic-core
      
      
      > @uwdata/mosaic-core@0.12.0 types
      > tsc
      
      ✘ [ERROR] No matching export in "src/util/selection-types.ts" for import "SelectionClause"
      
          src/index.js:39:9:
            39 │ export { SelectionClause } from './util/selection-types.js'
               ╵          ~~~~~~~~~~~~~~~
      
      ✘ [ERROR] No matching export in "src/util/selection-types.ts" for import "SelectionClause"
      
          src/index.js:39:9:
            39 │ export { SelectionClause } from './util/selection-types.js'
               ╵          ~~~~~~~~~~~~~~~
      
      <path>/mosaic/node_modules/esbuild/lib/main.js:1476
        let error = new Error(text);
                    ^
      
      Error: Build failed with 1 error:
      src/index.js:39:9: ERROR: No matching export in "src/util/selection-types.ts" for import "SelectionClause"
          at failureErrorWithLog (<path>/mosaic/node_modules/esbuild/lib/main.js:1476:15)
          at <path>/mosaic/node_modules/esbuild/lib/main.js:945:25
          at <path>/mosaic/node_modules/esbuild/lib/main.js:897:52
          at buildResponseToResult (<path>/mosaic/node_modules/esbuild/lib/main.js:943:7)
          at <path>/mosaic/node_modules/esbuild/lib/main.js:970:16
          at responseCallbacks.<computed> (<path>/mosaic/node_modules/esbuild/lib/main.js:622:9)
          at handleIncomingPacket (<path>/mosaic/node_modules/esbuild/lib/main.js:677:12)
          at Socket.readFromStdout (<path>/mosaic/node_modules/esbuild/lib/main.js:600:7)
          at Socket.emit (node:events:519:28)
          at addChunk (node:internal/streams/readable:559:12) {
        errors: [Getter/Setter],
        warnings: [Getter/Setter]
      }
      
      Node.js v20.14.0
      npm error Lifecycle script `build` failed with error:
      npm error Error: command failed
      npm error   in workspace: @uwdata/mosaic-core@0.12.0
      npm error   at location: <path>/mosaic/packages/core
      
      

———————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 Lerna (powered by Nx)   Ran target build for 8 projects (4s)

   ✔  1/2 succeeded [0 read from cache]

   ✖  1/2 targets failed, including the following:

      - @uwdata/mosaic-core:build
 ```