### PR TITLE
Support param-valued data tables.

### DIFF
--- a/packages/inputs/src/Table.js
+++ b/packages/inputs/src/Table.js
@@ -1,4 +1,4 @@
-import { MosaicClient, clausePoints, coordinator, toDataColumns } from '@uwdata/mosaic-core';
+import { MosaicClient, clausePoints, coordinator, isParam, toDataColumns } from '@uwdata/mosaic-core';
 import { Query, column, desc } from '@uwdata/mosaic-sql';
 import { formatDate, formatLocaleAuto, formatLocaleNumber } from './util/format.js';
 import { input } from './input.js';
@@ -32,6 +32,11 @@ export class Table extends MosaicClient {
     this.format = format;
     this.align = align;
     this.widths = typeof width === 'object' ? width : {};
+
+    if (isParam(from)) {
+      // if data table is a param, re-initialize upon change
+      from.addEventListener('value', () => this.initialize());
+    }
 
     this.offset = 0;
     this.limit = +rowBatch;
@@ -94,6 +99,10 @@ export class Table extends MosaicClient {
     this.element.appendChild(this.style);
   }
 
+  sourceTable() {
+    return isParam(this.from) ? this.from.value : this.from;
+  }
+
   clause(rows = []) {
     const { data, limit, schema } = this;
     const fields = schema.map(s => s.column);
@@ -116,7 +125,8 @@ export class Table extends MosaicClient {
   }
 
   fields() {
-    return this.columns.map(name => column(name, this.from));
+    const from = this.sourceTable();
+    return this.columns.map(name => column(name, from));
   }
 
   fieldInfo(info) {
@@ -148,8 +158,8 @@ export class Table extends MosaicClient {
   }
 
   query(filter = []) {
-    const { from, limit, offset, schema, sortColumn, sortDesc } = this;
-    return Query.from(from)
+    const { limit, offset, schema, sortColumn, sortDesc } = this;
+    return Query.from(this.sourceTable())
       .select(schema.map(s => s.column))
       .where(filter)
       .orderby(sortColumn ? (sortDesc ? desc(sortColumn) : sortColumn) : [])

--- a/packages/plot/src/marks/DenseLineMark.js
+++ b/packages/plot/src/marks/DenseLineMark.js
@@ -16,13 +16,13 @@ export class DenseLineMark extends RasterMark {
   }
 
   query(filter = []) {
-    const { channels, normalize, source, pad } = this;
+    const { channels, normalize, pad } = this;
     const [nx, ny] = this.bins = this.binDimensions();
     const [x] = binExpr(this, 'x', nx, extentX(this, filter), pad);
     const [y] = binExpr(this, 'y', ny, extentY(this, filter), pad);
 
     const q = Query
-      .from(source.table)
+      .from(this.sourceTable())
       .where(stripXY(this, filter));
 
     this.aggr = ['density'];

--- a/packages/plot/src/marks/Density1DMark.js
+++ b/packages/plot/src/marks/Density1DMark.js
@@ -36,10 +36,10 @@ export class Density1DMark extends Mark {
 
   query(filter = []) {
     if (this.hasOwnData()) throw new Error('Density1DMark requires a data source');
-    const { bins, channels, dim, source: { table } } = this;
+    const { bins, channels, dim } = this;
     const extent = this.extent = (dim === 'x' ? extentX : extentY)(this, filter);
     const [x, bx] = binExpr(this, dim, bins, extent);
-    const q = markQuery(channels, table, [dim])
+    const q = markQuery(channels, this.sourceTable(), [dim])
       .where(filter.concat(isBetween(bx, extent)));
     const v = this.channelField('weight') ? 'weight' : null;
     return binLinear1d(q, x, v);

--- a/packages/plot/src/marks/ErrorBarMark.js
+++ b/packages/plot/src/marks/ErrorBarMark.js
@@ -20,12 +20,12 @@ export class ErrorBarMark extends Mark {
   }
 
   query(filter = []) {
-    const { channels, field, source: { table } } = this;
+    const { channels, field } = this;
     const fields = channels.concat([
       { field: avg(field), as: '__avg__' },
       { field: div(stddev(field), sqrt(count(field))), as: '__se__', }
     ]);
-    return markQuery(fields, table).where(filter);
+    return markQuery(fields, this.sourceTable()).where(filter);
   }
 
   queryResult(data) {

--- a/packages/plot/src/marks/Grid2DMark.js
+++ b/packages/plot/src/marks/Grid2DMark.js
@@ -77,7 +77,7 @@ export class Grid2DMark extends Mark {
   }
 
   query(filter = []) {
-    const { interpolate, pad, channels, densityMap, source } = this;
+    const { interpolate, pad, channels, densityMap } = this;
     const [x0, x1] = this.extentX = extentX(this, filter);
     const [y0, y1] = this.extentY = extentY(this, filter);
     const [nx, ny] = this.bins = this.binDimensions();
@@ -91,7 +91,7 @@ export class Grid2DMark extends Mark {
       : [lte(+x0, bx), lt(bx, +x1), lte(+y0, by), lt(by, +y1)];
 
     const q = Query
-      .from(source.table)
+      .from(this.sourceTable())
       .where(filter.concat(bounds));
 
     /** @type {string[]} */

--- a/packages/plot/src/marks/HexbinMark.js
+++ b/packages/plot/src/marks/HexbinMark.js
@@ -23,7 +23,7 @@ export class HexbinMark extends Mark {
 
   query(filter = []) {
     if (this.hasOwnData()) return null;
-    const { plot, binWidth, channels, source } = this;
+    const { plot, binWidth, channels } = this;
 
     // Extract channel information, update top-level query
     // and extract dependent columns for aggregates
@@ -109,7 +109,7 @@ export class HexbinMark extends Mark {
               ),
             [y]: cond(tt, int32(add(pj, cond(lt(py, pj), -1, 1))), pj)
           }, '*')
-          .from(source.table)
+          .from(this.sourceTable())
           .where(isNotNull(xc.field), isNotNull(yc.field), filter)
       );
   }

--- a/packages/plot/src/marks/RasterTileMark.js
+++ b/packages/plot/src/marks/RasterTileMark.js
@@ -36,7 +36,7 @@ export class RasterTileMark extends Grid2DMark {
   }
 
   tileQuery(extent) {
-    const { interpolate, pad, channels, densityMap, source } = this;
+    const { interpolate, pad, channels, densityMap } = this;
     const [[x0, x1], [y0, y1]] = extent;
     const [nx, ny] = this.bins;
     const [x, bx] = binExpr(this, 'x', nx, [x0, x1], pad);
@@ -49,7 +49,7 @@ export class RasterTileMark extends Grid2DMark {
       : [lte(+x0, bx), lt(bx, +x1), lte(+y0, by), lt(by, +y1)];
 
     const q = Query
-      .from(source.table)
+      .from(this.sourceTable())
       .where(bounds);
 
     const groupby = this.groupby = [];

--- a/packages/spec/src/ast/PlotFromNode.js
+++ b/packages/spec/src/ast/PlotFromNode.js
@@ -16,7 +16,7 @@ export function parseMarkData(spec, ctx) {
   }
 
   const { from: table, ...options } = spec;
-  return new PlotFromNode(table, parseOptions(options, ctx));
+  return new PlotFromNode(ctx.maybeParam(table), parseOptions(options, ctx));
 }
 
 export class PlotFromNode extends ASTNode {
@@ -28,17 +28,17 @@ export class PlotFromNode extends ASTNode {
 
   instantiate(ctx) {
     const { table, options } = this;
-    return ctx.api[FROM](table, options.instantiate(ctx));
+    return ctx.api[FROM](table.instantiate(ctx), options.instantiate(ctx));
   }
 
   codegen(ctx) {
-    const { type, table, options } = this;
-    const opt = options.codegen(ctx);
-    return `${ctx.ns()}${type}("${table}"${opt ? ', ' + opt : ''})`;
+    const table = this.table.codegen(ctx);
+    const opt = this.options.codegen(ctx);
+    return `${ctx.ns()}${this.type}(${table}${opt ? ', ' + opt : ''})`;
   }
 
   toJSON() {
     const { type, table, options } = this;
-    return { [type]: table, ...options.toJSON() };
+    return { [type]: table.toJSON(), ...options.toJSON() };
   }
 }

--- a/packages/spec/src/spec/Input.ts
+++ b/packages/spec/src/spec/Input.ts
@@ -171,7 +171,7 @@ export interface Table {
   /**
    * The name of a database table to use as a data source for this widget.
    */
-  from: string;
+  from: string | ParamRef;
   /**
    * A list of column names to include in the table grid.
    * If unspecified, all table columns are included.

--- a/packages/spec/src/spec/PlotFrom.ts
+++ b/packages/spec/src/spec/PlotFrom.ts
@@ -9,7 +9,7 @@ export type PlotDataInline = any[];
 /** Input data specification for a plot mark. */
 export interface PlotFrom {
   /** The name of the backing data table. */
-  from: string;
+  from: string | ParamRef;
   /** A selection that filters the mark data. */
   filterBy?: ParamRef;
   /**


### PR DESCRIPTION
- Add Param-value support for `from` table names in vgplot marks and table views. This change permits dynamic swapping of backing data tables at runtime, including among differently sized samples.