### PR TITLE
Add selection activation for inputs.

### DIFF
--- a/packages/core/src/SelectionClause.js
+++ b/packages/core/src/SelectionClause.js
@@ -26,7 +26,7 @@ export function clausePoint(field, value, {
 }) {
   /** @type {ExprNode | null} */
   const predicate = value !== undefined
-    ? isNotDistinct(field, literal(value))
+    ? isIn(field, [literal(value)])
     : null;
   return {
     meta: { type: 'point' },

--- a/packages/inputs/src/Menu.js
+++ b/packages/inputs/src/Menu.js
@@ -96,6 +96,12 @@ export class Menu extends MosaicClient {
             this.selectedValue(value);
           }
         });
+      } else {
+        // trigger selection activation
+        this.select.addEventListener('pointerenter', evt => {
+          if (!evt.buttons) this.activate();
+        });
+        this.select.addEventListener('focus', () => this.activate());
       }
     }
   }
@@ -116,6 +122,11 @@ export class Menu extends MosaicClient {
 
   reset() {
     this.select.selectedIndex = this.from ? 0 : -1;
+  }
+
+  activate() {
+    // @ts-ignore - activate is only called for a Selection
+    this.selection.activate(clausePoint(this.field, 0, { source: this }));
   }
 
   publish(value) {

--- a/packages/inputs/src/Search.js
+++ b/packages/inputs/src/Search.js
@@ -77,6 +77,12 @@ export class Search extends MosaicClient {
             this.searchbox.value = value;
           }
         });
+      } else {
+        // trigger selection activation
+        this.searchbox.addEventListener('pointerenter', evt => {
+          if (!evt.buttons) this.activate();
+        });
+        this.searchbox.addEventListener('focus', () => this.activate());
       }
     }
   }
@@ -85,11 +91,20 @@ export class Search extends MosaicClient {
     this.searchbox.value = '';
   }
 
+  clause(value) {
+    const { field, type } = this;
+    return clauseMatch(field, value, { source: this, method: type });
+  }
+
+  activate() {
+    // @ts-ignore - activate is only called for a Selection
+    this.selection.activate(this.clause(''));
+  }
+
   publish(value) {
-    const { selection, field, type } = this;
+    const { selection } = this;
     if (isSelection(selection)) {
-      const clause = clauseMatch(field, value, { source: this, method: type });
-      selection.update(clause);
+      selection.update(this.clause(value));
     } else if (isParam(selection)) {
       selection.update(value);
     }


### PR DESCRIPTION
- Add selection activation for inputs. Inputs trigger selection activation upon keyboard focus or pointer enter (when a drag is not in progress).