### PR TITLE
Fix dynamic column handling.

### DIFF
--- a/packages/plot/src/marks/Mark.js
+++ b/packages/plot/src/marks/Mark.js
@@ -1,5 +1,5 @@
 import { isParam, MosaicClient, toDataColumns } from '@uwdata/mosaic-core';
-import { Query, SelectQuery, collectParams, column, isAggregateExpression, isColumnRef, isNode, isParamLike } from '@uwdata/mosaic-sql';
+import { Query, SelectQuery, collectParams, column, isAggregateExpression, isColumnParam, isColumnRef, isNode, isParamLike } from '@uwdata/mosaic-sql';
 import { isColor } from './util/is-color.js';
 import { isConstantOption } from './util/is-constant-option.js';
 import { isSymbol } from './util/is-symbol.js';
@@ -15,7 +15,7 @@ const isFieldObject = (channel, field) => {
 const fieldEntry = (channel, field) => ({
   channel,
   field,
-  as: isColumnRef(field) ? field.column : channel
+  as: isColumnRef(field) && !isColumnParam(field) ? field.column : channel
 });
 const valueEntry = (channel, value) => ({ channel, value });
 

--- a/packages/sql/src/ast/column-param.js
+++ b/packages/sql/src/ast/column-param.js
@@ -1,6 +1,15 @@
 import { COLUMN_PARAM } from '../constants.js';
 import { ColumnRefNode } from './column-ref.js';
 
+/**
+ * Check if a value is a dynamic column reference node.
+ * @param {*} value The value to check.
+ * @returns {value is ColumnParamNode}
+ */
+export function isColumnParam(value) {
+  return value instanceof ColumnParamNode;
+}
+
 export class ColumnParamNode extends ColumnRefNode {
   /**
    * Instantiate a column param node.

--- a/packages/sql/src/index.js
+++ b/packages/sql/src/index.js
@@ -3,7 +3,7 @@ export { BetweenOpNode, NotBetweenOpNode } from './ast/between-op.js'
 export { BinaryOpNode } from './ast/binary-op.js';
 export { CaseNode, WhenNode } from './ast/case.js';
 export { CastNode } from './ast/cast.js';
-export { ColumnParamNode } from './ast/column-param.js';
+export { ColumnParamNode, isColumnParam } from './ast/column-param.js';
 export { ColumnRefNode, ColumnNameRefNode, isColumnRef } from './ast/column-ref.js';
 export { FragmentNode } from './ast/fragment.js';
 export { FromClauseNode } from './ast/from.js';

--- a/packages/sql/src/visit/visitors.js
+++ b/packages/sql/src/visit/visitors.js
@@ -1,4 +1,4 @@
-import { AGGREGATE, COLUMN_REF, FRAGMENT, PARAM, VERBATIM, WINDOW } from '../constants.js';
+import { AGGREGATE, COLUMN_PARAM, COLUMN_REF, FRAGMENT, PARAM, VERBATIM, WINDOW } from '../constants.js';
 import { aggregateNames, AggregateNode } from '../ast/aggregate.js';
 import { ColumnRefNode } from '../ast/column-ref.js';
 import { SQLNode } from '../ast/node.js';
@@ -82,7 +82,7 @@ export function collectAggregates(root) {
 export function collectColumns(root) {
   const cols = {};
   walk(root, (node) => {
-    if (node.type === COLUMN_REF) {
+    if (node.type === COLUMN_REF || node.type === COLUMN_PARAM) {
       cols[node] = node; // key on string-coerced node
     }
   });


### PR DESCRIPTION
- Fix dynamic column handling. Ensure column extraction includes column params. Within vgplot marks, do not use column name as alias if it is a dynamic param.

Close #610.