### PR TITLE
Add density 1D normalize option.

### DIFF
--- a/packages/plot/src/marks/Density1DMark.js
+++ b/packages/plot/src/marks/Density1DMark.js
@@ -1,6 +1,6 @@
 import { toDataColumns } from '@uwdata/mosaic-core';
 import { binLinear1d, isBetween } from '@uwdata/mosaic-sql';
-import { sum } from 'd3';
+import { max, sum } from 'd3';
 import { Transient } from '../symbols.js';
 import { binExpr } from './util/bin-expr.js';
 import { dericheConfig, dericheConv1d } from './util/density.js';
@@ -78,7 +78,7 @@ export class Density1DMark extends Mark {
     const b = this.channelField(dim).as;
     const b0 = +lo;
     const delta = (hi - b0) / (bins - 1);
-    const scale = 1 / (delta * (normalize ? sum(grid) : 1));
+    const scale = 1 / (delta * norm(grid, result, normalize));
 
     const _b = new Float64Array(bins);
     const _v = new Float64Array(bins);
@@ -99,4 +99,11 @@ export class Density1DMark extends Mark {
     }
     return [{ type, data: { length }, options }];
   }
+}
+
+function norm(grid, smoothed, type) {
+  const value = type === true || type === 'sum' ? sum(grid)
+    : type === 'max' ? max(smoothed)
+    : 1;
+  return value || 1;
 }

--- a/packages/plot/src/marks/Density1DMark.js
+++ b/packages/plot/src/marks/Density1DMark.js
@@ -1,5 +1,6 @@
 import { toDataColumns } from '@uwdata/mosaic-core';
 import { binLinear1d, isBetween } from '@uwdata/mosaic-sql';
+import { sum } from 'd3';
 import { Transient } from '../symbols.js';
 import { binExpr } from './util/bin-expr.js';
 import { dericheConfig, dericheConv1d } from './util/density.js';
@@ -10,7 +11,12 @@ import { Mark, channelOption, markQuery } from './Mark.js';
 
 export class Density1DMark extends Mark {
   constructor(type, source, options) {
-    const { bins = 1024, bandwidth = 20, ...channels } = options;
+    const {
+      bins = 1024,
+      bandwidth = 20,
+      normalize = false,
+      ...channels
+    } = options;
     const dim = type.endsWith('X') ? 'y' : 'x';
 
     super(type, source, channels, dim === 'x' ? xext : yext);
@@ -25,6 +31,11 @@ export class Density1DMark extends Mark {
     this.bandwidth = handleParam(bandwidth, value => {
       this.bandwidth = value;
       return this.grid ? this.convolve().update() : null;
+    });
+
+    /** @type {boolean} */
+    this.normalize = handleParam(normalize, value => {
+      return (this.normalize = value, this.convolve().update());
     });
   }
 
@@ -52,7 +63,9 @@ export class Density1DMark extends Mark {
   }
 
   convolve() {
-    const { bins, bandwidth, dim, grid, plot, extent: [lo, hi] } = this;
+    const {
+      bins, bandwidth, normalize, dim, grid, plot, extent: [lo, hi]
+    } = this;
 
     // perform smoothing
     const neg = grid.some(v => v < 0);
@@ -65,7 +78,7 @@ export class Density1DMark extends Mark {
     const b = this.channelField(dim).as;
     const b0 = +lo;
     const delta = (hi - b0) / (bins - 1);
-    const scale = 1 / delta;
+    const scale = 1 / (delta * (normalize ? sum(grid) : 1));
 
     const _b = new Float64Array(bins);
     const _v = new Float64Array(bins);

--- a/packages/spec/src/spec/marks/Density.ts
+++ b/packages/spec/src/spec/marks/Density.ts
@@ -46,10 +46,12 @@ export interface Density1DOptions {
   bins?: number | ParamRef;
 
   /**
-   * Flag indicating if density estimates should be normalized by dividing
-   * by the total point mass. Defaults to false.
+   * Normalization method for density estimates. If `false` or `'none'` (the
+   * default), the density estimates are smoothed weighted counts. If `true`
+   * or `'sum'`, density estimates are divided by the sum of the total point
+   * mass. If `'max'`, estimates are divided by the maximum smoothed value.
    */
-  normalize?: boolean | ParamRef;
+  normalize?: boolean | 'max' | 'sum' | 'none' | ParamRef;
 }
 
 export interface DensityAreaXOptions extends Omit<AreaXOptions, 'x' | 'x1' | 'x2'> {

--- a/packages/spec/src/spec/marks/Density.ts
+++ b/packages/spec/src/spec/marks/Density.ts
@@ -1,10 +1,10 @@
-import { ParamRef } from "../Param.js";
-import { AreaXOptions, AreaYOptions } from "./Area.js";
-import { DotOptions } from "./Dot.js";
-import { LineXOptions, LineYOptions } from "./Line.js";
-import { MarkData, MarkOptions, TextStyles } from "./Marks.js";
-import { Grid2DOptions } from "./Raster.js";
-import { TextOptions } from "./Text.js";
+import { ParamRef } from '../Param.js';
+import { AreaXOptions, AreaYOptions } from './Area.js';
+import { DotOptions } from './Dot.js';
+import { LineXOptions, LineYOptions } from './Line.js';
+import { MarkData, MarkOptions, TextStyles } from './Marks.js';
+import { Grid2DOptions } from './Raster.js';
+import { TextOptions } from './Text.js';
 
 // Density2D
 
@@ -44,6 +44,12 @@ export interface Density1DOptions {
    * Defaults to 1024.
    */
   bins?: number | ParamRef;
+
+  /**
+   * Flag indicating if density estimates should be normalized by dividing
+   * by the total point mass. Defaults to false.
+   */
+  normalize?: boolean | ParamRef;
 }
 
 export interface DensityAreaXOptions extends Omit<AreaXOptions, 'x' | 'x1' | 'x2'> {


### PR DESCRIPTION
- Add density 1D `normalize` option. If set to `true, scales density estimates by the total (weighted) point mass.

See also #606.