### PR TITLE
Support multiple 1D density estimates.

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -19,6 +19,7 @@
         <option value="bias">Bias Parameter</option>
         <option value="contours">Contours</option>
         <option value="crossfilter">Crossfilter</option>
+        <option value="density-groups">Density Groups</option>
         <option value="density1d">Density 1D</option>
         <option value="density2d">Density 2D</option>
         <option value="driving-shifts">Driving Shifts into Reverse</option>

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -145,6 +145,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { text: 'Contours', link: '/examples/contours' },
+            { text: 'Density Groups', link: '/examples/density-groups' },
             { text: 'Density 1D', link: '/examples/density1d' },
             { text: 'Density 2D', link: '/examples/density2d' },
             { text: 'Flights Density', link: '/examples/flights-density' },

--- a/docs/examples/density-groups.md
+++ b/docs/examples/density-groups.md
@@ -1,0 +1,18 @@
+<script setup>
+  import { coordinator } from '@uwdata/vgplot';
+  coordinator().clear();
+</script>
+
+# Density Groups
+
+Density plots of penguin bill depths, grouped by species. The normalize parameter supporting different forms of comparison, controlling if an individual density estimate is scaled by total point mass or normalized by the sum or max of the point mass. The stack and offset parameters control stacking of density areas.
+
+<Example spec="/specs/yaml/density-groups.yaml" />
+
+## Specification
+
+::: code-group
+<<< @/public/specs/esm/density-groups.js [JavaScript]
+<<< @/public/specs/yaml/density-groups.yaml [YAML]
+<<< @/public/specs/json/density-groups.json [JSON]
+:::

--- a/docs/examples/density-groups.md
+++ b/docs/examples/density-groups.md
@@ -5,7 +5,7 @@
 
 # Density Groups
 
-Density plots of penguin bill depths, grouped by species. The normalize parameter supporting different forms of comparison, controlling if an individual density estimate is scaled by total point mass or normalized by the sum or max of the point mass. The stack and offset parameters control stacking of density areas.
+Density plots of penguin bill depths, grouped by species. The normalize parameter supports different forms of comparison, controlling if an individual density estimate is scaled by total point mass or normalized by the sum or max of the point mass. The stack and offset parameters control stacking of density areas.
 
 <Example spec="/specs/yaml/density-groups.yaml" />
 

--- a/docs/public/specs/esm/density-groups.js
+++ b/docs/public/specs/esm/density-groups.js
@@ -1,0 +1,42 @@
+import * as vg from "@uwdata/vgplot";
+
+await vg.coordinator().exec([
+  vg.loadParquet("penguins", "data/penguins.parquet")
+]);
+
+const $bandwidth = vg.Param.value(20);
+const $normalize = vg.Param.value("none");
+const $stack = vg.Param.value(false);
+const $offset = vg.Param.value(null);
+
+export default vg.vconcat(
+  vg.hconcat(
+    vg.menu({label: "Normalize", as: $normalize, options: ["none", "sum", "max"]}),
+    vg.menu({label: "Stack", as: $stack, options: [false, true]}),
+    vg.menu({
+      label: "Offset",
+      as: $offset,
+      options: [
+      {label: "none", value: null},
+      {label: "normalize", value: "normalize"},
+      {label: "center", value: "center"}
+    ]
+    })
+  ),
+  vg.plot(
+    vg.densityY(
+      vg.from("penguins"),
+      {
+        x: "bill_depth",
+        fill: "species",
+        fillOpacity: 0.4,
+        bandwidth: $bandwidth,
+        normalize: $normalize,
+        stack: $stack,
+        offset: $offset
+      }
+    ),
+    vg.marginLeft(50),
+    vg.height(200)
+  )
+);

--- a/docs/public/specs/json/density-groups.json
+++ b/docs/public/specs/json/density-groups.json
@@ -1,0 +1,80 @@
+{
+  "meta": {
+    "title": "Density Groups",
+    "description": "Density plots of penguin bill depths, grouped by species. The normalize parameter supporting different forms of comparison, controlling if an individual density estimate is scaled by total point mass or normalized by the sum or max of the point mass. The stack and offset parameters control stacking of density areas.\n"
+  },
+  "data": {
+    "penguins": {
+      "file": "data/penguins.parquet"
+    }
+  },
+  "params": {
+    "bandwidth": 20,
+    "normalize": "none",
+    "stack": false,
+    "offset": null
+  },
+  "vconcat": [
+    {
+      "hconcat": [
+        {
+          "input": "menu",
+          "label": "Normalize",
+          "as": "$normalize",
+          "options": [
+            "none",
+            "sum",
+            "max"
+          ]
+        },
+        {
+          "input": "menu",
+          "label": "Stack",
+          "as": "$stack",
+          "options": [
+            false,
+            true
+          ]
+        },
+        {
+          "input": "menu",
+          "label": "Offset",
+          "as": "$offset",
+          "options": [
+            {
+              "label": "none",
+              "value": null
+            },
+            {
+              "label": "normalize",
+              "value": "normalize"
+            },
+            {
+              "label": "center",
+              "value": "center"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "plot": [
+        {
+          "mark": "densityY",
+          "data": {
+            "from": "penguins"
+          },
+          "x": "bill_depth",
+          "fill": "species",
+          "fillOpacity": 0.4,
+          "bandwidth": "$bandwidth",
+          "normalize": "$normalize",
+          "stack": "$stack",
+          "offset": "$offset"
+        }
+      ],
+      "marginLeft": 50,
+      "height": 200
+    }
+  ]
+}

--- a/docs/public/specs/json/density-groups.json
+++ b/docs/public/specs/json/density-groups.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "Density Groups",
-    "description": "Density plots of penguin bill depths, grouped by species. The normalize parameter supporting different forms of comparison, controlling if an individual density estimate is scaled by total point mass or normalized by the sum or max of the point mass. The stack and offset parameters control stacking of density areas.\n"
+    "description": "Density plots of penguin bill depths, grouped by species. The normalize parameter supports different forms of comparison, controlling if an individual density estimate is scaled by total point mass or normalized by the sum or max of the point mass. The stack and offset parameters control stacking of density areas.\n"
   },
   "data": {
     "penguins": {

--- a/docs/public/specs/yaml/density-groups.yaml
+++ b/docs/public/specs/yaml/density-groups.yaml
@@ -1,0 +1,44 @@
+meta:
+  title: Density Groups
+  description: >
+    Density plots of penguin bill depths, grouped by species.
+    The normalize parameter supporting different forms of comparison,
+    controlling if an individual density estimate is scaled by total point
+    mass or normalized by the sum or max of the point mass.
+    The stack and offset parameters control stacking of density areas.
+data:
+  penguins: { file: data/penguins.parquet }
+params:
+  bandwidth: 20
+  normalize: none
+  stack: false
+  offset: null
+vconcat:
+- hconcat:
+  - input: menu
+    label: Normalize
+    as: $normalize
+    options: [none, sum, max]
+  - input: menu
+    label: Stack
+    as: $stack
+    options: [false, true]
+  - input: menu
+    label: Offset
+    as: $offset
+    options:
+      - { label: none, value: null }
+      - { label: normalize, value: normalize }
+      - { label: center, value: center }
+- plot:
+  - mark: densityY
+    data: { from: penguins }
+    x: bill_depth
+    fill: species
+    fillOpacity: 0.4
+    bandwidth: $bandwidth
+    normalize: $normalize
+    stack: $stack
+    offset: $offset
+  marginLeft: 50
+  height: 200

--- a/docs/public/specs/yaml/density-groups.yaml
+++ b/docs/public/specs/yaml/density-groups.yaml
@@ -2,7 +2,7 @@ meta:
   title: Density Groups
   description: >
     Density plots of penguin bill depths, grouped by species.
-    The normalize parameter supporting different forms of comparison,
+    The normalize parameter supports different forms of comparison,
     controlling if an individual density estimate is scaled by total point
     mass or normalized by the sum or max of the point mass.
     The stack and offset parameters control stacking of density areas.

--- a/packages/inputs/src/Menu.js
+++ b/packages/inputs/src/Menu.js
@@ -39,14 +39,14 @@ export class Menu extends MosaicClient {
   constructor({
     element,
     filterBy,
+    as,
     from,
     column,
     label = column,
     format = x => x, // TODO
     options,
     value,
-    field = column,
-    as
+    field = column
   } = {}) {
     super(filterBy);
     this.from = from;
@@ -68,8 +68,8 @@ export class Menu extends MosaicClient {
 
     // if provided, populate menu options
     if (options) {
-      this.data = options.map(value => isObject(value) ? value : { value });
-      this.selectedValue(value ?? '');
+      this.data = options.map(opt => isObject(opt) ? opt : { value: opt });
+      this.selectedValue(value === undefined ? '' : value);
       this.update();
     }
 
@@ -174,7 +174,7 @@ export class Menu extends MosaicClient {
       const value = isSelection(selection)
         ? selection.valueFor(this)
         : selection.value;
-      this.selectedValue(value ?? '');
+      this.selectedValue(value === undefined ? '' : value);
     }
 
     return this;

--- a/packages/plot/src/marks/Density1DMark.js
+++ b/packages/plot/src/marks/Density1DMark.js
@@ -9,12 +9,15 @@ import { grid1d } from './util/grid.js';
 import { handleParam } from './util/handle-param.js';
 import { Mark, channelOption, markQuery } from './Mark.js';
 
+const GROUPBY = { fill: 1, stroke: 1, z: 1 };
+
 export class Density1DMark extends Mark {
   constructor(type, source, options) {
     const {
       bins = 1024,
       bandwidth = 20,
       normalize = false,
+      stack = false,
       ...channels
     } = options;
     const dim = type.endsWith('X') ? 'y' : 'x';
@@ -30,12 +33,17 @@ export class Density1DMark extends Mark {
     /** @type {number} */
     this.bandwidth = handleParam(bandwidth, value => {
       this.bandwidth = value;
-      return this.grid ? this.convolve().update() : null;
+      return this.grids ? this.convolve().update() : null;
+    });
+
+    /** @type {string | boolean} */
+    this.normalize = handleParam(normalize, value => {
+      return (this.normalize = value, this.convolve().update());
     });
 
     /** @type {boolean} */
-    this.normalize = handleParam(normalize, value => {
-      return (this.normalize = value, this.convolve().update());
+    this.stack = handleParam(stack, value => {
+      return (this.stack = value, this.update());
     });
   }
 
@@ -53,47 +61,66 @@ export class Density1DMark extends Mark {
     const q = markQuery(channels, this.sourceTable(), [dim])
       .where(filter.concat(isBetween(bx, extent)));
     const v = this.channelField('weight') ? 'weight' : null;
-    return binLinear1d(q, x, v);
+    const g = this.groupby = channels.flatMap(c => {
+      return (GROUPBY[c.channel] && c.field) ? c.as : [];
+    });
+    return binLinear1d(q, x, v, g);
   }
 
   queryResult(data) {
-    const { columns: { index, density } } = toDataColumns(data);
-    this.grid = grid1d(this.bins, index, density);
+    const c = toDataColumns(data).columns;
+    this.grids = grid1d(this.bins, c.index, c.density, c, this.groupby);
     return this.convolve();
   }
 
   convolve() {
     const {
-      bins, bandwidth, normalize, dim, grid, plot, extent: [lo, hi]
+      bins, bandwidth, normalize, dim, grids, groupby, plot, extent: [lo, hi]
     } = this;
 
-    // perform smoothing
-    const neg = grid.some(v => v < 0);
-    const size = dim === 'x' ? plot.innerWidth() : plot.innerHeight();
-    const config = dericheConfig(bandwidth * (bins - 1) / size, neg);
-    const result = dericheConv1d(config, grid, bins);
+    const cols = grids.columns;
+    const numGrids = grids.numRows;
 
-    // map smoothed grid values to sample data points
-    const v = dim === 'x' ? 'y' : 'x';
     const b = this.channelField(dim).as;
+    const v = dim === 'x' ? 'y' : 'x';
+    const size = dim === 'x' ? plot.innerWidth() : plot.innerHeight();
+    const neg = cols._grid.some(grid => grid.some(v => v < 0));
+    const config = dericheConfig(bandwidth * (bins - 1) / size, neg);
+
     const b0 = +lo;
     const delta = (hi - b0) / (bins - 1);
-    const scale = 1 / (delta * norm(grid, result, normalize));
 
-    const _b = new Float64Array(bins);
-    const _v = new Float64Array(bins);
-    for (let i = 0; i < bins; ++i) {
-      _b[i] = b0 + i * delta;
-      _v[i] = result[i] * scale;
+    const numRows = bins * numGrids;
+    const _b = new Float64Array(numRows);
+    const _v = new Float64Array(numRows);
+    const _g = groupby.reduce((m, name) => (m[name] = Array(numRows), m), {});
+
+    for (let k = 0, g = 0; g < numGrids; ++g) {
+      // fill in groupby values
+      groupby.forEach(name => _g[name].fill(cols[name][g], k, k + bins));
+
+      // perform smoothing, map smoothed grid values to sample data points
+      const grid = cols._grid[g];
+      const result = dericheConv1d(config, grid, bins);
+      const scale = 1 / norm(grid, result, delta, normalize);
+      for (let i = 0; i < bins; ++i, ++k) {
+        _b[k] = b0 + i * delta;
+        _v[k] = result[i] * scale;
+      }
     }
-    this.data = { numRows: bins, columns: { [b]: _b, [v]: _v } };
 
+    this.data = { numRows, columns: { [b]: _b, [v]: _v, ..._g } };
     return this;
   }
 
   plotSpecs() {
-    const { type, data: { numRows: length, columns }, channels, dim } = this;
-    const options = dim === 'x' ? { y: columns.y } : { x: columns.x };
+    const { type, data: { numRows: length, columns }, channels, dim, stack } = this;
+
+    // control if Plot's implicit stack transform is applied
+    // no stacking is done if x2/y2 are used instead of x/y
+    const _ = type.startsWith('area') && !stack ? '2' : '';
+    const options = dim === 'x' ? { [`y${_}`]: columns.y } : { [`x${_}`]: columns.x };
+
     for (const c of channels) {
       options[c.channel] = channelOption(c, columns);
     }
@@ -101,9 +128,9 @@ export class Density1DMark extends Mark {
   }
 }
 
-function norm(grid, smoothed, type) {
+function norm(grid, smoothed, delta, type) {
   const value = type === true || type === 'sum' ? sum(grid)
     : type === 'max' ? max(smoothed)
-    : 1;
+    : delta;
   return value || 1;
 }

--- a/packages/plot/src/marks/util/is-constant-option.js
+++ b/packages/plot/src/marks/util/is-constant-option.js
@@ -1,5 +1,7 @@
 const constantOptions = new Set([
+  'offset',
   'order',
+  'reverse',
   'sort',
   'label',
   'anchor',

--- a/packages/spec/src/spec/Param.ts
+++ b/packages/spec/src/spec/Param.ts
@@ -32,6 +32,7 @@ export interface ParamDate extends ParamBase {
 
 /** Literal Param values. */
 export type ParamLiteral =
+  | null
   | string
   | number
   | boolean;

--- a/packages/spec/src/spec/marks/Density.ts
+++ b/packages/spec/src/spec/marks/Density.ts
@@ -60,6 +60,11 @@ export interface DensityAreaXOptions extends Omit<AreaXOptions, 'x' | 'x1' | 'x2
    * areaX mark; lineX, dotX, and textX marks are also supported.
    */
   type: 'areaX';
+
+  /**
+   * Flag indicating if densities should be stacked. Defaults to false.
+   */
+  stack?: boolean | ParamRef;
 }
 
 export interface DensityAreaYOptions extends Omit<AreaYOptions, 'y' | 'y1' | 'y2'> {
@@ -68,6 +73,11 @@ export interface DensityAreaYOptions extends Omit<AreaYOptions, 'y' | 'y1' | 'y2
    * areaY mark; lineY, dot, and text marks are also supported.
    */
   type?: 'areaY';
+
+  /**
+   * Flag indicating if densities should be stacked. Defaults to false.
+   */
+  stack?: boolean | ParamRef;
 }
 
 export interface DensityLineXOptions extends Omit<LineXOptions, 'x' | 'x1' | 'x2'> {

--- a/packages/sql/src/transforms/bin-linear-1d.js
+++ b/packages/sql/src/transforms/bin-linear-1d.js
@@ -9,9 +9,10 @@ import { add, mul, neq, sub } from '../functions/operators.js';
  * @param {import('../ast/query.js').SelectQuery} query The base query to bin.
  * @param {import('../types.js').ExprValue} x The expression to bin.
  * @param {import('../types.js').ExprValue} [weight] The expression to weight by.
+ * @param {string[]} [groupby] Group by expressions.
  * @returns {Query}
  */
-export function binLinear1d(query, x, weight) {
+export function binLinear1d(query, x, weight = undefined, groupby = []) {
   const w = weight ? (x => mul(x, weight)) : (x => x);
   const p0 = floor(x);
   const p1 = add(p0, 1);
@@ -20,7 +21,7 @@ export function binLinear1d(query, x, weight) {
       query.clone().select({ i: int32(p0), w: w(sub(p1, x)) }),
       query.clone().select({ i: int32(p1), w: w(sub(x, p0)) })
     ))
-    .select({ index: 'i', density: sum('w') })
-    .groupby('index')
+    .select({ index: 'i', density: sum('w') }, groupby)
+    .groupby('index', groupby)
     .having(neq('density', 0));
 }

--- a/packages/sql/src/transforms/bin-linear-2d.js
+++ b/packages/sql/src/transforms/bin-linear-2d.js
@@ -26,11 +26,11 @@ function identity(x) {
  * @param {import('../types.js').ExprValue} yp The y grid bin expression
  * @param {import('../types.js').ExprValue | undefined} weight Point weights.
  * @param {number} xn The number of x grid bins.
- * @param {string[]} groupby Group by expressions.
+ * @param {string[]} [groupby] Group by expressions.
  * @returns {SelectQuery} A linear binning query for bin `index` and
  *  aggregate `density` columns, in addition to any group by expressions.
  */
-export function binLinear2d(q, xp, yp, weight, xn, groupby) {
+export function binLinear2d(q, xp, yp, weight, xn, groupby = []) {
 
   const w = weight ? x => mul(x, weight) : identity;
 

--- a/specs/esm/density-groups.js
+++ b/specs/esm/density-groups.js
@@ -1,0 +1,42 @@
+import * as vg from "@uwdata/vgplot";
+
+await vg.coordinator().exec([
+  vg.loadParquet("penguins", "data/penguins.parquet")
+]);
+
+const $bandwidth = vg.Param.value(20);
+const $normalize = vg.Param.value("none");
+const $stack = vg.Param.value(false);
+const $offset = vg.Param.value(null);
+
+export default vg.vconcat(
+  vg.hconcat(
+    vg.menu({label: "Normalize", as: $normalize, options: ["none", "sum", "max"]}),
+    vg.menu({label: "Stack", as: $stack, options: [false, true]}),
+    vg.menu({
+      label: "Offset",
+      as: $offset,
+      options: [
+      {label: "none", value: null},
+      {label: "normalize", value: "normalize"},
+      {label: "center", value: "center"}
+    ]
+    })
+  ),
+  vg.plot(
+    vg.densityY(
+      vg.from("penguins"),
+      {
+        x: "bill_depth",
+        fill: "species",
+        fillOpacity: 0.4,
+        bandwidth: $bandwidth,
+        normalize: $normalize,
+        stack: $stack,
+        offset: $offset
+      }
+    ),
+    vg.marginLeft(50),
+    vg.height(200)
+  )
+);

--- a/specs/json/density-groups.json
+++ b/specs/json/density-groups.json
@@ -1,0 +1,81 @@
+{
+  "meta": {
+    "title": "Density Groups",
+    "description": "Density plots of penguin bill depths, grouped by species. The normalize parameter supporting different forms of comparison, controlling if an individual density estimate is scaled by total point mass or normalized by the sum or max of the point mass. The stack and offset parameters control stacking of density areas.\n"
+  },
+  "data": {
+    "penguins": {
+      "type": "parquet",
+      "file": "data/penguins.parquet"
+    }
+  },
+  "params": {
+    "bandwidth": 20,
+    "normalize": "none",
+    "stack": false,
+    "offset": null
+  },
+  "vconcat": [
+    {
+      "hconcat": [
+        {
+          "input": "menu",
+          "label": "Normalize",
+          "as": "$normalize",
+          "options": [
+            "none",
+            "sum",
+            "max"
+          ]
+        },
+        {
+          "input": "menu",
+          "label": "Stack",
+          "as": "$stack",
+          "options": [
+            false,
+            true
+          ]
+        },
+        {
+          "input": "menu",
+          "label": "Offset",
+          "as": "$offset",
+          "options": [
+            {
+              "label": "none",
+              "value": null
+            },
+            {
+              "label": "normalize",
+              "value": "normalize"
+            },
+            {
+              "label": "center",
+              "value": "center"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "plot": [
+        {
+          "mark": "densityY",
+          "data": {
+            "from": "penguins"
+          },
+          "x": "bill_depth",
+          "fill": "species",
+          "fillOpacity": 0.4,
+          "bandwidth": "$bandwidth",
+          "normalize": "$normalize",
+          "stack": "$stack",
+          "offset": "$offset"
+        }
+      ],
+      "marginLeft": 50,
+      "height": 200
+    }
+  ]
+}

--- a/specs/json/density-groups.json
+++ b/specs/json/density-groups.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "Density Groups",
-    "description": "Density plots of penguin bill depths, grouped by species. The normalize parameter supporting different forms of comparison, controlling if an individual density estimate is scaled by total point mass or normalized by the sum or max of the point mass. The stack and offset parameters control stacking of density areas.\n"
+    "description": "Density plots of penguin bill depths, grouped by species. The normalize parameter supports different forms of comparison, controlling if an individual density estimate is scaled by total point mass or normalized by the sum or max of the point mass. The stack and offset parameters control stacking of density areas.\n"
   },
   "data": {
     "penguins": {

--- a/specs/ts/density-groups.ts
+++ b/specs/ts/density-groups.ts
@@ -3,7 +3,7 @@ import { Spec } from '@uwdata/mosaic-spec';
 export const spec : Spec = {
   "meta": {
     "title": "Density Groups",
-    "description": "Density plots of penguin bill depths, grouped by species. The normalize parameter supporting different forms of comparison, controlling if an individual density estimate is scaled by total point mass or normalized by the sum or max of the point mass. The stack and offset parameters control stacking of density areas.\n"
+    "description": "Density plots of penguin bill depths, grouped by species. The normalize parameter supports different forms of comparison, controlling if an individual density estimate is scaled by total point mass or normalized by the sum or max of the point mass. The stack and offset parameters control stacking of density areas.\n"
   },
   "data": {
     "penguins": {

--- a/specs/ts/density-groups.ts
+++ b/specs/ts/density-groups.ts
@@ -1,0 +1,82 @@
+import { Spec } from '@uwdata/mosaic-spec';
+
+export const spec : Spec = {
+  "meta": {
+    "title": "Density Groups",
+    "description": "Density plots of penguin bill depths, grouped by species. The normalize parameter supporting different forms of comparison, controlling if an individual density estimate is scaled by total point mass or normalized by the sum or max of the point mass. The stack and offset parameters control stacking of density areas.\n"
+  },
+  "data": {
+    "penguins": {
+      "file": "data/penguins.parquet"
+    }
+  },
+  "params": {
+    "bandwidth": 20,
+    "normalize": "none",
+    "stack": false,
+    "offset": null
+  },
+  "vconcat": [
+    {
+      "hconcat": [
+        {
+          "input": "menu",
+          "label": "Normalize",
+          "as": "$normalize",
+          "options": [
+            "none",
+            "sum",
+            "max"
+          ]
+        },
+        {
+          "input": "menu",
+          "label": "Stack",
+          "as": "$stack",
+          "options": [
+            false,
+            true
+          ]
+        },
+        {
+          "input": "menu",
+          "label": "Offset",
+          "as": "$offset",
+          "options": [
+            {
+              "label": "none",
+              "value": null
+            },
+            {
+              "label": "normalize",
+              "value": "normalize"
+            },
+            {
+              "label": "center",
+              "value": "center"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "plot": [
+        {
+          "mark": "densityY",
+          "data": {
+            "from": "penguins"
+          },
+          "x": "bill_depth",
+          "fill": "species",
+          "fillOpacity": 0.4,
+          "bandwidth": "$bandwidth",
+          "normalize": "$normalize",
+          "stack": "$stack",
+          "offset": "$offset"
+        }
+      ],
+      "marginLeft": 50,
+      "height": 200
+    }
+  ]
+};

--- a/specs/yaml/density-groups.yaml
+++ b/specs/yaml/density-groups.yaml
@@ -1,0 +1,44 @@
+meta:
+  title: Density Groups
+  description: >
+    Density plots of penguin bill depths, grouped by species.
+    The normalize parameter supporting different forms of comparison,
+    controlling if an individual density estimate is scaled by total point
+    mass or normalized by the sum or max of the point mass.
+    The stack and offset parameters control stacking of density areas.
+data:
+  penguins: { file: data/penguins.parquet }
+params:
+  bandwidth: 20
+  normalize: none
+  stack: false
+  offset: null
+vconcat:
+- hconcat:
+  - input: menu
+    label: Normalize
+    as: $normalize
+    options: [none, sum, max]
+  - input: menu
+    label: Stack
+    as: $stack
+    options: [false, true]
+  - input: menu
+    label: Offset
+    as: $offset
+    options:
+      - { label: none, value: null }
+      - { label: normalize, value: normalize }
+      - { label: center, value: center }
+- plot:
+  - mark: densityY
+    data: { from: penguins }
+    x: bill_depth
+    fill: species
+    fillOpacity: 0.4
+    bandwidth: $bandwidth
+    normalize: $normalize
+    stack: $stack
+    offset: $offset
+  marginLeft: 50
+  height: 200

--- a/specs/yaml/density-groups.yaml
+++ b/specs/yaml/density-groups.yaml
@@ -2,7 +2,7 @@ meta:
   title: Density Groups
   description: >
     Density plots of penguin bill depths, grouped by species.
-    The normalize parameter supporting different forms of comparison,
+    The normalize parameter supports different forms of comparison,
     controlling if an individual density estimate is scaled by total point
     mass or normalized by the sum or max of the point mass.
     The stack and offset parameters control stacking of density areas.


### PR DESCRIPTION
- Add groupby and stack support to `densityX` and `densityY` marks.
- Add `groupby` argument to `binLinear1D` SQL function.
- Add `density-groups` example.
- Expand param typing to accept `null` value.
- Fix `menu` input to support `null` values.