### PR TITLE
feat: add address arg for duckdb-server-rust

### DIFF
--- a/packages/duckdb-server-rust/src/app.rs
+++ b/packages/duckdb-server-rust/src/app.rs
@@ -34,6 +34,10 @@ async fn handle_get(
     }
 }
 
+pub const DEFAULT_DB_PATH: &str = ":memory:";
+pub const DEFAULT_CONNECTION_POOL_SIZE: u32 = 10;
+pub const DEFAULT_CACHE_SIZE: usize = 1000;
+
 #[axum::debug_handler]
 async fn handle_post(
     State(state): State<Arc<AppState>>,
@@ -49,10 +53,10 @@ pub fn app(
 ) -> Result<Router> {
     // Database and state setup
     let db = ConnectionPool::new(
-        dp_path.unwrap_or(":memory:"),
-        connection_pool_size.unwrap_or(10),
+        dp_path.unwrap_or(DEFAULT_DB_PATH),
+        connection_pool_size.unwrap_or(DEFAULT_CONNECTION_POOL_SIZE),
     )?;
-    let cache = lru::LruCache::new(cache_size.unwrap_or(1000).try_into()?);
+    let cache = lru::LruCache::new(cache_size.unwrap_or(DEFAULT_CACHE_SIZE).try_into()?);
 
     let state = Arc::new(AppState {
         db: Box::new(db),

--- a/packages/duckdb-server-rust/src/main.rs
+++ b/packages/duckdb-server-rust/src/main.rs
@@ -23,8 +23,8 @@ struct Args {
     database: String,
 
     /// HTTP Address
-    #[arg(short, long, default_value = "127.0.0.1")]
-    address: String,
+    #[arg(short, long, default_value_t = Ipv4Addr::LOCALHOST.into())]
+    address: IpAddr,
 
     /// HTTP Port
     #[arg(short, long, default_value_t = 3000)]
@@ -75,12 +75,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Listenfd setup
-    let addr = SocketAddr::new(
-        args.address
-            .parse::<IpAddr>()
-            .unwrap_or(Ipv4Addr::LOCALHOST.into()),
-        args.port,
-    );
+    let addr = SocketAddr::new(args.address, args.port);
     let mut listenfd = ListenFd::from_env();
     let listener = match listenfd.take_tcp_listener(0)? {
         // if we are given a tcp listener on listen fd 0, we use that one

--- a/packages/duckdb-server-rust/src/main.rs
+++ b/packages/duckdb-server-rust/src/main.rs
@@ -3,7 +3,7 @@ use axum_server::tls_rustls::RustlsConfig;
 use clap::Parser;
 use listenfd::ListenFd;
 use std::net::TcpListener;
-use std::{net::Ipv4Addr, net::SocketAddr, path::PathBuf};
+use std::{net::IpAddr, net::Ipv4Addr, net::SocketAddr, path::PathBuf};
 use tokio::net;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -21,6 +21,10 @@ struct Args {
     /// Path of database file (e.g., "database.db". ":memory:" for in-memory database)
     #[arg(default_value = ":memory:")]
     database: String,
+
+    /// HTTP Address
+    #[arg(short, long, default_value = "127.0.0.1")]
+    address: String,
 
     /// HTTP Port
     #[arg(short, long, default_value_t = 3000)]
@@ -71,7 +75,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Listenfd setup
-    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), args.port);
+    let addr = SocketAddr::new(
+        args.address
+            .parse::<IpAddr>()
+            .unwrap_or(Ipv4Addr::LOCALHOST.into()),
+        args.port,
+    );
     let mut listenfd = ListenFd::from_env();
     let listener = match listenfd.take_tcp_listener(0)? {
         // if we are given a tcp listener on listen fd 0, we use that one

--- a/packages/duckdb-server-rust/src/main.rs
+++ b/packages/duckdb-server-rust/src/main.rs
@@ -7,9 +7,9 @@ use std::{net::IpAddr, net::Ipv4Addr, net::SocketAddr, path::PathBuf};
 use tokio::net;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-use crate::app::DEFAULT_DB_PATH;
-use crate::app::DEFAULT_CONNECTION_POOL_SIZE;
 use crate::app::DEFAULT_CACHE_SIZE;
+use crate::app::DEFAULT_CONNECTION_POOL_SIZE;
+use crate::app::DEFAULT_DB_PATH;
 
 mod app;
 mod bundle;

--- a/packages/duckdb-server-rust/src/main.rs
+++ b/packages/duckdb-server-rust/src/main.rs
@@ -7,6 +7,10 @@ use std::{net::IpAddr, net::Ipv4Addr, net::SocketAddr, path::PathBuf};
 use tokio::net;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+use crate::app::DEFAULT_DB_PATH;
+use crate::app::DEFAULT_CONNECTION_POOL_SIZE;
+use crate::app::DEFAULT_CACHE_SIZE;
+
 mod app;
 mod bundle;
 mod cache;
@@ -19,7 +23,7 @@ mod websocket;
 #[command(version, about, long_about = None)]
 struct Args {
     /// Path of database file (e.g., "database.db". ":memory:" for in-memory database)
-    #[arg(default_value = ":memory:")]
+    #[arg(default_value = DEFAULT_DB_PATH)]
     database: String,
 
     /// HTTP Address
@@ -31,11 +35,11 @@ struct Args {
     port: u16,
 
     /// Max connection pool size
-    #[arg(long, default_value_t = 10)]
+    #[arg(long, default_value_t = DEFAULT_CONNECTION_POOL_SIZE)]
     connection_pool_size: u32,
 
     /// Max number of cache entries
-    #[arg(long, default_value_t = 1000)]
+    #[arg(long, default_value_t = DEFAULT_CACHE_SIZE)]
     cache_size: usize,
 }
 


### PR DESCRIPTION
Add `--address` as part of CLI arguments. The default is `127.0.0.1` and if parsing the given value fails, it falls back to `Ipv4Addr::LOCALHOST`

```
> ./duckdb-server --help                       
DuckDB Server for Mosaic.

Usage: duckdb-server [OPTIONS] [DATABASE]

Arguments:
  [DATABASE]  Path of database file (e.g., "database.db". ":memory:" for in-memory database) [default: :memory:]

Options:
  -a, --address <ADDRESS>                            HTTP Address [default: 127.0.0.1]
  -p, --port <PORT>                                  HTTP Port [default: 3000]
      --connection-pool-size <CONNECTION_POOL_SIZE>  Max connection pool size [default: 10]
      --cache-size <CACHE_SIZE>                      Max number of cache entries [default: 1000]
  -h, --help                                         Print help
  -V, --version                                      Print version
```