### PR TITLE
feat: improve restConnector error handling

### DIFF
--- a/packages/core/src/connectors/rest.js
+++ b/packages/core/src/connectors/rest.js
@@ -21,9 +21,16 @@ export function restConnector(uri = 'http://localhost:3000/') {
         body: JSON.stringify(query)
       });
 
+
+      const res = await req;
+
+      if (!res.ok) {
+        throw new Error(`Query failed with HTTP status ${res.status}: ${await res.text()}`);
+      }
+
       return query.type === 'exec' ? req
-        : query.type === 'arrow' ? decodeIPC(await (await req).arrayBuffer())
-        : (await req).json();
+        : query.type === 'arrow' ? decodeIPC(await res.arrayBuffer())
+        : res.json();
     }
   };
 }


### PR DESCRIPTION
The Rust server sends error messages to the client if the query fails (e.g., SQL syntax error, incorrect column name).
However, the current `restConnector` does not handle the error message from the server and tries to parse the response just based on the request type.

This PR adds a check whether the response was successful. If the response is not [`ok`](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok), then it throws an error with the response text that contains the error messages from the server.

With this change, `queryError` receives an Error instance with the error message from the server.

The error message format could be improved. 