### PR TITLE
feat: Add publish package

### DIFF
--- a/packages/inputs/src/Menu.js
+++ b/packages/inputs/src/Menu.js
@@ -1,6 +1,6 @@
-import { MosaicClient, Param, isParam, isSelection, clausePoint } from '@uwdata/mosaic-core';
+import { Param, isParam, isSelection, clausePoint } from '@uwdata/mosaic-core';
 import { Query } from '@uwdata/mosaic-sql';
-import { input } from './input.js';
+import { input, Input } from './input.js';
 
 const isObject = v => {
   return v && typeof v === 'object' && !Array.isArray(v);
@@ -8,7 +8,7 @@ const isObject = v => {
 
 export const menu = options => input(Menu, options);
 
-export class Menu extends MosaicClient {
+export class Menu extends Input {
   /**
    * Create a new menu input.
    * @param {object} [options] Options object
@@ -125,8 +125,7 @@ export class Menu extends MosaicClient {
   }
 
   activate() {
-    // @ts-ignore - activate is only called for a Selection
-    this.selection.activate(clausePoint(this.field, 0, { source: this }));
+    if (isSelection(this.selection)) this.selection.activate(clausePoint(this.field, 0, { source: this }));
   }
 
   publish(value) {

--- a/packages/inputs/src/Search.js
+++ b/packages/inputs/src/Search.js
@@ -1,12 +1,12 @@
-import { MosaicClient, Param, isParam, isSelection, clauseMatch } from '@uwdata/mosaic-core';
+import { Param, isParam, isSelection, clauseMatch } from '@uwdata/mosaic-core';
 import { Query } from '@uwdata/mosaic-sql';
-import { input } from './input.js';
+import { input, Input } from './input.js';
 
 let _id = 0;
 
 export const search = options => input(Search, options);
 
-export class Search extends MosaicClient {
+export class Search extends Input {
   /**
    * Create a new text search input.
    * @param {object} [options] Options object
@@ -97,8 +97,7 @@ export class Search extends MosaicClient {
   }
 
   activate() {
-    // @ts-ignore - activate is only called for a Selection
-    this.selection.activate(this.clause(''));
+    if (isSelection(this.selection)) this.selection.activate(this.clause(''));
   }
 
   publish(value) {

--- a/packages/inputs/src/Slider.js
+++ b/packages/inputs/src/Slider.js
@@ -1,12 +1,12 @@
-import { MosaicClient, Param, clauseInterval, clausePoint, isParam, isSelection } from '@uwdata/mosaic-core';
+import { Param, clauseInterval, clausePoint, isParam, isSelection } from '@uwdata/mosaic-core';
 import { Query, max, min } from '@uwdata/mosaic-sql';
-import { input } from './input.js';
+import { input, Input } from './input.js';
 
 let _id = 0;
 
 export const slider = options => input(Slider, options);
 
-export class Slider extends MosaicClient {
+export class Slider extends Input {
   /**
    * Create a new slider input.
    * @param {object} [options] Options object
@@ -165,8 +165,7 @@ export class Slider extends MosaicClient {
   }
 
   activate() {
-    // @ts-ignore - activate is only called for a Selection
-    this.selection.activate(this.clause(0));
+    if (isSelection(this.selection)) this.selection.activate(this.clause(0));
   }
 
   publish(value) {

--- a/packages/inputs/src/Table.js
+++ b/packages/inputs/src/Table.js
@@ -1,13 +1,13 @@
-import { MosaicClient, clausePoints, coordinator, isParam, toDataColumns } from '@uwdata/mosaic-core';
+import { clausePoints, coordinator, isParam, toDataColumns } from '@uwdata/mosaic-core';
 import { Query, desc } from '@uwdata/mosaic-sql';
 import { formatDate, formatLocaleAuto, formatLocaleNumber } from './util/format.js';
-import { input } from './input.js';
+import { input, Input } from './input.js';
 
 let _id = -1;
 
 export const table = options => input(Table, options);
 
-export class Table extends MosaicClient {
+export class Table extends Input {
   /**
    * Create a new Table instance.
    * @param {object} options Options object
@@ -206,6 +206,23 @@ export class Table extends MosaicClient {
 
     this.isPending = false;
     return this;
+  }
+
+  activate() {
+    const { data } = this;
+    const n = data.length - 1;
+
+    const { numRows } = data[n];
+
+    for (let i = 0; i < numRows; i++) {
+      this.currentRow = i;
+      this.selection.update(this.clause([i]));
+    }
+    
+    if (numRows > 0) {
+      this.currentRow = -1;
+      this.selection.update(this.clause());
+    }
   }
 
   sort(event, column) {

--- a/packages/inputs/src/input.js
+++ b/packages/inputs/src/input.js
@@ -1,4 +1,24 @@
-import { coordinator } from '@uwdata/mosaic-core';
+ 
+// TODO: change this to be at same level as MosaicClient to avoid duplicate in interactors
+import { coordinator, MosaicClient } from '@uwdata/mosaic-core';
+
+/**
+ * Base class for all inputs.
+ * This class should not be instantiated directly.
+ */
+export class Input extends MosaicClient {
+  constructor(filterBy) {
+    super(filterBy);
+  }
+
+  /**
+   * Activates the input.
+   * @throws {Error} If the method is not implemented by the subclass.
+   */
+  activate() {
+    throw new Error('activate method must be implemented by subclass');
+  }
+}
 
 export function input(InputClass, options) {
   const input = new InputClass(options);

--- a/packages/plot/src/interactors/Highlight.js
+++ b/packages/plot/src/interactors/Highlight.js
@@ -2,6 +2,7 @@ import { throttle } from '@uwdata/mosaic-core';
 import { and, isAggregateExpression } from '@uwdata/mosaic-sql';
 import { getDatum } from './util/get-datum.js';
 import { sanitizeStyles } from './util/sanitize-styles.js';
+import { Interactor } from './Interactor.js';
 
 function configureMark(mark) {
   const { channels } = mark;
@@ -34,12 +35,12 @@ function configureMark(mark) {
   return mark;
 }
 
-export class Highlight {
+export class Highlight extends Interactor {
   constructor(mark, {
     selection,
     channels = {}
   }) {
-    this.mark = configureMark(mark);
+    super(configureMark(mark));
     this.selection = selection;
     const c = Object.entries(sanitizeStyles(channels));
     this.channels = c.length ? c : [['opacity', 0.2]];
@@ -79,6 +80,10 @@ export class Highlight {
         node.setAttribute(attr, t ? base[j] : value);
       }
     }
+  }
+
+  activate() {
+    return this.update();
   }
 }
 

--- a/packages/plot/src/interactors/Interactor.js
+++ b/packages/plot/src/interactors/Interactor.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-unused-vars */
+// TODO: change this to be at same level as MosaicClient to avoid duplicate in inputs
+
+/**
+ * Base class for all interactors.
+ * This class should not be instantiated directly.
+ */
+export class Interactor {
+    constructor(mark) {
+        this.mark = mark;
+    }
+
+    /**
+     * Initializes the interactor.
+     * @param {SVGElement} svg - The SVG element.
+     * @throws {Error} If the method is not implemented by the subclass.
+     */
+    init(svg) {
+      throw new Error('init method must be implemented by subclass');
+    }
+  
+    /**
+     * Activates the interactor.
+     * @throws {Error} If the method is not implemented by the subclass.
+     */
+    activate() {
+      throw new Error('activate method must be implemented by subclass');
+    }
+  }

--- a/packages/plot/src/interactors/Interval1D.js
+++ b/packages/plot/src/interactors/Interval1D.js
@@ -5,8 +5,9 @@ import { closeTo } from './util/close-to.js';
 import { getField } from './util/get-field.js';
 import { invert } from './util/invert.js';
 import { sanitizeStyles } from './util/sanitize-styles.js';
+import { Interactor } from './Interactor.js';
 
-export class Interval1D {
+export class Interval1D extends Interactor {
   constructor(mark, {
     channel,
     selection,
@@ -15,7 +16,7 @@ export class Interval1D {
     peers = true,
     brush: style
   }) {
-    this.mark = mark;
+    super(mark);
     this.channel = channel;
     this.pixelSize = pixelSize || 1;
     this.selection = selection;

--- a/packages/plot/src/interactors/Interval2D.js
+++ b/packages/plot/src/interactors/Interval2D.js
@@ -5,8 +5,9 @@ import { closeTo } from './util/close-to.js';
 import { getField } from './util/get-field.js';
 import { invert } from './util/invert.js';
 import { sanitizeStyles } from './util/sanitize-styles.js';
+import { Interactor } from './Interactor.js';
 
-export class Interval2D {
+export class Interval2D extends Interactor {
   constructor(mark, {
     selection,
     xfield,
@@ -15,7 +16,7 @@ export class Interval2D {
     peers = true,
     brush: style
   }) {
-    this.mark = mark;
+    super(mark);
     this.pixelSize = pixelSize || 1;
     this.selection = selection;
     this.peers = peers;

--- a/packages/plot/src/interactors/Nearest.js
+++ b/packages/plot/src/interactors/Nearest.js
@@ -1,8 +1,9 @@
 import { clausePoint, clausePoints, isSelection } from '@uwdata/mosaic-core';
 import { select, pointer, min } from 'd3';
 import { getField } from './util/get-field.js';
+import { Interactor } from './Interactor.js';
 
-export class Nearest {
+export class Nearest extends Interactor {
   constructor(mark, {
     selection,
     pointer,
@@ -10,7 +11,7 @@ export class Nearest {
     fields,
     maxRadius = 40
   }) {
-    this.mark = mark;
+    super(mark);
     this.selection = selection;
     this.clients = new Set().add(mark);
     this.pointer = pointer;
@@ -71,11 +72,13 @@ export class Nearest {
 
     // trigger activation updates
     svg.addEventListener('pointerenter', evt => {
-      if (!evt.buttons) {
-        const v = this.channels.map(() => 0);
-        selection.activate(this.clause(v));
-      }
+      if (!evt.buttons) this.activate();
     });
+  }
+
+  activate() {
+    const v = this.channels.map(() => 0);
+    this.selection.activate(this.clause(v));
   }
 }
 

--- a/packages/plot/src/interactors/PanZoom.js
+++ b/packages/plot/src/interactors/PanZoom.js
@@ -1,10 +1,11 @@
 import { Selection, clauseInterval } from '@uwdata/mosaic-core';
 import { select, zoom, ZoomTransform } from 'd3';
 import { getField } from './util/get-field.js';
+import { Interactor } from './Interactor.js';
 
 const asc = (a, b) => a - b;
 
-export class PanZoom {
+export class PanZoom extends Interactor {
   constructor(mark, {
     x = new Selection(),
     y = new Selection(),
@@ -14,7 +15,7 @@ export class PanZoom {
     panx = true,
     pany = true
   }) {
-    this.mark = mark;
+    super(mark);
     this.xsel = x;
     this.ysel = y;
     this.xfield = xfield || getField(mark, 'x');
@@ -59,7 +60,7 @@ export class PanZoom {
     this.svg = svg;
     if (this.initialized) return; else this.initialized = true;
 
-    const { panx, pany, mark: { plot: { element } }, xsel, ysel } = this;
+    const { panx, pany, mark: { plot: { element } }} = this;
 
     this.xscale = svg.scale('x');
     this.yscale = svg.scale('y');
@@ -85,17 +86,20 @@ export class PanZoom {
       let enter = false;
       element.addEventListener('pointerenter', evt => {
         if (enter) return; else enter = true;
-        if (evt.buttons) return; // don't activate if mouse down
-        if (panx) {
-          const { xscale, xfield } = this;
-          xsel.activate(this.clause(xscale.domain, xfield, xscale));
-        }
-        if (pany) {
-          const { yscale, yfield } = this;
-          ysel.activate(this.clause(yscale.domain, yfield, yscale));
-        }
+        if (!evt.buttons) this.activate(); // don't activate if mouse down
       });
       element.addEventListener('pointerleave', () => enter = false);
+    }
+  }
+
+  activate() {
+    if (this.panx) {
+      const { xscale, xfield } = this;
+      this.xsel.activate(this.clause(xscale.domain, xfield, xscale));
+    }
+    if (this.pany) {
+      const { yscale, yfield } = this;
+      this.ysel.activate(this.clause(yscale.domain, yfield, yscale));
     }
   }
 }

--- a/packages/plot/src/interactors/Region.js
+++ b/packages/plot/src/interactors/Region.js
@@ -7,8 +7,9 @@ import { patchScreenCTM } from './util/patchScreenCTM.js';
 import { sanitizeStyles } from './util/sanitize-styles.js';
 import { neqSome } from './util/neq.js';
 import { getDatum } from './util/get-datum.js';
+import { Interactor } from './Interactor.js';
 
-export class Region {
+export class Region extends Interactor {
   constructor(mark, {
     channels,
     selection,
@@ -19,7 +20,7 @@ export class Region {
       strokeDasharray: '1,1'
     }
   }) {
-    this.mark = mark;
+    super(mark);
     this.selection = selection;
     this.peers = peers;
 

--- a/packages/plot/src/interactors/Toggle.js
+++ b/packages/plot/src/interactors/Toggle.js
@@ -1,8 +1,9 @@
 import { clausePoints } from '@uwdata/mosaic-core';
 import { getDatum } from './util/get-datum.js';
 import { neq, neqSome } from './util/neq.js';
+import { Interactor } from './Interactor.js';
 
-export class Toggle {
+export class Toggle extends Interactor {
   /**
    * @param {*} mark The mark to interact with.
    * @param {*} options The interactor options.
@@ -12,8 +13,8 @@ export class Toggle {
     channels,
     peers = true
   }) {
+    super(mark)
     this.value = null;
-    this.mark = mark;
     this.selection = selection;
     this.peers = peers;
     const fields = this.fields = [];
@@ -75,9 +76,12 @@ export class Toggle {
     });
 
     svg.addEventListener('pointerenter', evt => {
-      if (evt.buttons) return;
-      this.selection.activate(this.clause([this.fields.map(() => 0)]));
+      if (!evt.buttons) this.activate();
     });
+  }
+
+  activate() {
+    this.selection.activate(this.clause([this.fields.map(() => 0)]));
   }
 }
 

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -1,0 +1,27 @@
+# mosaic-publish TODO: Adjust this doc 
+
+A CLI tool for compiling and optimizing specifications. The tool processes spec files, handles dataset optimizations, and provides a configurable way to manage different compile and optimization tasks.
+
+## Installation
+
+This tool is designed to be used via `npx` or can be installed globally.
+
+### Run with `npx`
+
+```bash
+npx @uwdata/publish --spec ./path/to/spec.json
+```
+
+### Global Installation
+
+To install the CLI tool globally:
+
+```bash
+npm install -g @uwdata/publish
+```
+
+Now you can run the tool from anywhere:
+
+```bash
+mosaic-publish --spec ./path/to/spec.json
+```

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@uwdata/publish",
+  "version": "1.0.0",
+  "description": "CLI tool for spec optimization",
+  "main": "dist/index.js",
+  "bin": {
+    "mosaic-publish": "./dist/publish/src/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "chalk": "^4.1.2",
+    "skia-canvas": "^2.0.2",
+    "yargs": "^17.7.2"
+  },
+  "devDependencies": {
+    "@types/jsdom": "^21.1.7",
+    "@types/yargs": "^17.0.33",
+    "typescript": "^5.6.3"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module"
+}

--- a/packages/publish/src/MosaicPublisher.ts
+++ b/packages/publish/src/MosaicPublisher.ts
@@ -1,0 +1,315 @@
+import yaml from "yaml";
+import fs from 'fs';
+import { JSDOM } from 'jsdom';
+import chalk from 'chalk';
+import path from "path";
+
+// Mosaic modules
+import { 
+  parseSpec, astToESM, astToDOM, 
+  SpecNode, DataNode, FileDataNode, 
+  ParquetDataNode, OptionsNode, 
+  CodegenContext, 
+  QueryDataNode,
+} from '@uwdata/mosaic-spec';
+import { ExprNode, ColumnNameRefNode } from '@uwdata/mosaic-sql';
+import { MosaicClient } from '../../vgplot/src/index.js';
+import { Interactor } from '@uwdata/mosaic-plot/src/interactors/Interactor.js';
+import { Input } from '@uwdata/mosaic-inputs/src/input.js';
+
+// Utility imports
+import { 
+  clientsReady, htmlTemplate, mockCanvas, 
+  publishConnector, PublishContext, templateCSS, VGPLOT,
+  LogLevel, Logger,
+  preamble
+} from './util/index.js';
+
+/**
+ * Class to facilitate publishing a Mosaic specification.
+ * @param specPath Path to the Mosaic specification file.
+ * @param outputPath Path to the desired output directory.
+ * @param title Optional title for the HTML file.
+ * @param optimize Level of optimization for published visualization.
+ * @param logLevel Desired logging level (debug, info, warn, error, silent)
+ * 
+ * The `publish` method is the main entry point for the class
+ */
+export class MosaicPublisher {
+  private specPath: string;
+  private outputPath: string;
+  private title?: string;
+  private optimize: 'minimal' | 'more' | 'most';
+  private logger: Logger;
+
+  // Internal references used throughout
+  private ctx: PublishContext;
+  private ast?: SpecNode;
+  private data?: Record<string, DataNode>;
+  
+  constructor(
+    specPath: string, 
+    outputPath: string, 
+    title: string | undefined, 
+    optimize: 'minimal' | 'more' | 'most',
+    logLevel: LogLevel
+  ) {
+    this.specPath = specPath;
+    this.outputPath = outputPath;
+    this.title = title;
+    this.optimize = optimize;
+
+    // Create our logger instance
+    this.logger = new Logger(logLevel);
+
+    // Create PublishContext
+    const connector = publishConnector();
+    this.ctx = new PublishContext(connector);
+    if (logLevel !== 'debug') {
+      this.ctx.coordinator.logger(false);
+    }
+  }
+
+  /**
+   * Main entry point for publishing a Mosaic specification.
+   */
+  public async publish() {
+    this.logger.info(chalk.cyan('Parsing and processing specification...'));
+    
+    // Parse specification
+    this.parseSpecification();
+    if (!this.ast) return;
+    this.data = this.ast.data;
+
+    // If spec is valid create relevant output directory
+    if (fs.existsSync(this.outputPath)) {
+      this.logger.debug(`Removing existing directory: ${this.outputPath}`);
+      fs.rmSync(this.outputPath, { recursive: true });
+    }
+    this.logger.debug(`Creating directory: ${this.outputPath}`);
+    fs.mkdirSync(this.outputPath, { recursive: true });
+    
+    // Setup jsdom
+    this.logger.debug('Setting up jsdom environment...');
+    const dom = new JSDOM(
+      `<!DOCTYPE html><body></body>`,
+      { pretendToBeVisual: true }
+    );
+    globalThis.window = dom.window as any;
+    globalThis.document = dom.window.document;
+    globalThis.navigator ??= dom.window.navigator;
+    globalThis.requestAnimationFrame = window.requestAnimationFrame;
+    mockCanvas(globalThis.window);
+
+    // Load the visualization in the DOM and gather interactors/inputs
+    // TODO: fix type issue with astToDOM to remove the any cast
+    const { element } = await astToDOM(this.ast, {api: this.ctx.api} as any);
+    document.body.appendChild(element);
+    this.logger.debug('Waiting for clients to be ready...');
+    await clientsReady(this.ctx);
+
+    const { interactors, inputs, tables } = this.processClients();
+    const isInteractive = interactors.size + inputs.size !== 0;
+    
+    if (isInteractive) {
+      // Activate interactors and inputs
+      this.logger.info(chalk.cyan('Activating interactive elements...'));
+      await this.activateInteractorsAndInputs(interactors, inputs);
+
+      // Modify AST and process data (extensions, data definitions, etc.)
+      const og = FileDataNode.prototype.codegenQuery;
+      FileDataNode.prototype.codegenQuery = function(ctx: CodegenContext) {
+        const code = og.call(this, ctx);
+        const { file } = this;
+        return code?.replace(`"${file}"`, `window.location.origin + "/${file}"`);
+      };
+      this.logger.debug('Updating data nodes...');
+      await this.updateDataNodes(tables);
+
+      // Export relevant data from DuckDB to Parquet
+      this.logger.info(chalk.cyan('Exporting data to Parquet...'));
+      await this.exportDataFromDuckDB(tables);
+    }
+
+    this.logger.info(chalk.cyan('Writing output files...'));
+    this.writeFiles(isInteractive, element);
+  }
+
+  private parseSpecification() {
+    try {
+      const specFile = fs.readFileSync(this.specPath, 'utf-8');
+      this.ast = parseSpec(yaml.parse(specFile));
+    } catch (e) {
+      console.error('Error parsing spec:', e);
+      process.exit(1);
+    }
+  }
+
+  private processClients() {
+    this.logger.debug('--------------- Clients ---------------');
+
+    const interactors = new Set<Interactor>();
+    const inputs = new Set<Input>();
+    const tables: Record<string, Set<string>> = {};
+
+    for (const client of this.ctx.coordinator.clients) {
+      this.logger.debug(client.constructor.name);
+      if (client instanceof MosaicClient) {
+        const fields = client.fields();
+        if (fields) {
+          for (const field of fields) {
+            const { table, column } = field;
+            if (!(table in tables)) tables[table] = new Set();
+            if (column instanceof ExprNode) {
+              if (column instanceof ColumnNameRefNode) {
+                tables[table].add(column.column);
+              }
+            } else {
+              tables[table].add(column);
+            }
+          }
+        }
+      }
+      if (client instanceof Input) {
+        inputs.add(client);
+        
+        const input = client as any; // TODO: change Input class to make this cleaner
+        if (input.from && input.column) {
+          if (!(input.from in tables)) tables[input.from] = new Set();
+          tables[input.from].add(input.column);
+        }
+      }
+      if (client.plot) {
+        for (const interactor of client.plot.interactors) {
+          interactors.add(interactor);
+        }
+      }
+    }
+    return { interactors, inputs, tables };
+  }
+
+  /**
+   * Activate the Interactors and Inputs, waiting 
+   * for queries to finish.
+   */
+  private async activateInteractorsAndInputs(interactors: Set<Interactor>, inputs: Set<Input>) {
+    this.logger.debug('--------------- Activating ---------------');
+    for (const interactor of interactors) {
+      this.logger.debug(interactor.constructor.name);
+      interactor.activate();
+      await this.waitForQueryToFinish();
+    }
+
+    for (const input of inputs) {
+      this.logger.debug(input.constructor.name);
+      input.activate();
+      await this.waitForQueryToFinish();
+    }
+  }
+
+  private async waitForQueryToFinish() {
+    while (this.ctx.coordinator.manager.pendingExec) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+
+  /**
+   * Process data definitions (DataNodes) and converts them to ParquetDataNode
+   * objects based on specified tables.
+   */
+  private async updateDataNodes(tables: Record<string, Set<string>>) {
+    // process data definitions
+    for (const node of Object.values(this.data!)) {
+      if (!(node.name in tables)) {
+        delete this.ast!.data[node.name];
+        continue;
+      }
+      const name = node.name;
+      const file = `data/${name}.parquet`;
+      this.ast!.data[name] = new ParquetDataNode(name, file, new OptionsNode({}));
+    }
+
+    // process tables from DuckDB
+    const db_tables = await this.ctx.coordinator.query('SHOW ALL TABLES', { type: 'json' });
+    if (db_tables.some((table: any) => table.name.startsWith('preagg_'))) {
+      this.ast!.data['schema'] = new SchemaCreateNode('schema', 'mosaic');
+      for (const table of db_tables) {
+        if (table.name.startsWith('preagg_')) {
+          const name = `${table.schema}.${table.name}`;
+          tables[name] = new Set(table.column_names);
+          const file = `data/.mosaic/${table.name}.parquet`;
+          this.ast!.data[name] = new ParquetDataNode(name, file, new OptionsNode({}));
+        }
+      }
+    }
+  }
+
+  /**
+   * Write out the index.js, index.html, and create data/ directory as needed.
+   */
+  private writeFiles(isInteractive: boolean, element?: HTMLElement | SVGElement) {
+    const code = astToESM(this.ast!, {
+      connector: 'wasm',
+      imports: new Map([[VGPLOT, '* as vg']]),
+      preamble: this.optimize == 'most' ? preamble : undefined
+    });
+    const html = htmlTemplate(isInteractive, this.title, element, templateCSS);
+
+    fs.writeFileSync(path.join(this.outputPath, 'index.html'), html);
+    if (isInteractive) {
+      fs.writeFileSync(path.join(this.outputPath, 'index.js'), code);
+    }
+  }
+
+  /**
+   * Export relevant data from DuckDB to local Parquet
+   */
+  private async exportDataFromDuckDB(tables: Record<string, Set<string>>) {
+    const copy_queries: string[] = [];
+    for (const node of Object.values(this.data!)) {
+      if (!(node instanceof ParquetDataNode)) continue;
+      const table = node.name;
+      const file = node.file;
+      const relevant_columns = tables[table];
+      if (relevant_columns.size === 0) {
+        this.logger.debug(`No relevant columns found for table ${table}`);
+        continue;
+      }
+
+      let query: string;
+      switch (this.optimize) {
+        case 'minimal':
+          query = `COPY (SELECT * FROM ${table}) TO '${this.outputPath}/${file}' (FORMAT PARQUET)`;
+          break;
+        case 'more':
+        case 'most':
+          query = `COPY (SELECT ${Array.from(relevant_columns).join(', ')} FROM ${table}) TO '${this.outputPath}/${file}' (FORMAT PARQUET)`;
+          break;
+        default:
+          throw new Error(`Invalid optimization level: ${this.optimize}`);
+      }
+      copy_queries.push(query);
+    }
+
+    if (copy_queries.length > 0) {
+      // TODO: Make the following conditionally on data needs
+      fs.mkdirSync(path.join(this.outputPath, 'data'), { recursive: true });
+      fs.mkdirSync(path.join(this.outputPath, 'data/.mosaic'), { recursive: true });
+
+      await this.ctx.coordinator.exec(copy_queries);
+    }
+  }
+}
+
+class SchemaCreateNode extends QueryDataNode {
+  schema: string;
+
+  constructor(name: string, schema: string) {
+    super(name, "schema");
+    this.schema = schema;
+  }
+
+  public codegenQuery(ctx: CodegenContext) {
+    return `'CREATE SCHEMA IF NOT EXISTS ${this.schema};'`;
+  }
+}

--- a/packages/publish/src/index.ts
+++ b/packages/publish/src/index.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { MosaicPublisher } from './MosaicPublisher.js';
+import { LogLevel } from './util/index.js';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import chalk from 'chalk';
+
+interface CliArgs {
+  spec: string;
+  optimize: 'minimal' | 'more' | 'most';
+  output?: string;
+  title?: string;
+  logLevel: LogLevel;
+}
+
+// Build the command-line parser without using the yargs type parameter:
+const parsed = yargs(hideBin(process.argv))
+  .scriptName('mosaic-publish')
+  .usage('$0 [args]')
+  .options({
+    spec: {
+      alias: 's',
+      type: 'string',
+      describe: 'Path to the specification file',
+      demandOption: true,
+    },
+    optimize: {
+      alias: 'o',
+      type: 'string',
+      describe: 'Level of optimizations',
+      choices: ['minimal', 'more', 'most'] as const,
+      default: 'minimal',
+    },
+    output: {
+      alias: 'out',
+      type: 'string',
+      describe: 'Output folder path for the result',
+    },
+    title: {
+      alias: 't',
+      type: 'string',
+      describe: 'Title of published visualization',
+    },
+    logLevel: {
+      alias: 'l',
+      type: 'string',
+      describe: 'Logging level (debug, info, warn, error, silent)',
+      choices: ['debug', 'info', 'warn', 'error', 'silent'] as const,
+      default: 'info'
+    }
+  })
+  .help()
+  .parseSync();
+
+// Cast the results to our interface
+const argv: CliArgs = {
+  spec: parsed.spec,
+  optimize: parsed.optimize as 'minimal' | 'more' | 'most',
+  output: parsed.output,
+  title: parsed.title,
+  logLevel: parsed.logLevel as LogLevel
+};
+
+// Provide user-facing pretty-print statements
+console.log(chalk.bold.blue('Spec file:'), chalk.yellowBright(argv.spec));
+console.log(chalk.bold.blue('Optimize:'), chalk.yellowBright(argv.optimize));
+console.log(chalk.bold.blue('Output:'), chalk.yellowBright(argv.output ?? 'out/'));
+if (argv.title) {
+  console.log(chalk.bold.blue('Title:'), chalk.yellowBright(argv.title));
+}
+
+// Instantiate the publisher
+const publisher = new MosaicPublisher(
+  argv.spec, 
+  argv.output ?? 'out', 
+  argv.title, 
+  argv.optimize, 
+  argv.logLevel
+);
+
+// Execute publishing in an async context
+(async () => {
+  try {
+    console.log(chalk.cyan('Publishing visualization...'));
+    await publisher.publish();
+    console.log(chalk.bold.green('✔ Publish complete!'));
+  } catch (err) {
+    console.error(chalk.red('An error occurred while publishing:'), err);
+    process.exit(1);
+  }
+})();

--- a/packages/publish/src/util/Logger.ts
+++ b/packages/publish/src/util/Logger.ts
@@ -1,0 +1,25 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent';
+export class Logger {
+  constructor(private level: LogLevel) {}
+
+  debug(...args: unknown[]) {
+    if (this.level === 'debug') {
+      console.log(...args);
+    }
+  }
+  info(...args: unknown[]) {
+    if (this.level === 'debug' || this.level === 'info') {
+      console.log(...args);
+    }
+  }
+  warn(...args: unknown[]) {
+    if (['debug','info','warn'].includes(this.level)) {
+      console.warn(...args);
+    }
+  }
+  error(...args: unknown[]) {
+    if (this.level !== 'silent') {
+      console.error(...args);
+    }
+  }
+}

--- a/packages/publish/src/util/constants.ts
+++ b/packages/publish/src/util/constants.ts
@@ -1,0 +1,171 @@
+export const htmlTemplate = (isInteractive: boolean, title?: string, element?: HTMLElement | SVGElement, css = templateCSS) => `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>${title ?? 'Mosaic Visualization'}</title>
+</head>
+<body>
+  <article class="mosaic">
+    ${isInteractive ? '<div class="ssr"></div>' : ''}
+    ${element?.outerHTML ?? ''}
+  </article>
+</body>
+${isInteractive ? `
+<script type="module">
+  import {default as visualization, clientsReady} from './index.js';
+
+  clientsReady().then(() => {
+    document.querySelector('.mosaic')?.replaceChildren(visualization);
+  });
+</script>` : ''}
+${css}
+</html>`;
+
+export const templateCSS =`<style>
+.mosaic {
+  position: relative;
+  margin-top: 1.5em;
+  margin-bottom: 1em;
+}
+
+.mosaic .ssr {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  cursor: not-allowed;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.mosaic .plot,
+.mosaic .legend,
+.mosaic .legend svg {
+  background: none !important;
+  line-height: initial;
+  user-select: none;
+}
+
+.mosaic .plot-d6a7b5 {
+  background: none !important;
+}
+
+.mosaic label {
+  margin-right: 0.5em;
+}
+
+.mosaic .input {
+  margin-right: 1em;
+}
+
+.mosaic .input > * {
+  vertical-align: middle;
+}
+
+.mosaic select {
+  -webkit-appearance: auto;
+  appearance: auto;
+}
+
+.mosaic button,
+.mosaic input,
+.mosaic optgroup,
+.mosaic select,
+.mosaic textarea {
+  padding: revert;
+  border: revert;
+}
+
+.mosaic input[type=text] {
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  padding-left: 4px;
+}
+
+.mosaic table {
+  display: table;
+  position: relative;
+  table-layout: fixed;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-variant-numeric: tabular-nums;
+  box-sizing: border-box;
+  max-width: initial;
+  min-height: 33px;
+  margin: 0;
+  width: 100%;
+  font-size: 13px;
+  line-height: 15.6px;
+}
+
+.mosaic thead tr th {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  cursor: ns-resize;
+  border-bottom: solid 1px #ccc;
+}
+
+.dark .mosaic thead tr th {
+  background: rgb(30, 30, 32);
+  border-bottom: solid 1px #444;
+}
+
+.mosaic tbody tr:hover {
+  background: #eef;
+}
+
+.dark .mosaic tbody tr:hover {
+  background: #224;
+}
+
+.mosaic th {
+  color: #111;
+  text-align: left;
+  vertical-align: bottom;
+}
+
+.mosaic td,
+.mosaic th {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  padding: 3px 6.5px 3px 0;
+}
+
+.dark .mosaic td,
+.dark .mosaic th {
+  color: #ccc;
+}
+
+.mosaic tbody tr:first-child td {
+  padding-top: 4px;
+}
+
+.mosaic td,
+.mosaic th {
+  border: none
+}
+
+.mosaic td,
+.mosaic tr:not(:last-child) th {
+  border-bottom: solid 1px #eee;
+}
+
+.dark .mosaic td,
+.dark .mosaic tr:not(:last-child) th {
+  border-bottom: solid 1px #333;
+}
+
+.mosaic td {
+  color: #444;
+  vertical-align: top;
+}
+</style>`;
+
+export const VGPLOT = 'https://cdn.jsdelivr.net/npm/@uwdata/vgplot@latest/dist/vgplot.js';
+
+// TODO: switch this to ./renderHelpers version when changes pushed to npm
+// Currently, this is hack to see when clients are ready use .pending when it is available
+export const preamble = `export function clientsReady() {
+  const clients = [...vg.coordinator().clients];
+  return Promise.allSettled(clients.map(c => c.initialize()))
+}`

--- a/packages/publish/src/util/index.ts
+++ b/packages/publish/src/util/index.ts
@@ -1,0 +1,4 @@
+export * from './constants.js';
+export * from './publishHelpers.js';
+export * from './renderHelpers.js';
+export * from './Logger.js';

--- a/packages/publish/src/util/publishHelpers.ts
+++ b/packages/publish/src/util/publishHelpers.ts
@@ -1,0 +1,36 @@
+import { Coordinator, decodeIPC } from "@uwdata/mosaic-core";
+import { DuckDB } from "@uwdata/mosaic-duckdb";
+import { InstantiateContext } from "@uwdata/mosaic-spec";
+import { createAPIContext } from "../../../vgplot/src/index.js";
+
+export function publishConnector() {
+  const db = new DuckDB();
+  db.exec('PRAGMA force_compression=Uncompressed');
+
+  type Query = {
+    type: 'exec' | 'arrow' | 'json';
+    sql: string;
+  }
+
+  return {
+    query: async (query: Query) => {
+      const { type, sql } = query;
+      switch (type) {
+        case 'exec':
+          return db.exec(sql);
+        case 'arrow':
+          return decodeIPC(await db.arrowBuffer(sql));
+        default:
+          return db.query(sql);
+      }
+    }
+  };
+}
+
+export class PublishContext extends InstantiateContext {
+  constructor(connector: any) {
+    const coordinator = new Coordinator(connector);
+    const api = createAPIContext({ coordinator });
+    super({ api });
+  }
+}

--- a/packages/publish/src/util/renderHelpers.ts
+++ b/packages/publish/src/util/renderHelpers.ts
@@ -1,0 +1,32 @@
+import { MosaicClient } from "@uwdata/mosaic-core/src/MosaicClient.js";
+import { InstantiateContext } from "@uwdata/mosaic-spec";
+import { Canvas } from "skia-canvas";
+
+export function mockCanvas (window: any) {
+    const og = window.document.createElement
+    window.document.createElement = function (tagName: string) {
+        if (tagName !== 'canvas') {
+            return og.call(this, tagName)
+        } else {
+            const canvas = new Canvas();
+            const el = og.call(this, tagName) as HTMLCanvasElement;
+            // TODO: this is a hack to get around the fact that the canvas is not a real canvas
+            el.getContext = canvas.getContext.bind(canvas) as unknown as HTMLCanvasElement['getContext'];
+            el.toDataURL = canvas.toDataURLSync.bind(canvas);
+            const set = el.setAttribute;
+            el.setAttribute = function (name: string, value: string) {
+                if (name !== 'width' && name !== 'height') {
+                    set.call(this, name, value);
+                } else {
+                    canvas[name] = parseInt(value);
+                }
+            }
+            return el;
+        }
+    }
+}
+
+export function clientsReady(ctx: InstantiateContext) {
+  const clients = [...ctx.coordinator.clients] as MosaicClient[];
+  return Promise.allSettled(clients.map(c => c.pending));
+}

--- a/packages/publish/tsconfig.json
+++ b/packages/publish/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "include": ["src/**/*.js", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "allowJs": true,
+    "outDir": "dist/",
+    "declaration": true,
+    "strict": true,
+    "moduleResolution": "Node16",
+    "module": "Node16",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+  },
+}


### PR DESCRIPTION
This PR contains and MVP for the new `Publish` CLI tool that will be used to transform YAML/JSON specs into shippable visualizations.

## Current Changes:
- Introduced `Input` and `Interactor` base classes, refactored `Menu`, `Search`, `Slider`, `Table`, and all interactors to extend from these for consistent activation behavior (added common interface for `activate` function).
- Added `mosaic-publish` CLI tool for compiling and optimizing specs, handling data export, interactivity, and optimizations.

## TODOs:
- [ ] Add more user control over optimization params/streamline current user control (selective dataset inclusion, DuckDB export settings, granular optimization flags, etc.).
- [ ] Refactor duplicated logic between `MosaicClient` and new base classes. Namely combine both base classes into one base class that discribes any activatable client.
    - Open Question: Where should this be created since these span multiple `packages`
- [ ] Expand README and add tests for CLI and utilities
- Add further optimization and improve upon current optimizations:
    - Namely work on better pre-rendering + hydration
    - Automatic Tiling implementation
    - Cache hydration
    - Smart spec re-writing
    - etc.

## Open Questions:
- Should `Input` and `Interactor` remain separate or be unified?
- How should we handle interactive pre-rendered visualizations before data is loaded?
- Are there any better/other output formats we shoudl support?
- Is the current way of handling dependencies correct (w/o relative reference to package and instead using npm version)?