### PR TITLE
fix: don't crash client when the coordinator has been removed

### DIFF
--- a/packages/core/src/MosaicClient.js
+++ b/packages/core/src/MosaicClient.js
@@ -122,7 +122,7 @@ export class MosaicClient {
    */
   requestQuery(query) {
     const q = query || this.query(this.filterBy?.predicate(this));
-    return this._coordinator.requestQuery(this, q);
+    return this._coordinator?.requestQuery(this, q);
   }
 
   /**
@@ -140,7 +140,7 @@ export class MosaicClient {
    * @returns {Promise}
    */
   initialize() {
-    return this._coordinator.initializeClient(this);
+    return this._coordinator?.initializeClient(this);
   }
 
   /**


### PR DESCRIPTION
When the client is disconnected, the coordinator does not exist anymore but queries may still come back. We should try not to crash.