### PR TITLE
Order connected mark by output name, not input field.

### DIFF
--- a/packages/plot/src/marks/ConnectedMark.js
+++ b/packages/plot/src/marks/ConnectedMark.js
@@ -39,7 +39,7 @@ export class ConnectedMark extends Mark {
         .filter(c => c !== as && c !== value);
       return m4(q, expr, as, value, cols);
     } else {
-      return q.orderby(field);
+      return q.orderby(as);
     }
   }
 }


### PR DESCRIPTION
- Fix connected marks (`lineY`, `areaX`, etc) by ordering points using the output column name, not the input field. This allows downstream optimizations like preaggregation to work as they should.

Close #676.