### PR TITLE
Add Aggregate Function `geomean` (mosaic-sql)

### DIFF
--- a/docs/api/sql/aggregate-functions.md
+++ b/docs/api/sql/aggregate-functions.md
@@ -99,6 +99,12 @@ Create an aggregate function that calculates the sum of the input _expression_.
 
 Create an aggregate function that calculates the product of the input _expression_.
 
+## geomean
+
+`geomean(expression)`
+
+Create an aggregate function that calculates the geometric mean of the input _expression_.
+
 ## median
 
 `median(expression)`

--- a/packages/core/src/preagg/sufficient-statistics.js
+++ b/packages/core/src/preagg/sufficient-statistics.js
@@ -1,4 +1,4 @@
-import { AggregateNode, and, argmax, argmin, count, div, ExprNode, isNotNull, max, min, mul, pow, regrAvgX, regrAvgY, regrCount, sql, sqrt, sub, sum } from '@uwdata/mosaic-sql';
+import { AggregateNode, and, argmax, argmin, count, div, ExprNode, isNotNull, max, min, mul, pow, product, regrAvgX, regrAvgY, regrCount, sql, sqrt, sub, sum } from '@uwdata/mosaic-sql';
 import { fnv_hash } from '../util/hash.js';
 
 /**
@@ -18,6 +18,8 @@ export function sufficientStatistics(node, preagg, avg) {
       return sumExpr(preagg, node);
     case 'avg':
       return avgExpr(preagg, node);
+    case 'geomean':
+      return geomeanExpr(preagg, node);
     case 'arg_max':
       return argmaxExpr(preagg, node);
     case 'arg_min':
@@ -153,6 +155,21 @@ function avgExpr(preagg, node) {
   const as = addStat(preagg, node);
   const { expr, name } = countExpr(preagg, node);
   return div(sum(mul(as, name)), expr);
+}
+
+/**
+ * Generate an expression for calculating geometric means over data dimensions.
+ * As a side effect, this method adds a column to the input *preagg* object
+ * to track the count of non-null values per-partition.
+ * @param {Record<string, ExprNode>} preagg A map of columns (such as
+ *  sufficient statistics) to pre-aggregate.
+ * @param {AggregateNode} [node] The originating aggregate function call.
+ * @returns {ExprNode} An aggregate expression over pre-aggregated dimensions.
+ */
+function geomeanExpr(preagg, node) {
+  const as = addStat(preagg, node);
+  const { expr, name } = countExpr(preagg, node);
+  return pow(product(pow(as, name)), div(1, expr));
 }
 
 /**

--- a/packages/core/test/preaggregator.test.js
+++ b/packages/core/test/preaggregator.test.js
@@ -64,7 +64,7 @@ describe('PreAggregator', () => {
   it('supports geomean aggregate', async () => {
     const [result, optimized] = await run(geomean('x'));
 
-    expect(result).toBeCloseTo(Math.pow(12, 1 / 2), 10);
+    expect(result).toBeCloseTo(Math.sqrt(12), 10);
     expect(optimized).toBe(true);
   });
 

--- a/packages/core/test/preaggregator.test.js
+++ b/packages/core/test/preaggregator.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { Query, add, argmax, argmin, avg, corr, count, covarPop, covariance, gt, isNotDistinct, literal, loadObjects, max, min, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, stddev, stddevPop, sum, varPop, variance } from '@uwdata/mosaic-sql';
+import { Query, add, argmax, argmin, avg, corr, count, covarPop, covariance, geomean, gt, isNotDistinct, literal, loadObjects, max, min, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, stddev, stddevPop, sum, varPop, variance } from '@uwdata/mosaic-sql';
 import { Coordinator, Selection } from '../src/index.js';
 import { nodeConnector } from './util/node-connector.js';
 import { TestClient } from './util/test-client.js';
@@ -59,6 +59,13 @@ describe('PreAggregator', () => {
 
   it('supports avg aggregate', async () => {
     expect(await run(avg('x'))).toStrictEqual([3.5, true]);
+  });
+
+  it('supports geomean aggregate', async () => {
+    const [result, optimized] = await run(geomean('x'));
+
+    expect(result).toBeCloseTo(Math.pow(12, 1 / 2), 10);
+    expect(optimized).toBe(true);
   });
 
   it('supports min aggregate', async () => {

--- a/packages/spec/src/config/transforms.js
+++ b/packages/spec/src/config/transforms.js
@@ -18,6 +18,7 @@ export function transformNames(overrides = []) {
     'dateMonthDay',
     'dateDay',
     'first',
+    'geomean',
     'geojson',
     'last',
     'max',

--- a/packages/spec/src/spec/Transform.ts
+++ b/packages/spec/src/spec/Transform.ts
@@ -229,6 +229,14 @@ export interface First extends AggregateOptions, WindowOptions {
   first: Arg1;
 }
 
+/* A geometric mean aggregate transform. */
+export interface Geomean extends AggregateOptions, WindowOptions {
+  /**
+   * Compute the geometric mean value of the given column.
+   */
+  first: Arg1;
+}
+
 /* A last aggregate transform. */
 export interface Last extends AggregateOptions, WindowOptions {
   /**

--- a/packages/spec/src/spec/Transform.ts
+++ b/packages/spec/src/spec/Transform.ts
@@ -234,7 +234,7 @@ export interface Geomean extends AggregateOptions, WindowOptions {
   /**
    * Compute the geometric mean value of the given column.
    */
-  first: Arg1;
+  geomean: Arg1;
 }
 
 /* A last aggregate transform. */

--- a/packages/sql/src/functions/aggregate.js
+++ b/packages/sql/src/functions/aggregate.js
@@ -99,6 +99,15 @@ export function first(expr) {
 }
 
 /**
+ * Compute a geomean aggregate.
+ * @param {import('../types.js').ExprValue} expr The expression to aggregate.
+ * @returns {AggregateNode} A SQL aggregate function call.
+ */
+export function geomean(expr) {
+  return aggFn('geomean', expr);
+}
+
+/**
  * Compute a sample kurtosis aggregate.
  * @param {import('../types.js').ExprValue} expr The expression to aggregate.
  * @returns {AggregateNode} A SQL aggregate function call.

--- a/packages/sql/src/index.js
+++ b/packages/sql/src/index.js
@@ -24,7 +24,7 @@ export { VerbatimNode } from './ast/verbatim.js';
 export { WindowClauseNode, WindowDefNode, WindowFrameNode, WindowFunctionNode, WindowNode } from './ast/window.js';
 export { WithClauseNode } from './ast/with.js';
 
-export { argmax, argmin, arrayAgg, avg, corr, count, covariance, covarPop, entropy, first, kurtosis, mad, max, median, min, mode, last, product, quantile, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, skewness, stddev, stddevPop, stringAgg, sum, variance, varPop } from './functions/aggregate.js';
+export { argmax, argmin, arrayAgg, avg, corr, count, covariance, covarPop, entropy, first, geomean, kurtosis, mad, max, median, min, mode, last, product, quantile, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, skewness, stddev, stddevPop, stringAgg, sum, variance, varPop } from './functions/aggregate.js';
 export { cond } from './functions/case.js';
 export { cast, float32, float64, int32 } from './functions/cast.js';
 export { column } from './functions/column.js';

--- a/packages/sql/test/aggregate.test.js
+++ b/packages/sql/test/aggregate.test.js
@@ -1,6 +1,6 @@
 import { expect, describe, it } from 'vitest';
 import { columns } from './util/columns.js';
-import { argmax, argmin, arrayAgg, avg, column, corr, count, covariance, covarPop, entropy, first, gt, kurtosis, last, mad, max, median, min, mode, product, quantile, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSlope, regrSXX, regrSXY, regrSYY, skewness, stddev, stddevPop, stringAgg, sum, variance, varPop } from '../src/index.js';
+import { argmax, argmin, arrayAgg, avg, column, corr, count, covariance, covarPop, entropy, first, geomean, gt, kurtosis, last, mad, max, median, min, mode, product, quantile, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSlope, regrSXX, regrSXY, regrSYY, skewness, stddev, stddevPop, stringAgg, sum, variance, varPop } from '../src/index.js';
 
 describe('Aggregate functions', () => {
   it('include accessible metadata', () => {
@@ -61,6 +61,10 @@ describe('Aggregate functions', () => {
 
   it('include first', () => {
     expect(String(first('foo'))).toBe('first("foo")');
+  });
+
+  it('include geomean', () => {
+    expect(String(geomean('foo'))).toBe('geomean("foo")');
   });
 
   it('include kurtosis', () => {

--- a/packages/vgplot/src/api.js
+++ b/packages/vgplot/src/api.js
@@ -28,6 +28,7 @@ export {
   covarPop,
   entropy,
   first,
+  geomean,
   kurtosis,
   mad,
   max,


### PR DESCRIPTION
This pull request introduces a new aggregate function — `geomean` — to the `mosaic-sql` package for computing the geometric mean.

### What does this pull request cover?

- Add `geomean` aggregate function
- Add preaggregation handling (in `sufficient-statistics.js`)
- Add tests (in `preaggregator.test.js` and `aggregate.test.js`)
- Update documentation

### What is missing?

The JSON schema file has not yet been updated.
It is currently unclear whether this file will be auto-generated or if a manual modification is required.