### PR TITLE
chore: losen `duckdb` dependency for Pyodide compatibility

### DIFF
--- a/packages/widget/pyproject.toml
+++ b/packages/widget/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "anywidget>=0.9.0",
-  "duckdb>=1.1.3",
+  "duckdb>=1.1.2",
   "pyarrow"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -960,7 +960,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anywidget", specifier = ">=0.9.0" },
-    { name = "duckdb", specifier = ">=1.1.3" },
+    { name = "duckdb", specifier = ">=1.1.2" },
     { name = "pyarrow" },
 ]
 


### PR DESCRIPTION
Currently, it is not possible to directly `%pip install mosaic-widget` in a Pyodide environment, since Pyodide distributes `duckdb==1.1.2` while `mosaic-widget` requires `duckdb>=1.1.3`.

This PR would make it easier to work on issues such as #624 which explore Python notebook-based web intergrations of Mosaic.

For example, to create [Marimo based Spec Playground](https://marimo.app/#code/JYWwDg9gTgLgBCAhlUEBQaD6mDmBTAOzykRjwBNMB3YGACzgF44AiABgDoBGLjgJhZpEYMEwTJUHAIIiAFAEoMaAALCwHAMZ4ANttl1g5PJg0QjjACpQArnkVGAZnEyyQEeQC40cHwggcQclkoFlCAYjgAWQgAZ0RgDQ84AAUAT3oIAjgAdTwAIxTtRFScKAhrAnJQlkVfOCg8GGsoAiVVEU0dPQMjEzM8Sxs7NEdnVwgAGjgYsDwNTBBGxHJSRE9vXxm5zHIysHIIKizmNw5rYA5diH3DglkNup9rmGBMmMYAb0WYRABtFgIiEWLAAuklvn8WIZQXAHNAEEs4MAslt5hCVj8AL4TB6PABuiG0tkYqIWSwxfzYIP+gOBIJxj18RTyOkYAHIAMo6ObwABqwBi1kJwAAXqRXgQ2bjaptZvMrjcjriGk0WnBZKSFQcjhNFBh2uotLp9IZjKZzFZbPY8E4XNE4glsoZ8DApjFuRoyJRUes6vb4honeQXRqPV7MD7lY1mq19WpOsaemb+oMrUIYqkCBo4KMXA5Gho6AtYgGI3KpgArGKZKYNavaPHGTWrN1ynZ7bUEX2bMMUMtzMSIKjxeD5mCF4sO+aojVtrW3DgEonDOpDkf1PD1xv9+WrUPaHl9yN1CJSBxkKCwgsGAg4HOrWFlEBwZB5WgkKCpOB0GAwMAxOAAFUACUABkpioPA4DAUhCzgegoNReCIA3LcoIQuBtAgDRCWg0g6A4OALAMACBWmaxZkvchgFgL88mseB3TwEAAJgFCqGgABrOAaHoBBkVAXCbThWAYg4XF3QPT0jzlMQq0yDgsOWGJZHkghLmscAVMkw9vTleQOAaMAii0WQ2R-P8Yg8AB6ay2Smczf3-Gy2XkGUfBVGN1R06S9LmXU2njI1ulNPoLSGRREAzLMcxtMYxwnNwpx3MkfgpbsfAiAAxa9N3gugoIcaxdGmWTtAFF5bxfADHGRCgkSyawqApaykoDDdIAktt0QfZg11oK9xyLNqEhSnqfgUKNVSyWdtnGxAArjDpgpNXpzQGS1hlzcYMr8AIghCcIIkAl5ypeTdqncjdpsC5aulW5NwrTba8hiAAWKYYPocq8k+1IzFNXaAHEAAlMAAYQAEQAOUwAAhKQOQAUUwEDQLEe5GR8FgLOc2ySCoDgcFoOhrHo90oFMAgyGpzQIBAaympakaNGshoHBiayCuU1r4gIazBDqPVcSizNs1GBLhpLUa63KSm8GCPBIEwBxgAPJIYhgKBdrqaocqGvKCbgKmaZgACICcAADIyIBVtW8Etx96fyqD-QSDqIGqXE6jrQdhwGsB-uoowOFxjhA8l2QHBYD5QYhmH4cRlG0cxayPhtu2D0xGpvd8OtDPid0VegCMfiaFSrp96M1TrJRV2i8W4slydS1JeaFC8LHWFCJGCE04hSDywltBd2K3FKuYALyL8YKgGJkTvDCTcIM24AtuBLaMPFrORIwAA9Q5gEBtEtr2u9JcrNYXzAf2Pv310xrvfH60drxbmXNzl0yWC3nfKjwA+t9tA5y7gZMge8YCTXPuUUQzBXpvQ4HDPAiAGLACKtoDkMDZrzEvpVHAN8j7aCmDjQh4dkAUxAVjTyapfi50ZB8KEVQkjPAlP8JcthQTENpHgFgzCwAvAUuAmAmI6GPBEmvfhEoGrTBgRwVWlRZCGEYCwABQJjIXQMvIygw9ZAsBYZkShT8kROH0epIRHBNYoDAFArGII67PwbrFJwzcWY7mwZgQwGstY618HrXKrECrG0yKbc2TgkKmmpmg4A9Vp4b1JIYR2UU4AACkOQAHloZnyoXlPq-tX5DXfvMWWzRTLR1RJzNSad4nkExBwNShjHjUKyC-VCdTqx3GFvXMWTjUIQAbE2Oce5URJGop6Hx2NQj60LHlDCqsDwAXZsQQgWhyDSPKVkxk4ifh5APGsuU-wKSgkXISWwFdO5GOMawOZPDpHbPVqIru1zuFeMvMwO5eB-jXNBA8rGFJ3QwEwM0EezBH4XKxg4RylkbLWVMHPMAZQ96pA4K8ayAB+IFnwnlAjwJiKUYKu5oNhPbbhFifiiV4nQXRuMGn4t8Dod0sIY5xyhrDBGyNUZgUxB8LFixs4-MZJXC58LkSQOjoAcGpADwf3ASGtwlLUSqty4l2Ls6CqMX8xomAvoMGYFqn6HBkj4SjkqxYqqn6EvVQCrVHAAEVTOfyp+wrqZRxYIAXg3ABDO3AD4FrNX4UxLCcolRMLYWHqkN0nFgAiAXjS2lQTIl9zwPauo3rp5kAArkh+iasYtMDgDEOYcI7XlkN6oFprQEcBTZuGxtLvVWtnivAInFqJQFkHW6m7xNpTBtZrTAEBOKphXDGmt+EOBUBQGQTAFaVLJvSJuUtWNHWipYIAUHI4BZXtjxMdNNkKeqHfQFVU0vKgseMyhObLk5gQZOCt+rjiny0vZs690tpzllES4p9Y1yQtlEbLfpKUKT3rgMLA0CYQprRTJta0todrnJ8KcQIR6fYbMeGECIkMlaECMFmaJMQMBd2hhAMg+VSA8SgiAawms4DkagogY25G2LPnomrVZ69LYswALQ0GDI0R2bFen9NHkYWY-8sxfippYvm8ABSCigpBb8iBGw8RJhvcg1gNCNryJbJIGE0i5qgtRSxwB6ICMau6VZsTIgSHHhoZoDRqbaC-Jkez0Eyh4lNABTeqn1OMEYLwXgfBHZUAMLsjCvwLaqw0MAQkIJ9BOSsrZQOYALjQBwNZeFEAKw8lak+jjzpGjyA3uxzjLpHYNAAI7nF9h5tT5A8iMAAHy+Y4AAZktuJLuSGrpNNuoae6SYwobQiumbp21dqgEgLAfiGg9gRtw8-PJk3pvqGRJrHRojaFgpIVC2yIABL+FmBeImqRrIrZeKzRLYAstThy1xmAl3SxFcaGxzgXA+D8DY4HJrbGCCZDwGxxABAkWBeAQB9rLIUEvHQdWCib0WAg98HYoWs2fBjegPAXVhncQo4mzm4OCa6hY-gPA3EDgnx+GSg9yT4BUdRCfUGF0mOqcTaQCgceSS3AM-G-ANSB61Ru0DLl10cB4GVnaVMHbU3rgRrF5MPC31DN-V091kDD1+v9sg2MNwu04MHWqFIFY-D6ok+drjOL1lib0DJnTBmTNVh3fdrE34yQACXF44BA1SMgJALxosm+heb0meQrepcaMQNjOBUgGUujz2MKggq9dCutNXIw4ouE1zBva8Hv1IZPBEbII4ph0EODmCAMySI8S4opjIDEXwpHSIXlExBGxQFRUjx4a656C4wnkMoVAKZBuUqPCzLOUKEFc2UAgixqbQUOEsszX5HdB1NNFmLW3UuL5Dsl6ybkeIGDgsPQ4CyKgEAXrXjIWR1o5hojyJzy3TQ1+7wf4ghFiKECmNZzWztBMYeWdhjc5Wr+rLiJ84vgNANQra6D1SuY0asYJCLatY+DQwAKd4oRyqjzzT+qXjybxDMi7LAHlJTAYTfZkB5AQC9qDTTIAS-Cbx4Dby7wAKHzHyWw+6xZ+4kyW6mDW7NS24szWQ7IQB5DWQABsL2bADgeQghTWDgDgAA7BoG9AABzSFsBvRcCCGCFsBNZNYACceQYhghKhbAfAAArGwIgG9HgHgPIfIdZL-HQYAoQvlkbs+CFjbj8HbtmEDLQCDGTB7PPGxJ+Mwavv7uwfTIzFwW4SzPIJ9OQqXmRCDBYJEOjORifpbEguDmgsVJghRI7MiKfvXlMP9qskgSQJ6AEohLJAAJKQwASFFwDcIAROGjwNAHgEhT6WwAA8pidWjs8RiR8EiAOAYkREZe6BZECEJm9UvGkAYAxUg8Ne84RwCIfcleN4a8zQdRBG+QpBnE4koi2QBUzSE82YZEPkXoTszhgSCxBABBgSRBWxZBaWWgFArEKEtmRgl4tAhEwE3+KAVUyIeIfSjYDR14J+GEeBskqSGS5xTRSsEAbIlB5S1kak-q2g7xgReMZubBgeHBYRzMT61kWsFhvMyIx2coFS7SURxeRwcqJ+-2X4FqCyNoSyWY9UFKuRGEqIBRga8iIa0RMQ88VUHJskvG-2G8dJFOlsbGeQUU9UlsfOdO3GGBl+MwRQSKredQWUpO9AxGkAIqa81xaBAx7s68wB4aampEBpBw1mk+ZxxGvwvutkhg2gZwhMFA1g7h1kgWpAbGAobGPB6JpuTpLp1qKmHpXpMAPpMQfp+JBkoiHW0eSghK2A3C2ATAzALA2ASAyI2AvCIsHQNgHSaAQAA) the self-hosting of a custom `mosaic-widget` build was necessary to work around the dependency constraint issue.