### PR TITLE
Improve M4 Query Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To build and develop Mosaic locally:
 
 To run local interactive examples:
 
-* Run `npm run dev` to launch a local web server and view examples. By default, the examples use DuckDB-WASM in the browser. For greater performance, launch and connect to a local DuckDB server as described below below.
+* Run `npm run dev` to launch a local web server and view examples. By default, the examples use DuckDB-WASM in the browser. For greater performance, launch and connect to a local DuckDB server as described below.
 
 To launch a local DuckDB server:
 

--- a/docs/api/sql/queries.md
+++ b/docs/api/sql/queries.md
@@ -47,7 +47,6 @@ The following static methods create a new `SelectQuery` and invoke the correspon
 
 - `Query.select()`: See the [`select`](#select) method below.
 - `Query.from()`: See the [`from`](#from) method below.
-- `Query.with()`: See the [`with`](#with) method below.
 
 In addition, the following static methods take multiple queries as input and return `SetOperation` instances:
 
@@ -55,6 +54,12 @@ In addition, the following static methods take multiple queries as input and ret
 - `Query.unionAll(...queries)`: Union results with no de-duplication of rows.
 - `Query.intersect(...queries)`: Query for distinct rows that are output by both the left and right input queries.
 - `Query.except(...queries)`: Query for distinct rows from the left input query that aren't output by the right input query.
+
+Common table expressions can be applied via static method
+
+- `Query.with()`: See the [`with`](#with) method below.
+
+Each of the methods described above can also be utilized in conjunction with a WITH clause. For example, `Query.with().select()` results in a `SelectQuery`, whereas `Query.with().union()` will produce a `SetOperation`.
 
 To instead create a query for metadata (column names and types), pass a query to the static `describe` method:
 
@@ -94,7 +99,7 @@ The _tables_ may be table name strings, queries or subquery expressions, and map
 
 ## with
 
-`query.with(...expressions)`
+`Query.with(...expressions)`
 
 Provide a set of named subqueries in the form of [common table expressions](https://duckdb.org/docs/sql/query_syntax/with.html) and return this query instance.
 The input _expressions_ should consist of one or more maps (as JavaScript `object` values) from subquery names to query expressions.
@@ -155,19 +160,19 @@ This method is additive: any previously defined filter criteria will still remai
 
 ## orderby
 
-`SelectQuery.orderby(...expressions)`
+`Query.orderby(...expressions)`
 
 Update the query to additionally order results by the provided _expressions_ and return this query instance.
 This method is additive: any previously defined sort criteria will still remain.
 
 ## limit
 
-`SelectQuery.limit(rows)`
+`Query.limit(rows)`
 
 Update the query to limit results to the specified number of _rows_ and return this query instance.
 
 ## offset
 
-`SelectQuery.offset(rows)`
+`Query.offset(rows)`
 
 Update the query to offset the results by the specified number of _rows_ and return this query instance.

--- a/packages/sql/src/ast/query.js
+++ b/packages/sql/src/ast/query.js
@@ -46,7 +46,7 @@ export class Query extends ExprNode {
    * @returns {WithClause}
    */
   static with(...expr) {
-    return new WithClause(expr);
+    return new WithClause(...expr);
   }
 
   /**
@@ -582,7 +582,11 @@ export class SetOperation extends Query {
 }
 
 class WithClause {
-  constructor(expr) {
+  /**
+   * Instantiate a new WITH clause instance.
+   * @param {...import('../types.js').WithExpr} expr The WITH CTE queries.
+   */
+  constructor(...expr) {
     this._with = expr;
   }
 
@@ -592,7 +596,7 @@ class WithClause {
    * @returns {SelectQuery}
    */
   select(...expr) {
-    return Query.select(...expr).with(this._with);
+    return Query.select(...expr).with(...this._with);
   }
 
   /**
@@ -601,7 +605,7 @@ class WithClause {
    * @returns {SelectQuery}
    */
   from(...expr) {
-    return Query.from(...expr).with(this._with);
+    return Query.from(...expr).with(...this._with);
   }
 
   /**
@@ -610,7 +614,7 @@ class WithClause {
    * @returns {SetOperation}
    */
   union(...queries) {
-    return Query.union(...queries).with(this._with);
+    return Query.union(...queries).with(...this._with);
   }
 
   /**
@@ -619,7 +623,7 @@ class WithClause {
    * @returns {SetOperation}
    */
   unionAll(...queries) {
-    return Query.unionAll(...queries).with(this._with);
+    return Query.unionAll(...queries).with(...this._with);
   }
 
   /**
@@ -628,7 +632,7 @@ class WithClause {
    * @returns {SetOperation}
    */
   intersect(...queries) {
-    return Query.intersect(...queries).with(this._with);
+    return Query.intersect(...queries).with(...this._with);
   }
 
   /**
@@ -637,6 +641,6 @@ class WithClause {
    * @returns {SetOperation}
    */
   except(...queries) {
-    return Query.except(...queries).with(this._with);
+    return Query.except(...queries).with(...this._with);
   }
 }

--- a/packages/sql/src/transforms/m4.js
+++ b/packages/sql/src/transforms/m4.js
@@ -22,14 +22,12 @@ import { floor } from '../functions/numeric.js';
 export function m4(input, bin, x, y, groups = []) {
   const pixel = int32(floor(bin));
 
+  // Below, we treat input as a CTE when it is a query. DuckDB will
+  // automatically materialize the CTE if it performs a grouped aggregation.
   const useCTE = isQuery(input);
   const inputExpr = useCTE ? 'input' : input;
   const query = useCTE ? Query.with({ input }) : Query;
 
-  // DuckDB automatically materializes the input query based on heuristics.
-  // Explicit use of MATERIALIZED is not required when:
-  // 1. CTE performs a grouped aggregation
-  // 2. CTE is queried more than once (here 4x)
   const q = (sel) => Query
     .from(inputExpr)
     .select(sel)


### PR DESCRIPTION
## Why are the changes necessary?

M4 query performance can be improved by a factor of up to 4 using materialized CTEs.

### Benchmark Example

Consider the following benchmark example

<img width="813" alt="m4query" src="https://github.com/user-attachments/assets/f6f75fdc-a7b9-4afc-b8d5-af6f605b5d81" />

```yaml
meta:
  title: NOAA Global Historical Climatology Network Daily (GHCN-D)
  description: >
    Time series showing the daily number of weather stations in use, based
    on a dataset of 20 million daily weather observations from 1890 to 2024.
data:
  noaa: { file: data/noaa_20m.parquet }
plot:
- mark: lineY
  data: { from: noaa }
  x: date
  y: { count:  }
  stroke: steelblue
xLabel: Date
yLabel: Total Stations
width: 800
height: 400
```

Executing the M4 query from above line chart on a MacBook Pro (M1 Pro) produces the following timings

|        | CTE Usage | Duration |
| -----: | :-------: | -------: |
| Before |    no     |  1,355ms |
|  After |    yes    |    362ms |


## What does this pull request cover?

### Overview

- Add CTES for `SetOperation`
- Update of M4 Query using CTEs
- Update Documentation 
- Fix typo

### Add CTEs for `SetOperation`

The `Query.with` method has been redesigned to support the new M4 query formulation with CTEs. It is now also supported for `SetOperation` and introduces a new intermediate `WithClause` object, from which both `SelectQuery` and `SetOperation` objects can be instantiated.

Here is an example demonstrating the use of a `WITH` clause together with `unionAll`, which was previously not possible.

```javascript
Query
  .with({
    base: Query.from("table").groupby(...)
  })
  .unionAll(
    Query
      .from("base")
      .select({ x: min("x"), y: argmin("y", "x") })
      .groupby(...),
    Query
      .from("base")
      .select({ x: max("x"), y: argmax("y", "x") })
      .groupby(...)
  )
  .orderby("x")
```

To achieve this, the `with` instance method of `SelectQuery` has been moved to the `Query` class.

### Update of M4 Query using CTES

The M4 query has been improved by employing CTEs instead of subqueries. This approach allows intermediate results to be cached and reused. DuckDB automatically materializes the input query based on heuristics, specifically when

  1. CTE performs a grouped aggregation, and
  2. CTE is queried more than once (here 4x)

See also [here](https://duckdb.org/docs/sql/query_syntax/with.html#cte-materialization).

## Caveats

### `Query.subqueries`

By adding a `WITH` clause to `SetOperation`, the `subqueries` methods probably need refactoring. Queries from `SetOperation` could have now subqueries coming from CTEs, which are not yet considered. There is also an existing comment in `SetOperation`, that the implementation of `subqueries` is not optimal and potentially incomplete. This method has been left unchanged.

### Support of `MATERIALIZED` / `NOT MATERIALIZED`

While materializing not only helps when there is a grouped aggregation query, it can improve performance for ungrouped queries as well.

Looking at the _Overview/Detail Chart_ from Mosaic examples — but using 1 million data points — materializing would speed up update processes significantly (by a factor up to 2). However, as there is no grouped aggregation, materializing won't be applied here. Thus, adding keywords `MATERIALIZED` (and `NOT MATERIALIZED` for completeness) to `WithClauseNode` would make sense.

As queries of `WITH` clause are passed currently as (name, query) pairs using objects, syntax does not allow for adding an extra parameter without compromising the simplicity of API. However, before passing a query to `WITH`, an optional boolean flag on `Query` object could be set, indicating forced usage of `MATERIALIZED` or `NOT MATERIALIZED`. This flag could be then passed to `WithClauseNode` to create the appropriate clause, allowing explicit control over `MATERIALIZED` usage in M4 queries. This has not been implemented yet.