### PR TITLE
feat: improve `ast-to-dom` typing

### DIFF
--- a/packages/spec/src/ast-to-dom.js
+++ b/packages/spec/src/ast-to-dom.js
@@ -7,10 +7,7 @@ import { error } from './util.js';
 /**
  * Generate a running web application (DOM content) for a Mosaic spec AST.
  * @param {SpecNode} ast Mosaic AST root node.
- * @param {object} [options] Instantiation options.
- * @param {string} [options.baseURL] The base URL for loading data files.
- * @param {any[]} [options.plotDefaults] Array of default plot attributes.
- * @param {Map<string, Param>} [options.params] A map of predefined Params/Selections.
+ * @param {ConstructorParameters<typeof InstantiateContext>[0]} [options] Instantiation options.
  * @returns {Promise<{
  *   element: HTMLElement | SVGSVGElement;
 *    params: Map<string, Param | Selection>;
@@ -54,6 +51,14 @@ export async function astToDOM(ast, options) {
 }
 
 export class InstantiateContext {
+  /**
+   * Create a new InstantiateContext instance.
+   * @param {object} options Optional instantiation options.
+   * @param {string} [options.baseURL] The base URL for loading data files.
+   * @param {any[]} [options.plotDefaults] Array of default plot attributes.
+   * @param {Map<string, Param>} [options.params] A map of predefined Params/Selections.
+   * @param {ReturnType<typeof createAPIContext>} [options.api] The context to be used for vgplot API methods.
+   */
   constructor({
     api = createAPIContext(),
     plotDefaults = [],


### PR DESCRIPTION
Improved the typing of the `options` parameter of `ast-to-dom` to be based on `InstantiateContext` as this is what it is being used for.