### PR TITLE
feat: Add cte method for fine-grained WITH clause control.

### DIFF
--- a/docs/api/sql/expressions.md
+++ b/docs/api/sql/expressions.md
@@ -9,6 +9,15 @@ SQL expression builders. All SQL expressions are represented in the form of an a
 Create an expression AST node that references a column by _name_.
 Upon string coercion, the column name will be properly quoted.
 
+## cte
+
+`cte(name, query, materialized)`
+
+Create an AST node for a Common Table Expression (CTE) to be used within a SQL `WITH` clause.
+The resulting node can be passed as an argument to the `Query.with()` method.
+The string-valued _name_ and Query-valued _query_ arguments are required.
+The optional boolean-valued _materialized_ argument indicates if the CTE should be materialized during query execution; if unspecified, it is left to the backing database to decide.
+
 ## literal
 
 `literal(value)`

--- a/docs/api/sql/queries.md
+++ b/docs/api/sql/queries.md
@@ -101,8 +101,8 @@ The _tables_ may be table name strings, queries or subquery expressions, and map
 
 `Query.with(...expressions)`
 
-Provide a set of named subqueries in the form of [common table expressions](https://duckdb.org/docs/sql/query_syntax/with.html) and return this query instance.
-The input _expressions_ should consist of one or more maps (as JavaScript `object` values) from subquery names to query expressions.
+Provide a set of named subqueries in the form of [common table expressions (CTEs)](https://duckdb.org/docs/sql/query_syntax/with.html) and return this query instance.
+The input _expressions_ should consist of one or more maps (as JavaScript `object` values) from subquery names to query expressions and/or CTE instances produced by the `cte` method.
 
 ## distinct
 

--- a/packages/sql/src/ast/query.js
+++ b/packages/sql/src/ast/query.js
@@ -159,7 +159,8 @@ export class Query extends ExprNode {
       list.push(new WithClauseNode(name, query));
     };
     expr.flat().forEach(e => {
-      if (e != null) for (const name in e) add(name, e[name]);
+      if (e instanceof WithClauseNode) list.push(e);
+      else if (e != null) for (const name in e) add(name, e[name]);
     });
     this._with = this._with.concat(list);
     return this;

--- a/packages/sql/src/ast/with.js
+++ b/packages/sql/src/ast/with.js
@@ -7,8 +7,12 @@ export class WithClauseNode extends SQLNode {
    * Instantiate a with clause node for a common table expression (CTE).
    * @param {string} name The common table expression (CTE) name.
    * @param {Query} query The common table expression (CTE) query.
+   * @param {boolean | null} [materialized] The common table expression (CTE)
+   *  materialization flag. If `true`, forces materialization of the CTE.
+   *  If `false`, materialization is not performed. Otherwise (for example, if
+   *  `undefined` or `null`), materialization is decided by the database.
    */
-  constructor(name, query) {
+  constructor(name, query, materialized = undefined) {
     super(WITH_CLAUSE);
     /**
      * The common table expression (CTE) name.
@@ -22,9 +26,19 @@ export class WithClauseNode extends SQLNode {
      * @readonly
      */
     this.query = query;
+    /**
+     * The common table expression (CTE) materialization flag.
+     * @type {boolean | null}
+     * @readonly
+     */
+    this.materialized = materialized;
   }
 
   toString() {
-    return `"${this.name}" AS (${this.query})`;
+    const flag = this.materialized;
+    const mat = flag === true ? ' MATERIALIZED'
+      : flag === false ? ' NOT MATERIALIZED'
+      : '';
+    return `"${this.name}" AS${mat} (${this.query})`;
   }
 }

--- a/packages/sql/src/functions/cte.js
+++ b/packages/sql/src/functions/cte.js
@@ -1,0 +1,16 @@
+import { Query } from '../ast/query.js';
+import { WithClauseNode } from '../ast/with.js';
+
+/**
+ * Create a common table expression (CTE) to include within a WITH clause.
+ * @param {string} name The common table expression (CTE) name.
+ * @param {Query} query The common table expression (CTE) query.
+ * @param {boolean | null} [materialized] The common table expression (CTE)
+ *  materialization flag. If `true`, forces materialization of the CTE.
+ *  If `false`, materialization is not performed. Otherwise (for example, if
+ *  `undefined` or `null`), materialization is decided by the database.
+ * @returns {WithClauseNode}
+ */
+export function cte(name, query, materialized) {
+  return new WithClauseNode(name, query, materialized);
+}

--- a/packages/sql/src/index.js
+++ b/packages/sql/src/index.js
@@ -28,6 +28,7 @@ export { argmax, argmin, arrayAgg, avg, corr, count, covariance, covarPop, entro
 export { cond } from './functions/case.js';
 export { cast, float32, float64, int32 } from './functions/cast.js';
 export { column } from './functions/column.js';
+export { cte } from './functions/cte.js';
 export { dateBin, dateMonth, dateMonthDay, dateDay, epoch_ms, interval } from './functions/datetime.js';
 export { literal } from './functions/literal.js';
 export { abs, ceil, exp, floor, greatest, isFinite, isInfinite, isNaN, least, ln, log, round, sign, sqrt, trunc } from './functions/numeric.js';

--- a/packages/sql/src/types.ts
+++ b/packages/sql/src/types.ts
@@ -2,6 +2,7 @@ import { ColumnRefNode } from './ast/column-ref.js';
 import { ExprNode, SQLNode } from './ast/node.js';
 import { TableRefNode } from './ast/table-ref.js';
 import { Query } from './ast/query.js';
+import { WithClauseNode } from './ast/with.js';
 
 /**
  * Interface representing a dynamic parameter value.
@@ -80,7 +81,11 @@ export type SelectEntry =
 
 export type SelectExpr = MaybeArray<SelectEntry>;
 
-export type WithExpr = MaybeArray<Record<string, Query>>;
+export type WithEntry =
+  | WithClauseNode
+  | Record<string, Query>;
+
+export type WithExpr = MaybeArray<WithEntry>;
 
 export type FromEntry =
   | string

--- a/packages/sql/test/cte.test.js
+++ b/packages/sql/test/cte.test.js
@@ -1,0 +1,26 @@
+import { expect, describe, it } from 'vitest';
+import { Query, cte } from '../src/index.js';
+
+describe('cte', () => {
+  it('creates a common table expression', () => {
+    const q = Query.select({ x: 42 });
+
+    const x = cte('foo', q, false);
+    expect(x.name).toBe('foo');
+    expect(x.query).toBe(q);
+    expect(x.materialized).toBe(false);
+    expect(x.toString()).toBe(`"foo" AS NOT MATERIALIZED (${q})`);
+
+    const y = cte('foo', q, true);
+    expect(y.name).toBe('foo');
+    expect(y.query).toBe(q);
+    expect(y.materialized).toBe(true);
+    expect(y.toString()).toBe(`"foo" AS MATERIALIZED (${q})`);
+
+    const z = cte('foo', q);
+    expect(z.name).toBe('foo');
+    expect(z.query).toBe(q);
+    expect(z.materialized).toBe(undefined);
+    expect(z.toString()).toBe(`"foo" AS (${q})`);
+  });
+});

--- a/packages/sql/test/query.test.js
+++ b/packages/sql/test/query.test.js
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { asNode, asTableRef, column, desc, gt, lt, max, min, sql, Query, sum, lead, over } from '../src/index.js';
+import { asNode, asTableRef, column, desc, gt, lt, max, min, sql, Query, sum, lead, over, cte, add } from '../src/index.js';
 
 describe('Query', () => {
   it('selects column name strings', () => {
@@ -462,6 +462,20 @@ describe('Query', () => {
       'WITH "a" AS (SELECT "foo" FROM "data1"),',
            '"b" AS (SELECT "bar" FROM "data2")',
       'SELECT * FROM "a", "b"'
+    ].join(' '));
+
+    expect(Query
+      .with(
+        cte('foo', Query.select({ x: 42 }), false),
+        cte('bar', Query.select({ y: 42 }), true)
+      )
+      .select({ v: add('x', 'y') })
+      .from('foo', 'bar')
+      .toString()
+    ).toBe([
+      'WITH "foo" AS NOT MATERIALIZED (SELECT 42 AS "x"),',
+           '"bar" AS MATERIALIZED (SELECT 42 AS "y")',
+      'SELECT ("x" + "y") AS "v" FROM "foo", "bar"'
     ].join(' '));
   });
 


### PR DESCRIPTION
- Add `cte(...)` method for direct construction of WITH clause nodes.
- Add `materialized` property to WITH clause nodes to control explicit CTE materialization.
- Update M4 transform to enforce CTE materialization.

Close #693.