### PR TITLE
feat: Add cache exporting and hydration capabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16623,6 +16623,7 @@
       "name": "@uwdata/publish",
       "version": "1.0.0",
       "dependencies": {
+        "@uwdata/flechette": "^2.0.0",
         "chalk": "^4.1.2",
         "skia-canvas": "^2.0.2",
         "yargs": "^17.7.2"
@@ -16635,6 +16636,12 @@
         "@types/yargs": "^17.0.33",
         "typescript": "^5.6.3"
       }
+    },
+    "packages/publish/node_modules/@uwdata/flechette": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@uwdata/flechette/-/flechette-2.0.0.tgz",
+      "integrity": "sha512-4E5mQLNV2VcrHrDS77w4e3luusYGk/jchJSWgonGGUKJ2eNf1yt1qNCy+wzB7SqZ4WOPaK6j1mtzRFtRPzA8Xg==",
+      "license": "BSD-3-Clause"
     },
     "packages/spec": {
       "name": "@uwdata/mosaic-spec",

--- a/packages/core/src/QueryManager.js
+++ b/packages/core/src/QueryManager.js
@@ -106,6 +106,11 @@ export class QueryManager {
     }
   }
 
+  /**
+   * Get or set the client cache.
+   * @param {boolean | import('./util/cache.js').Cache} [value] The cache instance or `true` to create an LRU cache.
+   * @returns {import('./util/cache.js').Cache} The cache instance.
+   */
   cache(value) {
     return value !== undefined
       ? (this.clientCache = value === true ? lruCache() : (value || voidCache()))

--- a/packages/core/src/util/cache.js
+++ b/packages/core/src/util/cache.js
@@ -1,16 +1,78 @@
+import { list, tableFromArrays, tableFromIPC, tableToIPC,  uint8, utf8 } from "@uwdata/flechette";
+
 const requestIdle = typeof requestIdleCallback !== 'undefined'
   ? requestIdleCallback
   : setTimeout;
 
+/**
+ * @typedef {import('@uwdata/flechette').Table | Promise<import('@uwdata/flechette').Table>} CacheEntry
+ * @typedef {Object} Cache
+ * @property {(key: string) => CacheEntry | undefined} get Retrieves a value from the cache.
+ * @property {(key: string, value: CacheEntry) => any} set Stores a value in the cache and returns it.
+ * @property {() => void} clear Clears all entries in the cache.
+ * @property {() => Uint8Array | null} export Exports the cache as an array of bytes in Arrow IPC binary format or null if the cache is empty.
+ * @property {(data: ArrayBuffer | Uint8Array | Uint8Array[]) => void} import Imports the cache from an array of bytes in Arrow IPC binary format.
+ */
+
+/**
+ * Converts a cache instance into a byte buffer.
+ * @param {[string, import('@uwdata/flechette').Table][]} kv An array of key-value pairs representing
+ * the cache contents.
+ * @returns {Uint8Array | null} A byte buffer representing the cache or null if the cache is empty.
+ */
+const keyValuesToIPC = (kv) => {
+  const cache_object = kv.reduce(
+    (acc, [key, value]) => {
+      const bytes = tableToIPC(value, { format: 'stream' });
+      acc.key.push(key);
+      acc.value.push(bytes);
+      return acc;
+    },
+    { key: [], value: [] }
+  );
+  const table = tableFromArrays(cache_object, {
+    types: {
+      key: utf8(),
+      value: list(uint8())
+    }
+  });
+  return tableToIPC(table, { format: 'stream' })
+}
+
+/**
+ * Converts a byte buffer representing a cache instance into an array of key-value pairs.
+ * @param {ArrayBuffer | Uint8Array | Uint8Array[]} bytes The source byte buffer, or an array of buffers representing the cache.
+ * @returns {[string, import('@uwdata/flechette').Table][]} An array of key-value pairs representing the cache contents.
+ */
+const keyValuesFromIPC = (bytes) => {
+  const cacheTable = tableFromIPC(bytes);
+  return cacheTable.toArray().reduce((acc, row) => {
+    return acc.concat([[row.key, tableFromIPC(row.value)]]);
+  }, []);
+}
+
+/**
+ * Creates a cache that does nothing (a no-op cache).
+ * @returns {Cache} A void cache that doesn't store or retrieve values.
+ */
 export const voidCache = () => ({
   get: () => undefined,
   set: (key, value) => value,
-  clear: () => {}
+  clear: () => {},
+  export: () => null,
+  import: () => {}
 });
 
+/**
+ * Creates a Least Recently Used (LRU) cache with a fixed size and time-to-live (TTL).
+ * @param {Object} [options] Configuration options for the cache.
+ * @param {number} [options.max=1000] Maximum number of entries before eviction.
+ * @param {number} [options.ttl=10800000] Time-to-live for each entry in milliseconds (default: 3 hours).
+ * @returns {Cache} An LRU cache instance.
+ */
 export function lruCache({
-  max = 1000, // max entries
-  ttl = 3 * 60 * 60 * 1000 // time-to-live, default 3 hours
+  max = 1000,
+  ttl = 3 * 60 * 60 * 1000
 } = {}) {
   let cache = new Map;
 
@@ -40,19 +102,31 @@ export function lruCache({
     }
   }
 
+  function get(key) {
+    const entry = cache.get(key);
+    if (entry) {
+      entry.last = performance.now();
+      return entry.value;
+    }
+  }
+
+  function set(key, value) {
+    cache.set(key, { last: performance.now(), value });
+    if (cache.size > max) requestIdle(evict);
+    return value;
+  }
+
   return {
-    get(key) {
-      const entry = cache.get(key);
-      if (entry) {
-        entry.last = performance.now();
-        return entry.value;
-      }
+    get,
+    set,
+    clear() { cache = new Map; },
+    export() {
+      const kv = Array.from(cache, ([key, { value }]) => [key, value])
+      return keyValuesToIPC(kv);
     },
-    set(key, value) {
-      cache.set(key, { last: performance.now(), value });
-      if (cache.size > max) requestIdle(evict);
-      return value;
-    },
-    clear() { cache = new Map; }
+    import(data) {
+      const kv = keyValuesFromIPC(data);
+      kv.forEach(([key, value]) => set(key, value));
+    }
   };
 }

--- a/packages/core/src/util/cache.js
+++ b/packages/core/src/util/cache.js
@@ -1,4 +1,5 @@
-import { tableFromIPC, tableToIPC } from "@uwdata/flechette";
+import { tableToIPC } from "@uwdata/flechette";
+import { decodeIPC } from "./decode-ipc.js";
 
 const requestIdle = typeof requestIdleCallback !== 'undefined'
   ? requestIdleCallback
@@ -86,18 +87,12 @@ export function lruCache({
     set,
     clear() { cache = new Map; },
     export() {
-      return Array.from(cache).reduce(
-        (acc, [key, entry]) => {
-          acc.set(key, tableToIPC(entry.value, { format: 'stream' }));
-          return acc;
-        },
-        new Map()
-      );
+      return new Map(Array.from(cache).map(([key, entry]) => [key, tableToIPC(entry.value)]));
     },
     import(data) {
-      Array.from(data).forEach(
-        ([key, value]) => set(key, tableFromIPC(value))
-      );
+      for (const [key, entry] of data) {
+        set(key, decodeIPC(entry));
+      }
     }
   };
 }

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -13,6 +13,7 @@
     "test": "npm run build && vitest run"
   },
   "dependencies": {
+    "@uwdata/flechette": "^2.0.0",
     "chalk": "^4.1.2",
     "skia-canvas": "^2.0.2",
     "yargs": "^17.7.2"

--- a/packages/publish/src/MosaicPublisher.ts
+++ b/packages/publish/src/MosaicPublisher.ts
@@ -248,7 +248,7 @@ export class MosaicPublisher {
         types: {
           cache: map(utf8(), binary())
         }
-      }), { format: 'stream' })!;
+      }), {})!;
       fs.writeFileSync(path.join(this.outputPath, cacheFile), cacheBytes);
     }
 

--- a/packages/publish/src/util/constants.ts
+++ b/packages/publish/src/util/constants.ts
@@ -165,7 +165,21 @@ export const VGPLOT = 'https://cdn.jsdelivr.net/npm/@uwdata/vgplot@latest/dist/v
 
 // TODO: switch this to ./renderHelpers version when changes pushed to npm
 // Currently, this is hack to see when clients are ready use .pending when it is available
-export const preamble = `export function clientsReady() {
+const clientsReady = `export function clientsReady() {
   const clients = [...vg.coordinator().clients];
   return Promise.allSettled(clients.map(c => c.initialize()))
 }`
+
+const loadCache = (cacheFile: string) => `
+const cacheBytes = await fetch(window.location.origin + "/${cacheFile}").then(res => res.arrayBuffer());
+vg.coordinator().manager.cache().import(cacheBytes);`;
+
+export const preamble = (needsClientReady: boolean, cacheFile?: string) => {
+  if (!needsClientReady && !cacheFile) {
+    return undefined
+  }
+  return `
+${needsClientReady ? clientsReady : ''}
+${cacheFile ? loadCache(cacheFile) : ''}
+`
+}

--- a/packages/publish/src/util/constants.ts
+++ b/packages/publish/src/util/constants.ts
@@ -162,6 +162,7 @@ export const templateCSS = `<style>
 </style>`;
 
 export const VGPLOT = 'https://cdn.jsdelivr.net/npm/@uwdata/vgplot@latest/dist/vgplot.js';
+export const FLECHETTE = 'https://cdn.jsdelivr.net/npm/@uwdata/flechette@latest/dist/flechette.js';
 
 // TODO: switch this to ./renderHelpers version when changes pushed to npm
 // Currently, this is hack to see when clients are ready use .pending when it is available
@@ -172,7 +173,7 @@ const clientsReady = `export function clientsReady() {
 
 const loadCache = (cacheFile: string) => `
 const cacheBytes = await fetch(window.location.origin + "/${cacheFile}").then(res => res.arrayBuffer());
-vg.coordinator().manager.cache().import(cacheBytes);`;
+vg.coordinator().manager.cache().import(tableFromIPC(cacheBytes).get(0).cache);`;
 
 export const preamble = (needsClientReady: boolean, cacheFile?: string) => {
   if (!needsClientReady && !cacheFile) {

--- a/packages/spec/src/ast-to-dom.js
+++ b/packages/spec/src/ast-to-dom.js
@@ -1,4 +1,4 @@
-import { Param, Selection } from '@uwdata/mosaic-core';
+import { Coordinator, Param, Selection } from '@uwdata/mosaic-core';
 import { createAPIContext, loadExtension } from '@uwdata/vgplot';
 import { SpecNode } from './ast/SpecNode.js';
 import { resolveExtensions } from './config/extensions.js';
@@ -69,6 +69,7 @@ export class InstantiateContext {
     this.plotDefaults = plotDefaults;
     this.activeParams = params;
     this.baseURL = baseURL;
+    /** @type {Coordinator} */
     this.coordinator = api.context.coordinator;
   }
 


### PR DESCRIPTION
Added better typing to caches and also the ability to import/export caches to Arrow IPC stream format. Then integrated this new functionality into the `publish` package alongisde better type propogation to ensure everything is working properly.

> **IMPORTANT NOTE:** When this is merged a new release will need to be cut due to the use of the new `.import()` function in the generated code as part of publish. This could be fixed by bundling current version of external packages into published visualization directory and refrencing this instead of CDN but let's discuss this in #682.