### PR TITLE
Add coalesce SQL function, use it to fix preaggregation counts

### DIFF
--- a/packages/core/test/preaggregator.test.js
+++ b/packages/core/test/preaggregator.test.js
@@ -60,6 +60,15 @@ describe('PreAggregator', () => {
     expect(await run(count('x'))).toStrictEqual([2, true]);
   });
 
+  it('supports empty count aggregate', async () => {
+    const query = (predicate = []) => {
+      return Query.from('testData')
+        .select({ measure: count() })
+        .where(predicate, false);
+    };
+    expect(await run(query)).toStrictEqual([0, true]);
+  });
+
   it('supports sum aggregate', async () => {
     expect(await run(sum('x'))).toStrictEqual([7, true]);
   });

--- a/packages/sql/src/functions/util.js
+++ b/packages/sql/src/functions/util.js
@@ -1,0 +1,14 @@
+/**
+ * @import { FunctionNode } from '../ast/function.js'
+ * @import { ExprValue } from '../types.js'
+ */
+import { fn } from '../util/function.js';
+
+/**
+ * Returns the first non-null argument.
+ * @param {...ExprValue} expr The input expressions.
+ * @returns {FunctionNode}
+ */
+export function coalesce(...expr) {
+  return fn('coalesce', ...expr);
+}

--- a/packages/sql/src/index.js
+++ b/packages/sql/src/index.js
@@ -37,6 +37,7 @@ export { asc, desc } from './functions/order-by.js';
 export { geojson, x, y, centroid, centroidX, centroidY } from './functions/spatial.js';
 export { sql } from './functions/sql-template-tag.js';
 export { regexp_matches, contains, prefix, suffix, lower, upper, length } from './functions/string.js';
+export { coalesce } from './functions/util.js';
 export { cume_dist, dense_rank, first_value, lag, last_value, lead, nth_value, ntile, percent_rank, rank, row_number } from './functions/window.js';
 
 export { rewrite } from './visit/rewrite.js';


### PR DESCRIPTION
- Add `coalesce` SQL function, which returns the first non-null argument.
- Fix preaggregation `count` measures to return zero (not null) for "empty" counts.