### PR TITLE
Add client.enabled property.

### DIFF
--- a/packages/core/src/Coordinator.js
+++ b/packages/core/src/Coordinator.js
@@ -301,7 +301,7 @@ function activateSelection(mc, selection, clause) {
   const { preaggregator, filterGroups } = mc;
   const { clients } = filterGroups.get(selection);
   for (const client of clients) {
-    if (client.active) {
+    if (client.enabled) {
       preaggregator.request(client, selection, clause);
     }
   }
@@ -319,7 +319,7 @@ function updateSelection(mc, selection) {
   const { clients } = filterGroups.get(selection);
   const { active } = selection;
   return Promise.allSettled(Array.from(clients, client => {
-    if (!client.active) return client.requestQuery();
+    if (!client.enabled) return client.requestQuery();
     const info = preaggregator.request(client, selection, active);
     const filter = info ? null : selection.predicate(client);
 

--- a/packages/core/src/MosaicClient.js
+++ b/packages/core/src/MosaicClient.js
@@ -1,16 +1,31 @@
-import { Coordinator } from './Coordinator.js';
-import { Selection } from './Selection.js';
+/** @import { Query } from '@uwdata/mosaic-sql' */
+/** @import { Coordinator } from './Coordinator.js' */
+/** @import { Selection } from './Selection.js' */
+import { queryFieldInfo } from './util/field-info.js';
 import { throttle } from './util/throttle.js';
 
 /**
- * Base class for Mosaic clients.
+ * A Mosaic client is a data consumer that indicates its data needs to a
+ * Mosaic coordinator via the query method. The coordinator is responsible
+ * for issuing queries and returning results to the client.
+ *
+ * The client life-cycle consists of connection to a coordinator,
+ * initialization (potentially involving queries for data schema and summary
+ * statistic information), and then interactive queries that may be driven by
+ * an associated selection. When no longer needed, a client should be
+ * disconnected from the coordinator.
+ *
+ * When active, a client will initialize and respond to query update requests.
+ * If set to be inactive, the client will delay initialization not respond to
+ * queries until made active again. Making a client inactive can improve system
+ * performance when associated interface elements are offscreen or disabled.
  */
 export class MosaicClient {
   /**
-   * Constructor.
-   * @param {*} filterSelection An optional selection to interactively filter
-   *  this client's data. If provided, a coordinator will re-query and update
-   *  the client when the selection updates.
+   * Create a new client instance.
+   * @param {Selection} [filterSelection] An optional selection to
+   *  interactively filter this client's data. If provided, a coordinator
+   *  will re-query and update the client when the selection updates.
    */
   constructor(filterSelection) {
     /** @type {Selection} */
@@ -20,6 +35,12 @@ export class MosaicClient {
     this._coordinator = null;
     /** @type {Promise<any>} */
     this._pending = Promise.resolve();
+    /** @type {boolean} */
+    this._active = true;
+    /** @type {boolean} */
+    this._initialized = false;
+    /** @type {Query | boolean} */
+    this._request = null;
   }
 
   /**
@@ -34,6 +55,33 @@ export class MosaicClient {
    */
   set coordinator(coordinator) {
     this._coordinator = coordinator;
+  }
+
+  /**
+   * Return this client's active state.
+   */
+  get active() {
+    return this._active;
+  }
+
+  /**
+   * Set this client's active state;
+   */
+  set active(state) {
+    state = !!state; // ensure boolean
+    if (this._active !== state) {
+      this._active = state;
+      if (state) {
+        if (!this._initialized) {
+          // initialization includes a query request
+          this.initialize();
+        } else if (this._request) {
+          // request query now if requested while inactive
+          this.requestQuery(this._request === true ? undefined : this._request);
+        }
+        this._request = null;
+      }
+    }
   }
 
   /**
@@ -122,24 +170,40 @@ export class MosaicClient {
 
   /**
    * Request the coordinator to execute a query for this client.
-   * If an explicit query is not provided, the client query method will
-   * be called, filtered by the current filterBy selection. This method
-   * has no effect if the client is not registered with a coordinator.
+   * If an explicit query is not provided, the client `query` method will
+   * be called, filtered by the current `filterBy` selection. This method has
+   * no effect if the client is not connected to a coordinator. If the client
+   * is connected by currently inactive, the request will be serviced if/when
+   * the client is later active.
+   * @param {Query} [query] The query to request. If unspecified, the query
+   *  will be determind by the client's `query` method and the current
+   *  `filterBy` selection state.
    * @returns {Promise}
    */
   requestQuery(query) {
-    const q = query || this.query(this.filterBy?.predicate(this));
-    return this._coordinator?.requestQuery(this, q);
+    if (this._active) {
+      const q = query || this.query(this.filterBy?.predicate(this));
+      return this._coordinator?.requestQuery(this, q);
+    } else {
+      this._request = query ?? true;
+      return null;
+    }
   }
 
   /**
    * Request that the coordinator perform a throttled update of this client
-   * using the default query. Unlike requestQuery, for which every call will
-   * result in an executed query, multiple calls to requestUpdate may be
-   * consolidated into a single update.
+   * using the default query. Unlike requestQuery, for which every call results
+   * in an executed query, multiple calls to requestUpdate may be consolidated
+   * into a single update. This method has no effect if the client is not
+   * connected to a coordinator. If the client is connected but currently
+   * inactive, the request will be serviced if/when the client is later active.
    */
   requestUpdate() {
-    this._requestUpdate();
+    if (this._active) {
+      this._requestUpdate();
+    } else {
+      this.requestQuery();
+    }
   }
 
   /**
@@ -148,8 +212,15 @@ export class MosaicClient {
    * registered with a coordinator.
    * @returns {Promise}
    */
-  initialize() {
-    return this._coordinator?.initializeClient(this);
+  async initialize() {
+    if (!this._active) {
+      // clear flag so we initialize when active again
+      this._initialized = false;
+    } else if (this._coordinator) {
+      // if connected, let's initialize
+      this._initialized = true;
+      this._pending = initialize(this);
+    }
   }
 
   /**
@@ -160,4 +231,20 @@ export class MosaicClient {
   update() {
     return this;
   }
+}
+
+/**
+ * Perform client initialization. This method has been broken out so we can
+ * capture the resulting promise and set it as the client's pending promise.
+ * @param {MosaicClient} client The Mosaic client to initialize.
+ * @returns {Promise} A Promise that resolves when initialization completes.
+ */
+async function initialize(client) {
+  // retrieve field statistics
+  const fields = client.fields();
+  if (fields?.length) {
+    client.fieldInfo(await queryFieldInfo(client.coordinator, fields));
+  }
+  await client.prepare(); // perform custom preparation
+  return client.requestQuery(); // request data query
 }

--- a/packages/core/src/make-client.js
+++ b/packages/core/src/make-client.js
@@ -9,8 +9,8 @@ import { coordinator as defaultCoordinator } from './Coordinator.js';
  *  Defaults to the global coordinator.
  * @property {Selection|null} [selection] A selection whose predicates are
  *  fed into the query function to produce the SQL query.
- * @property {boolean} [active] A flag (default `true`) indicating if the
- *  client should initially be active or inactive.
+ * @property {boolean} [enabled] A flag (default `true`) indicating if the
+ *  client should initially be enabled or not.
  * @property {function(): Promise<void>} [prepare]
  *  An async function to prepare the client before running queries.
  * @property {function(any): any} [query]
@@ -49,11 +49,11 @@ class ProxyClient extends MosaicClient {
    */
   constructor({
     selection = undefined,
-    active = true,
+    enabled = true,
     ...methods
   }) {
     super(selection);
-    this.active = active;
+    this.enabled = enabled;
 
     /** @type {MakeClientOptions} */
     this._methods = methods;

--- a/packages/core/src/make-client.js
+++ b/packages/core/src/make-client.js
@@ -1,64 +1,88 @@
-import { MosaicClient } from "./MosaicClient.js";
-import {
-  coordinator as defaultCoordinator,
-} from "./Coordinator.js";
+/** @import { Coordinator } from './Coordinator.js' */
+/** @import { Selection } from './Selection.js' */
+import { MosaicClient } from './MosaicClient.js';
+import { coordinator as defaultCoordinator } from './Coordinator.js';
 
 /**
  * @typedef {Object} MakeClientOptions
- * @property {import('./Coordinator.js').Coordinator} [coordinator] - Mosaic coordinator. Default to the global coordinator.
- * @property {import('./Selection.js').Selection|null} [selection] - A selection whose predicates will be fed into the query function to produce the SQL query.
- * @property {function(): Promise<void>} [prepare] - An async function to prepare the client before running queries.
- * @property {function(any): any} query - A function that returns a query from a list of selection predicates.
- * @property {function(any): void} [queryResult] - Called by the coordinator to return a query result.
- * @property {function(): void} [queryPending] - Called by the coordinator to report a query execution error.
- * @property {function(any): void} [queryError] - Called by the coordinator to inform the client that a query is pending.
+ * @property {Coordinator} [coordinator] Mosaic coordinator.
+ *  Defaults to the global coordinator.
+ * @property {Selection|null} [selection] A selection whose predicates are
+ *  fed into the query function to produce the SQL query.
+ * @property {boolean} [active] A flag (default `true`) indicating if the
+ *  client should initially be active or inactive.
+ * @property {function(): Promise<void>} [prepare]
+ *  An async function to prepare the client before running queries.
+ * @property {function(any): any} [query]
+ *  A function that returns a query from a list of selection predicates.
+ * @property {function(any): void} [queryResult]
+ *  Called by the coordinator to return a query result.
+ * @property {function(): void} [queryPending]
+ *  Called by the coordinator to report a query execution error.
+ * @property {function(any): void} [queryError]
+ *  Called by the coordinator to inform the client that a query is pending.
  */
 
-/** Make a new client with the given options, and connect the client to the provided coordinator.
- * @param {MakeClientOptions} options - The options for making the client
- * @returns {MosaicClient & { destroy: () => void }} - The result object with methods to request an update or destroy the client.
+/**
+ * Make a new client with the given options, and connect the client to the
+ * provided coordinator.
+ * @param {MakeClientOptions} options The options for making the client.
+ * @returns {MosaicClient & { destroy: () => void }} The resulting client,
+ *  along with a method to destroy the client when no longer needed.
  */
 export function makeClient(options) {
-  const coordinator = options.coordinator ?? defaultCoordinator();
-  const client = new ProxyClient({ ...options, coordinator });
+  const {
+    coordinator = defaultCoordinator(),
+    ...clientOptions
+  } = options;
+  const client = new ProxyClient(clientOptions);
   coordinator.connect(client);
   return client;
 }
 
-/** An internal class used to implement the makeClient API */
+/**
+ * An internal class used to implement the makeClient API.
+ */
 class ProxyClient extends MosaicClient {
-  /** @param {MakeClientOptions} options */
-  constructor(options) {
-    super(options.selection);
+  /**
+   * @param {MakeClientOptions} options The options for making the client.
+   */
+  constructor({
+    selection = undefined,
+    active = true,
+    ...methods
+  }) {
+    super(selection);
+    this.active = active;
 
     /** @type {MakeClientOptions} */
-    this._options = { ...options };
+    this._methods = methods;
   }
 
   async prepare() {
-    await this._options.prepare?.();
+    await this._methods.prepare?.();
   }
 
   query(filter) {
-    return this._options.query(filter);
+    return this._methods.query?.(filter) ?? null;
   }
 
   queryResult(data) {
-    this._options.queryResult?.(data);
+    this._methods.queryResult?.(data);
     return this;
   }
 
   queryPending() {
-    this._options.queryPending?.();
+    this._methods.queryPending?.();
     return this;
   }
 
   queryError(error) {
-    this._options.queryError?.(error);
+    this._methods.queryError?.(error);
     return this;
   }
 
   destroy() {
-    this._options.coordinator.disconnect(this);
+    this.coordinator.disconnect(this);
   }
 }

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -118,7 +118,7 @@ describe('MosaicClient', () => {
     pending = [];
   });
 
-  it('respects active status', async () => {
+  it('respects enabled status', async () => {
     // instantiate coordinator to use node.js DuckDB
     // disable logging and preaggregation
     const coord = new Coordinator(nodeConnector(), {
@@ -131,13 +131,13 @@ describe('MosaicClient', () => {
     let result = null;
 
     class TestClient extends MosaicClient {
-      constructor() { super(undefined); this.active = false; }
+      constructor() { super(undefined); this.enabled = false; }
       prepare() { prepared = true; }
       query() { queried = true; return Query.select({ foo: 1 }); }
       queryResult(data) { result = data; }
     }
 
-    // client is inactive, lifecycle methods should defer
+    // client is disabled, lifecycle methods should defer
     const client = new TestClient();
     coord.connect(client);
     await client.pending;
@@ -145,18 +145,18 @@ describe('MosaicClient', () => {
     expect(queried).toBe(false);
     expect(result).toBe(null);
 
-    // activate client, initialization and query should proceed
-    client.active = true;
+    // enable client, initialization and query should proceed
+    client.enabled = true;
     await client.pending;
     expect(prepared).toBe(true);
     expect(queried).toBe(true);
     expect(result == null).toBe(false);
 
-    // clear state and deactivate client
+    // clear state and disable client
     prepared = false;
     queried = false;
     result = null;
-    client.active = false;
+    client.enabled = false;
 
     // request re-initialization, methods should defer
     client.initialize();
@@ -165,8 +165,8 @@ describe('MosaicClient', () => {
     expect(queried).toBe(false);
     expect(result).toBe(null);
 
-    // re-activate client, lifecycle methods should proceed
-    client.active = true;
+    // re-enable client, lifecycle methods should proceed
+    client.enabled = true;
     await client.pending;
     expect(prepared).toBe(true);
     expect(queried).toBe(true);


### PR DESCRIPTION
- Add client `enabled` property. When `enabled` is set to false, the client will not initialize nor respond to query requests and selection updates. This setting can improve performance, for example by suppressing updates to off-screen interface components. When `enabled` is set to true, any pending initialization or query requests will then proceed.
- Add `enabled` option to `makeClient` helper utility.
- Refactor initialization logic between coordinator and client.
- Add tests for client `enabled` property.