### PR TITLE
Drop client fields and fieldInfo methods, use prepare instead.

### DIFF
--- a/packages/core/src/Coordinator.js
+++ b/packages/core/src/Coordinator.js
@@ -1,8 +1,12 @@
+/** @import { PreAggregateOptions } from './preagg/PreAggregator.js' */
+/** @import { QueryResult } from './util/query-result.js' */
+/** @import { SelectionClause } from './util/selection-types.js' */
+/** @import { MosaicClient } from './MosaicClient.js' */
+/** @import { Selection } from './Selection.js' */
+/** @import { QueryType } from './types.js' */
 import { socketConnector } from './connectors/socket.js';
 import { PreAggregator } from './preagg/PreAggregator.js';
-import { QueryResult } from './util/query-result.js';
 import { voidLogger } from './util/void-logger.js';
-import { MosaicClient } from './MosaicClient.js';
 import { QueryManager, Priority } from './QueryManager.js';
 
 /**
@@ -35,8 +39,7 @@ export function coordinator(instance) {
  * @param {*} [options.manager] The query manager to use.
  * @param {boolean} [options.cache=true] Boolean flag to enable/disable query caching.
  * @param {boolean} [options.consolidate=true] Boolean flag to enable/disable query consolidation.
- * @param {import('./preagg/PreAggregator.js').PreAggregateOptions} [options.preagg]
- *  Options for the Pre-aggregator.
+ * @param {PreAggregateOptions} [options.preagg] Options for the Pre-aggregator.
  */
 export class Coordinator {
   constructor(db = socketConnector(), {
@@ -109,8 +112,7 @@ export class Coordinator {
 
   /**
    * Issue a query for which no result (return value) is needed.
-   * @param { import('./types.js').QueryType[] |
-   *  import('./types.js').QueryType} query The query or an array of queries.
+   * @param {QueryType[] | QueryType} query The query or an array of queries.
    *  Each query should be either a Query builder object or a SQL string.
    * @param {object} [options] An options object.
    * @param {number} [options.priority] The query priority, defaults to
@@ -125,8 +127,8 @@ export class Coordinator {
   /**
    * Issue a query to the backing database. The submitted query may be
    * consolidate with other queries and its results may be cached.
-   * @param {import('./types.js').QueryType} query The query as either a Query
-   *  builder object or a SQL string.
+   * @param {QueryType} query The query as either a Query builder objec
+   *   or a SQL string.
    * @param {object} [options] An options object.
    * @param {'arrow' | 'json'} [options.type] The query result format type.
    * @param {boolean} [options.cache=true] If true, cache the query result
@@ -149,8 +151,8 @@ export class Coordinator {
   /**
    * Issue a query to prefetch data for later use. The query result is cached
    * for efficient future access.
-   * @param {import('./types.js').QueryType} query The query as either a Query
-   *  builder object or a SQL string.
+   * @param {QueryType} query The query as either a Query builder object
+   *  or a SQL string.
    * @param {object} [options] An options object.
    * @param {'arrow' | 'json'} [options.type] The query result format type.
    * @returns {QueryResult} A query result promise.
@@ -189,7 +191,7 @@ export class Coordinator {
    * Update client data by submitting the given query and returning the
    * data (or error) to the client.
    * @param {MosaicClient} client A Mosaic client.
-   * @param {import('./types.js').QueryType} query The data query.
+   * @param {QueryType} query The data query.
    * @param {number} [priority] The query priority.
    * @returns {Promise} A Promise that resolves upon completion of the update.
    */
@@ -208,7 +210,7 @@ export class Coordinator {
    * the client is simply updated. Otherwise `updateClient` is called. As a
    * side effect, this method clears the current preaggregator state.
    * @param {MosaicClient} client The client to update.
-   * @param {import('./types.js').QueryType | null} [query] The query to issue.
+   * @param {QueryType | null} [query] The query to issue.
    */
   requestQuery(client, query) {
     this.preaggregator.clear();
@@ -261,7 +263,7 @@ export class Coordinator {
 /**
  * Connect a selection-client pair to the coordinator to process updates.
  * @param {Coordinator} mc The Mosaic coordinator.
- * @param {import('./Selection.js').Selection} selection A selection.
+ * @param {Selection} selection A selection.
  * @param {MosaicClient} client A Mosiac client that is filtered by the
  *  given selection.
  */
@@ -293,9 +295,8 @@ function connectSelection(mc, selection, client) {
  * next updates. Activation provides a preview of likely next events,
  * enabling potential precomputation to optimize updates.
  * @param {Coordinator} mc The Mosaic coordinator.
- * @param {import('./Selection.js').Selection} selection A selection.
- * @param {import('./util/selection-types.js').SelectionClause} clause A
- *  selection clause representative of the activation.
+ * @param {Selection} selection A selection.
+ * @param {SelectionClause} clause A selection clause for the activation.
  */
 function activateSelection(mc, selection, clause) {
   const { preaggregator, filterGroups } = mc;
@@ -311,7 +312,7 @@ function activateSelection(mc, selection, clause) {
  * Process an updated selection value, querying filtered data for any
  * associated clients.
  * @param {Coordinator} mc The Mosaic coordinator.
- * @param {import('./Selection.js').Selection} selection A selection.
+ * @param {Selection} selection A selection.
  * @returns {Promise} A Promise that resolves when the update completes.
  */
 function updateSelection(mc, selection) {

--- a/packages/core/test/client.test.js
+++ b/packages/core/test/client.test.js
@@ -132,7 +132,7 @@ describe('MosaicClient', () => {
 
     class TestClient extends MosaicClient {
       constructor() { super(undefined); this.enabled = false; }
-      prepare() { prepared = true; }
+      async prepare() { prepared = true; }
       query() { queried = true; return Query.select({ foo: 1 }); }
       queryResult(data) { result = data; }
     }


### PR DESCRIPTION
This PR simplifies and streamlines the client lifecycle to use a single `prepare` call as part of client initialization. It includes the breaking change of removing the Mosaic client `field` and `fieldInfo` lifecycle methods. Instead of these methods, clients can directly call mosaic-core's `queryFieldInfo` within a client's `prepare` lifecycle method.

- **Breaking**: Drop client `fields` and `fieldInfo` lifecycle methods, rely solely on `prepare` instead. The `queryFieldInfo` can be used instead to lookup field info directly; it uses the same types as the removed methods.
- Update inputs and plot package to call `queryFieldInfo` within the client `prepare` method.
