### PR TITLE
Add classes/types for database connectors.

### DIFF
--- a/packages/core/src/Coordinator.js
+++ b/packages/core/src/Coordinator.js
@@ -1,9 +1,10 @@
+/** @import { Connector } from './connectors/Connector.js' */
 /** @import { PreAggregateOptions } from './preagg/PreAggregator.js' */
 /** @import { QueryResult } from './util/query-result.js' */
 /** @import { SelectionClause } from './util/selection-types.js' */
 /** @import { MosaicClient } from './MosaicClient.js' */
 /** @import { Selection } from './Selection.js' */
-/** @import { QueryType } from './types.js' */
+/** @import { Logger, QueryType } from './types.js' */
 import { socketConnector } from './connectors/socket.js';
 import { PreAggregator } from './preagg/PreAggregator.js';
 import { voidLogger } from './util/void-logger.js';
@@ -33,15 +34,17 @@ export function coordinator(instance) {
  * A Mosaic Coordinator manages all database communication for clients and
  * handles selection updates. The Coordinator also performs optimizations
  * including query caching, consolidation, and pre-aggregation.
- * @param {*} [db] Database connector. Defaults to a web socket connection.
- * @param {object} [options] Coordinator options.
- * @param {*} [options.logger=console] The logger to use, defaults to `console`.
- * @param {*} [options.manager] The query manager to use.
- * @param {boolean} [options.cache=true] Boolean flag to enable/disable query caching.
- * @param {boolean} [options.consolidate=true] Boolean flag to enable/disable query consolidation.
- * @param {PreAggregateOptions} [options.preagg] Options for the Pre-aggregator.
  */
 export class Coordinator {
+  /**
+   * @param {Connector} [db] Database connector. Defaults to a web socket connection.
+   * @param {object} [options] Coordinator options.
+   * @param {Logger} [options.logger=console] The logger to use, defaults to `console`.
+   * @param {QueryManager} [options.manager] The query manager to use.
+   * @param {boolean} [options.cache=true] Boolean flag to enable/disable query caching.
+   * @param {boolean} [options.consolidate=true] Boolean flag to enable/disable query consolidation.
+   * @param {PreAggregateOptions} [options.preagg] Options for the Pre-aggregator.
+   */
   constructor(db = socketConnector(), {
     logger = console,
     manager = new QueryManager(),
@@ -78,8 +81,8 @@ export class Coordinator {
 
   /**
    * Get or set the database connector.
-   * @param {*} [db] The database connector to use.
-   * @returns The current database connector.
+   * @param {Connector} [db] The database connector to use.
+   * @returns {Connector} The current database connector.
    */
   databaseConnector(db) {
     return this.manager.connector(db);
@@ -87,8 +90,8 @@ export class Coordinator {
 
   /**
    * Get or set the logger.
-   * @param {*} logger  The logger to use.
-   * @returns The current logger
+   * @param {Logger} [logger] The logger to use.
+   * @returns {Logger} The current logger
    */
   logger(logger) {
     if (arguments.length) {

--- a/packages/core/src/MosaicClient.js
+++ b/packages/core/src/MosaicClient.js
@@ -205,6 +205,18 @@ export class MosaicClient {
   }
 
   /**
+   * Remove this client: disconnect from the coordinator and free up any
+   * resource use. This method has no effect if the client is not connected
+   * to a coordinator.
+   *
+   * If overriding this method in a client subclass, be sure to also
+   * disconnect from the coordinator.
+   */
+  destroy() {
+    this.coordinator?.disconnect(this);
+  }
+
+  /**
    * Requests a client update, for example to (re-)render an interface
    * component.
    * @returns {this | Promise<any>}

--- a/packages/core/src/QueryManager.js
+++ b/packages/core/src/QueryManager.js
@@ -1,3 +1,5 @@
+/** @import { Connector } from './connectors/Connector.js' */
+/** @import { Cache, Logger } from './types.js' */
 import { consolidator } from './QueryConsolidator.js';
 import { lruCache, voidCache } from './util/cache.js';
 import { PriorityQueue } from './util/priority-queue.js';
@@ -12,10 +14,15 @@ export class QueryManager {
   ) {
     /** @type {PriorityQueue} */
     this.queue = new PriorityQueue(3);
+    /** @type {Connector} */
     this.db = null;
+    /** @type {Cache} */
     this.clientCache = null;
+    /** @type {Logger} */
     this._logger = voidLogger();
+    /** @type {boolean} */
     this._logQueries = false;
+    /** @type {ReturnType<typeof consolidator> | null} */
     this._consolidate = null;
     /**
      * Requests pending with the query manager.
@@ -106,24 +113,48 @@ export class QueryManager {
     }
   }
 
+  /**
+   * Get or set the current query cache.
+   * @param {Cache | boolean} [value]
+   * @returns {Cache}
+   */
   cache(value) {
     return value !== undefined
       ? (this.clientCache = value === true ? lruCache() : (value || voidCache()))
       : this.clientCache;
   }
 
+  /**
+   * Get or set the current logger.
+   * @param {Logger} [value]
+   * @returns {Logger}
+   */
   logger(value) {
     return value ? (this._logger = value) : this._logger;
   }
 
+  /**
+   * Get or set if queries should be logged.
+   * @param {boolean} [value]
+   * @returns {boolean}
+   */
   logQueries(value) {
     return value !== undefined ? this._logQueries = !!value : this._logQueries;
   }
 
+  /**
+   * Get or set the database connector.
+   * @param {Connector} [connector]
+   * @returns {Connector}
+   */
   connector(connector) {
     return connector ? (this.db = connector) : this.db;
   }
 
+  /**
+   * Indicate if query consolidation should be performed.
+   * @param {boolean} flag
+   */
   consolidate(flag) {
     if (flag && !this._consolidate) {
       this._consolidate = consolidator(this.enqueue.bind(this), this.clientCache);

--- a/packages/core/src/connectors/Connector.ts
+++ b/packages/core/src/connectors/Connector.ts
@@ -25,6 +25,6 @@ export interface JSONQueryRequest extends QueryRequest {
 export interface Connector {
   /** Issue a query and return the result. */
   query(query: ArrowQueryRequest): Promise<Table>;
-  query(query: ExecQueryRequest): Promise<undefined>;
+  query(query: ExecQueryRequest): Promise<void>;
   query(query: JSONQueryRequest): Promise<Record<string, any>[]>;
 }

--- a/packages/core/src/connectors/Connector.ts
+++ b/packages/core/src/connectors/Connector.ts
@@ -1,0 +1,30 @@
+import type { Table } from '@uwdata/flechette';
+
+export interface QueryRequest {
+  /** The query type. */
+  type?: string;
+  /** A SQL query string. */
+  sql: string;
+}
+
+export interface ArrowQueryRequest extends QueryRequest {
+  /** The query type. */
+  type?: 'arrow';
+}
+
+export interface ExecQueryRequest extends QueryRequest {
+  /** The query type. */
+  type: 'exec';
+}
+
+export interface JSONQueryRequest extends QueryRequest {
+  /** The query type. */
+  type: 'json';
+}
+
+export interface Connector {
+  /** Issue a query and return the result. */
+  query(query: ArrowQueryRequest): Promise<Table>;
+  query(query: ExecQueryRequest): Promise<undefined>;
+  query(query: JSONQueryRequest): Promise<Record<string, any>[]>;
+}

--- a/packages/core/src/connectors/rest.js
+++ b/packages/core/src/connectors/rest.js
@@ -1,16 +1,13 @@
+/** @import { Connector } from './Connector.js' */
 import { decodeIPC } from '../util/decode-ipc.js';
 
+/**
+ * Connect to a DuckDB server over an HTTP REST interface.
+ * @param {string} uri The URI for the DuckDB REST server.
+ * @returns {Connector} A connector instance.
+ */
 export function restConnector(uri = 'http://localhost:3000/') {
   return {
-    /**
-     * Query the DuckDB server.
-     * @param {object} query
-     * @param {'exec' | 'arrow' | 'json' | 'create-bundle' | 'load-bundle'} [query.type] The query type.
-     * @param {string} [query.sql] A SQL query string.
-     * @param {string[]} [query.queries] The queries used to create a bundle.
-     * @param {string} [query.name] The name of a bundle to create or load.
-     * @returns the query result
-     */
     async query(query) {
       const req = fetch(uri, {
         method: 'POST',
@@ -20,7 +17,6 @@ export function restConnector(uri = 'http://localhost:3000/') {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(query)
       });
-
 
       const res = await req;
 

--- a/packages/core/src/connectors/socket.js
+++ b/packages/core/src/connectors/socket.js
@@ -1,4 +1,5 @@
-/** @import { Connector } from './Connector.js' */
+/** @import { ArrowQueryRequest, Connector, ExecQueryRequest, JSONQueryRequest } from './Connector.js' */
+/** @import { Table } from '@uwdata/flechette' */
 import { decodeIPC } from '../util/decode-ipc.js';
 
 /**
@@ -100,6 +101,22 @@ export class SocketConnector {
     }
   }
 
+  /**
+   * @overload
+   * @param {ArrowQueryRequest} query
+   * @returns {Promise<Table>}
+   *
+   * @overload
+   * @param {ExecQueryRequest} query
+   * @returns {Promise<void>}
+   *
+   * @overload
+   * @param {JSONQueryRequest} query
+   * @returns {Promise<Record<string, any>[]>}
+   *
+   * @param {ArrowQueryRequest | ExecQueryRequest | JSONQueryRequest} query
+   * @returns {Promise<Table | void | Record<string, any>[]>}}
+   */
   query(query) {
     return new Promise(
       (resolve, reject) => this.enqueue(query, resolve, reject)

--- a/packages/core/src/connectors/wasm.js
+++ b/packages/core/src/connectors/wasm.js
@@ -1,8 +1,88 @@
+/** @import { Connector } from './Connector.js' */
 import * as duckdb from '@duckdb/duckdb-wasm';
 import { decodeIPC } from '../util/decode-ipc.js';
 
-// bypass duckdb-wasm query method to get Arrow IPC bytes directly
-// https://github.com/duckdb/duckdb-wasm/issues/267#issuecomment-2252749509
+/**
+ * @typedef {object} DuckDBWASMOptions
+ * @property {boolean} [log] Flag to enable logging.
+ */
+
+/**
+ * @typedef {object} DuckDBWASMConnectorOptions
+ * @property {boolean} [log] Flag to enable logging.
+ * @property {duckdb.AsyncDuckDB} [duckdb]
+ *  Optional pre-existing DuckDB-WASM instance.
+ * @property {duckdb.AsyncDuckDBConnection} [connection]
+ *  Optional pre-existing DuckDB-WASM connection.
+ */
+
+/**
+ * Connect to a DuckDB-WASM instance.
+ * @param {DuckDBWASMConnectorOptions} options Connector options.
+ * @returns {DuckDBWASMConnector} A connector instance.
+ */
+export function wasmConnector(options = {}) {
+  return new DuckDBWASMConnector(options);
+}
+
+/**
+ * DuckDB-WASM connector.
+ * @implements {Connector}
+ */
+export class DuckDBWASMConnector {
+  /**
+   * Create a new DuckDB-WASM connector instance.
+   * @param {DuckDBWASMConnectorOptions} options
+   */
+  constructor(options = {}) {
+    const { duckdb, connection, ...opts } = options;
+    /** @type {DuckDBWASMOptions} */
+    this._options = opts;
+    /** @type {duckdb.AsyncDuckDB} */
+    this._db = duckdb;
+    /** @type {duckdb.AsyncDuckDBConnection} */
+    this._con = connection;
+    /** @type {Promise<unknown>} */
+    this._loadPromise;
+  }
+
+  /**
+   * Get the backing DuckDB-WASM instance.
+   * Lazily initializes DuckDB-WASM if not already loaded.
+   * @returns {Promise<duckdb.AsyncDuckDB>} The DuckDB-WASM instance.
+   */
+  async getDuckDB() {
+    if (!this._db) await connect(this);
+    return this._db;
+  }
+
+  /**
+   * Get the backing DuckDB-WASM connection.
+   * Lazily initializes DuckDB-WASM if not already loaded.
+   * @returns {Promise<duckdb.AsyncDuckDBConnection>} The DuckDB-WASM connection.
+   */
+  async getConnection() {
+    if (!this._con) await connect(this);
+    return this._con;
+  }
+
+  // @ts-ignore
+  async query(query) {
+    const { type, sql } = query;
+    const con = await this.getConnection();
+    const result = await getArrowIPC(con, sql);
+    return type === 'exec' ? undefined
+      : type === 'arrow' ? decodeIPC(result)
+      : decodeIPC(result).toArray();
+  };
+}
+
+/**
+ * Bypass duckdb-wasm query method to get Arrow IPC bytes directly.
+ * https://github.com/duckdb/duckdb-wasm/issues/267#issuecomment-2252749509
+ * @param {duckdb.AsyncDuckDBConnection} con The DuckDB-WASM connection.
+ * @param {string} query The SQL query to run.
+ */
 function getArrowIPC(con, query) {
   return new Promise((resolve, reject) => {
     con.useUnsafe(async (bindings, conn) => {
@@ -16,66 +96,29 @@ function getArrowIPC(con, query) {
   });
 }
 
-export function wasmConnector(options = {}) {
-  const { duckdb, connection, ...opts } = options;
-  let db = duckdb;
-  let con = connection;
-  let loadPromise;
-
-  function load() {
-    if (!loadPromise) {
-      // use a loading promise to avoid race conditions
-      // synchronizes multiple callees on the same load
-      loadPromise = (db
-        ? Promise.resolve(db)
-        : initDatabase(opts).then(result => db = result))
-        .then(db => db.connect())
-        .then(result => con = result);
-    }
-    return loadPromise;
+/**
+ * Establish a new database connection for the given connector.
+ * @param {DuckDBWASMConnector} c The connector.
+ * @returns {Promise<unknown>}
+ */
+function connect(c) {
+  if (!c._loadPromise) {
+    // use a loading promise to avoid race conditions
+    // synchronizes multiple callees on the same load
+    c._loadPromise = (
+      c._db
+        ? Promise.resolve(c._db)
+        : initDatabase(c._options).then(result => c._db = result))
+      .then(db => db.connect())
+      .then(result => c._con = result);
   }
-
-  /**
-   * Get the backing DuckDB-WASM instance.
-   * Will lazily initialize DuckDB-WASM if not already loaded.
-   * @returns {Promise<duckdb.AsyncDuckDB>} The DuckDB-WASM instance.
-   */
-  async function getDuckDB() {
-    if (!db) await load();
-    return db;
-  }
-
-  /**
-   * Get the backing DuckDB-WASM connection.
-   * Will lazily initialize DuckDB-WASM if not already loaded.
-   * @returns {Promise<duckdb.AsyncDuckDBConnection>} The DuckDB-WASM connection.
-   */
-  async function getConnection() {
-    if (!con) await load();
-    return con;
-  }
-
-  return {
-    getDuckDB,
-    getConnection,
-    /**
-     * Query the DuckDB-WASM instance.
-     * @param {object} query
-     * @param {'exec' | 'arrow' | 'json'} [query.type] The query type.
-     * @param {string} query.sql A SQL query string.
-     * @returns the query result
-     */
-    query: async query => {
-      const { type, sql } = query;
-      const con = await getConnection();
-      const result = await getArrowIPC(con, sql);
-      return type === 'exec' ? undefined
-        : type === 'arrow' ? decodeIPC(result)
-        : decodeIPC(result).toArray();
-    }
-  };
+  return c._loadPromise;
 }
 
+/**
+ * Initialize a new DuckDB-WASM instance.
+ * @param {DuckDBWASMOptions} options
+ */
 async function initDatabase({
   log = false
 } = {}) {

--- a/packages/core/src/connectors/wasm.js
+++ b/packages/core/src/connectors/wasm.js
@@ -1,4 +1,5 @@
-/** @import { Connector } from './Connector.js' */
+/** @import { ArrowQueryRequest, Connector, ExecQueryRequest, JSONQueryRequest } from './Connector.js' */
+/** @import { Table } from '@uwdata/flechette' */
 import * as duckdb from '@duckdb/duckdb-wasm';
 import { decodeIPC } from '../util/decode-ipc.js';
 
@@ -66,7 +67,22 @@ export class DuckDBWASMConnector {
     return this._con;
   }
 
-  // @ts-ignore
+  /**
+   * @overload
+   * @param {ArrowQueryRequest} query
+   * @returns {Promise<Table>}
+   *
+   * @overload
+   * @param {ExecQueryRequest} query
+   * @returns {Promise<void>}
+   *
+   * @overload
+   * @param {JSONQueryRequest} query
+   * @returns {Promise<Record<string, any>[]>}
+   *
+   * @param {ArrowQueryRequest | ExecQueryRequest | JSONQueryRequest} query
+   * @returns {Promise<Table | void | Record<string, any>[]>}}
+   */
   async query(query) {
     const { type, sql } = query;
     const con = await this.getConnection();

--- a/packages/core/src/index-types.ts
+++ b/packages/core/src/index-types.ts
@@ -1,3 +1,4 @@
 export * from './index.js';
 export * from './types.js';
+export * from './connectors/Connector.js';
 export * from './util/selection-types.js';

--- a/packages/core/src/make-client.js
+++ b/packages/core/src/make-client.js
@@ -98,8 +98,4 @@ class ProxyClient extends MosaicClient {
     this._methods.queryError?.(error);
     return this;
   }
-
-  destroy() {
-    this.coordinator.disconnect(this);
-  }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -81,4 +81,7 @@ export interface Logger {
   log(...args: any[]): void;
   warn(...args: any[]): void;
   error(...args: any[]): void;
+  group(label?: any): void;
+  groupCollapsed(label?: any): void;
+  groupEnd(): void;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,7 +64,7 @@ export interface Activatable {
 }
 
 /**
- * Interface for cache implmenetions.
+ * Interface for cache implementations.
  */
 export interface Cache {
   get(key: string): any;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -62,3 +62,23 @@ export interface Activatable {
    */
   activate(): void;
 }
+
+/**
+ * Interface for cache implmenetions.
+ */
+export interface Cache {
+  get(key: string): any;
+  set(key: string, value: any): any;
+  clear(): void;
+}
+
+/**
+ * Interface for logger implementations
+ */
+export interface Logger {
+  debug(...args: any[]): void;
+  info(...args: any[]): void;
+  log(...args: any[]): void;
+  warn(...args: any[]): void;
+  error(...args: any[]): void;
+}

--- a/packages/core/src/util/cache.js
+++ b/packages/core/src/util/cache.js
@@ -6,17 +6,22 @@ const requestIdle = typeof requestIdleCallback !== 'undefined'
 
 /**
  * Create a new cache that ignores all values.
- * @type {() => Cache}
+ * @returns {Cache}
  */
-export const voidCache = () => ({
-  get: () => undefined,
-  set: (key, value) => value,
-  clear: () => {}
-});
+export function voidCache() {
+  return {
+    get: () => undefined,
+    set: (key, value) => value,
+    clear: () => {}
+  };
+}
 
 /**
  * Create a new cache that uses an LRU eviction policy.
- * @type {(options?: {max?: number, ttl?: number}) => Cache}
+ * @param {object} [options] Cache options.
+ * @param {number} [options.max] Maximum number of cache entries.
+ * @param {number} [options.ttl] Time-to-live for cache entries.
+ * @returns {Cache}
  */
 export function lruCache({
   max = 1000, // max entries

--- a/packages/core/src/util/cache.js
+++ b/packages/core/src/util/cache.js
@@ -1,13 +1,23 @@
+/** @import { Cache } from '../types.js' */
+
 const requestIdle = typeof requestIdleCallback !== 'undefined'
   ? requestIdleCallback
   : setTimeout;
 
+/**
+ * Create a new cache that ignores all values.
+ * @type {() => Cache}
+ */
 export const voidCache = () => ({
   get: () => undefined,
   set: (key, value) => value,
   clear: () => {}
 });
 
+/**
+ * Create a new cache that uses an LRU eviction policy.
+ * @type {(options?: {max?: number, ttl?: number}) => Cache}
+ */
 export function lruCache({
   max = 1000, // max entries
   ttl = 3 * 60 * 60 * 1000 // time-to-live, default 3 hours

--- a/packages/core/src/util/void-logger.js
+++ b/packages/core/src/util/void-logger.js
@@ -5,6 +5,9 @@ export function voidLogger() {
     info(..._) {},
     log(..._) {},
     warn(..._) {},
-    error(..._) {}
+    error(..._) {},
+    group(label) {},
+    groupCollapsed(label) {},
+    groupEnd() {}
   };
 }

--- a/packages/widget/src/index.js
+++ b/packages/widget/src/index.js
@@ -47,6 +47,7 @@ export default {
       view.model.send({ ...query, uuid });
     }
 
+    /** @type {import('@uwdata/mosaic-core').Connector} */
     const connector = {
       query(query) {
         return new Promise((resolve, reject) => send(query, resolve, reject));
@@ -126,7 +127,7 @@ export default {
           }
         }
       }
-      logger.groupEnd('query');
+      logger.groupEnd();
     });
 
     coordinator().databaseConnector(connector);


### PR DESCRIPTION
- Add database connector types.
- Add class-based implementations of socket and wasm connectors.
- Add `destroy` method to client, transferred from `make-client` helper.