### PR TITLE
Mosaic Widget: avoid `params` mutation - fixes #746

### DIFF
--- a/packages/widget/src/index.js
+++ b/packages/widget/src/index.js
@@ -76,7 +76,7 @@ export default {
 
         param.addEventListener('value', (value) => {
           view.model.set('params', {
-            ...params,
+            ...view.model.get('params'),
             [name]: {
               value,
               ...(isSelection(param) ? { predicate: String(param.predicate()) } : {})

--- a/packages/widget/src/index.js
+++ b/packages/widget/src/index.js
@@ -75,11 +75,13 @@ export default {
         };
 
         param.addEventListener('value', (value) => {
-          params[name] = {
-            value,
-            ...(isSelection(param) ? { predicate: String(param.predicate()) } : {}),
-          };
-          view.model.set('params', params);
+          view.model.set('params', {
+            ...params,
+            [name]: {
+              value,
+              ...(isSelection(param) ? { predicate: String(param.predicate()) } : {})
+            },
+          });
           view.model.save_changes();
         });
       }

--- a/packages/widget/src/index.js
+++ b/packages/widget/src/index.js
@@ -66,10 +66,10 @@ export default {
       view.el.replaceChildren(dom.element);
 
       /** @type Params */
-      const params = {};
+      const initialParams = {};
 
       for (const [name, param] of dom.params) {
-        params[name] = {
+        initialParams[name] = {
           value: param.value,
           ...(isSelection(param) ? { predicate: String(param.predicate()) } : {}),
         };
@@ -86,7 +86,7 @@ export default {
         });
       }
 
-      view.model.set('params', params);
+      view.model.set('params', initialParams);
       view.model.save_changes();
     }
 


### PR DESCRIPTION
Permits Mosaic Widget `params` reactivity in marimo (don't know if issue affected Jupyter)