### PR TITLE
feat: changed describe query to support clickhouse

### DIFF
--- a/packages/sql/src/ast/query.js
+++ b/packages/sql/src/ast/query.js
@@ -515,7 +515,7 @@ export class DescribeQuery extends SQLNode {
    * @returns {string}
    */
   toString() {
-    return `DESCRIBE ${this.query}`;
+    return `DESC(${this.query})`;
   }
 }
 

--- a/packages/sql/test/query.test.js
+++ b/packages/sql/test/query.test.js
@@ -500,12 +500,12 @@ describe('Query', () => {
 
   it('supports describe queries', () => {
     const q = Query.select('foo', 'bar').from('data');
-    expect(Query.describe(q).toString()).toBe(`DESCRIBE ${q}`);
+    expect(Query.describe(q).toString()).toBe(`DESC(${q})`);
 
     const u = Query.unionAll(
       Query.select('foo', 'bar').from('data1'),
       Query.select('foo', 'bar').from('data2')
     );
-    expect(Query.describe(u).toString()).toBe(`DESCRIBE ${u}`);
+    expect(Query.describe(u).toString()).toBe(`DESC(${u})`);
   });
 });


### PR DESCRIPTION
Previously describe query used `DESCRIBE`, which was only supported by DuckDB. Changed query to `DESC()` which is supported by both DuckDB and Clickhouse. 