### PR TITLE
chore: update duckdb rust client

### DIFF
--- a/packages/duckdb-server-rust/Cargo.lock
+++ b/packages/duckdb-server-rust/Cargo.lock
@@ -1034,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8c35886fbb5356fe90c8a9b69da5623d509c32bdfb6eefa7f57081eb05f69b"
+checksum = "49ac283b6621e3becf8014d1efa655522794075834c72f744573debef9c9f6c8"
 dependencies = [
  "arrow",
  "cast",
@@ -1826,9 +1826,9 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddeb5c68cb108d753a03613337f4bc9bed32281123d1f7884971f060f532fb6c"
+checksum = "12cac9d03484c43fefac8b2066a253c9b0b3b0cd02cbe02a9ea2312f7e382618"
 dependencies = [
  "autocfg",
  "cc",

--- a/packages/duckdb-server-rust/Cargo.toml
+++ b/packages/duckdb-server-rust/Cargo.toml
@@ -20,7 +20,7 @@ axum = { version = "0.8", features = ["http1", "http2", "ws", "json", "tokio", "
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 axum-server-dual-protocol = "0.7"
 clap = { version = "4.5", features = ["derive"] }
-duckdb = { version = "1.2", features = ["bundled", "csv", "json", "parquet", "url", "r2d2"] }
+duckdb = { version = "1.2.2", features = ["bundled", "csv", "json", "parquet", "url", "r2d2"] }
 futures = "0.3"
 listenfd = "1.0"
 lru = "0.13"


### PR DESCRIPTION
Update DuckDB Rust client to `>= 1.2.2`. [The version 1.2.2 includes many bug fixes](https://github.com/duckdb/duckdb/releases/tag/v1.2.2) including https://github.com/duckdb/duckdb/pull/16691

Note that [`version = "1.2.2"` represents the version range `>=1.2.2, <2.0.0`](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#version-requirement-syntax)