### PR TITLE
Expose Arrow IPC options for database connectors.

### DIFF
--- a/dev/setup.js
+++ b/dev/setup.js
@@ -35,7 +35,7 @@ export async function setDatabaseConnector(type) {
       connector = restConnector();
       break;
     case 'rest_https':
-      connector = restConnector('https://localhost:3000/');
+      connector = restConnector({ uri: 'https://localhost:3000/' });
       break;
     case 'wasm':
       connector = wasm || (wasm = wasmConnector());

--- a/packages/core/src/connectors/rest.js
+++ b/packages/core/src/connectors/rest.js
@@ -1,12 +1,18 @@
 /** @import { Connector } from './Connector.js' */
+/** @import { ExtractionOptions } from '../util/decode-ipc.js' */
 import { decodeIPC } from '../util/decode-ipc.js';
 
 /**
  * Connect to a DuckDB server over an HTTP REST interface.
- * @param {string} uri The URI for the DuckDB REST server.
+ * @param {object} [options] Connector options.
+ * @param {string} [options.uri] The URI for the DuckDB REST server.
+ * @param {ExtractionOptions} [options.ipc] Arrow IPC extraction options.
  * @returns {Connector} A connector instance.
  */
-export function restConnector(uri = 'http://localhost:3000/') {
+export function restConnector({
+  uri = 'http://localhost:3000/',
+  ipc = undefined,
+} = {}) {
   return {
     async query(query) {
       const req = fetch(uri, {
@@ -25,7 +31,7 @@ export function restConnector(uri = 'http://localhost:3000/') {
       }
 
       return query.type === 'exec' ? req
-        : query.type === 'arrow' ? decodeIPC(await res.arrayBuffer())
+        : query.type === 'arrow' ? decodeIPC(await res.arrayBuffer(), ipc)
         : res.json();
     }
   };

--- a/packages/core/src/connectors/rest.js
+++ b/packages/core/src/connectors/rest.js
@@ -1,5 +1,5 @@
+/** @import { ExtractionOptions } from '@uwdata/flechette' */
 /** @import { Connector } from './Connector.js' */
-/** @import { ExtractionOptions } from '../util/decode-ipc.js' */
 import { decodeIPC } from '../util/decode-ipc.js';
 
 /**

--- a/packages/core/src/connectors/socket.js
+++ b/packages/core/src/connectors/socket.js
@@ -1,6 +1,5 @@
+/** @import { ExtractionOptions, Table } from '@uwdata/flechette' */
 /** @import { ArrowQueryRequest, Connector, ExecQueryRequest, JSONQueryRequest } from './Connector.js' */
-/** @import { ExtractionOptions } from '../util/decode-ipc.js' */
-/** @import { Table } from '@uwdata/flechette' */
 import { decodeIPC } from '../util/decode-ipc.js';
 
 /**

--- a/packages/core/src/connectors/socket.js
+++ b/packages/core/src/connectors/socket.js
@@ -1,14 +1,17 @@
 /** @import { ArrowQueryRequest, Connector, ExecQueryRequest, JSONQueryRequest } from './Connector.js' */
+/** @import { ExtractionOptions } from '../util/decode-ipc.js' */
 /** @import { Table } from '@uwdata/flechette' */
 import { decodeIPC } from '../util/decode-ipc.js';
 
 /**
  * Connect to a DuckDB server over a WebSocket interface.
- * @param {string} uri The URI for the DuckDB socket server.
+ * @param {object} [options] Connector options.
+ * @param {string} [options.uri] The URI for the DuckDB REST server.
+ * @param {ExtractionOptions} [options.ipc] Arrow IPC extraction options.
  * @returns {SocketConnector} A connector instance.
  */
-export function socketConnector(uri = 'ws://localhost:3000/') {
-  return new SocketConnector(uri);
+export function socketConnector(options) {
+  return new SocketConnector(options);
 }
 
 /**
@@ -16,7 +19,15 @@ export function socketConnector(uri = 'ws://localhost:3000/') {
  * @implements {Connector}
  */
 export class SocketConnector {
-  constructor(uri = 'ws://localhost:3000/') {
+  /**
+   * @param {object} [options] Connector options.
+   * @param {string} [options.uri] The URI for the DuckDB REST server.
+   * @param {ExtractionOptions} [options.ipc] Arrow IPC extraction options.
+   */
+  constructor({
+    uri = 'ws://localhost:3000/',
+    ipc = undefined,
+  } = {}) {
     this._uri = uri;
     this._queue = [];
     this._connected = false;
@@ -65,7 +76,7 @@ export class SocketConnector {
           } else if (query.type === 'exec') {
             resolve();
           } else if (query.type === 'arrow') {
-            resolve(decodeIPC(data));
+            resolve(decodeIPC(data, ipc));
           } else {
             throw new Error(`Unexpected socket data: ${data}`);
           }

--- a/packages/core/src/connectors/wasm.js
+++ b/packages/core/src/connectors/wasm.js
@@ -1,6 +1,5 @@
+/** @import { ExtractionOptions, Table } from '@uwdata/flechette' */
 /** @import { ArrowQueryRequest, Connector, ExecQueryRequest, JSONQueryRequest } from './Connector.js' */
-/** @import { ExtractionOptions } from '../util/decode-ipc.js' */
-/** @import { Table } from '@uwdata/flechette' */
 import * as duckdb from '@duckdb/duckdb-wasm';
 import { decodeIPC } from '../util/decode-ipc.js';
 

--- a/packages/core/src/connectors/wasm.js
+++ b/packages/core/src/connectors/wasm.js
@@ -1,4 +1,5 @@
 /** @import { ArrowQueryRequest, Connector, ExecQueryRequest, JSONQueryRequest } from './Connector.js' */
+/** @import { ExtractionOptions } from '../util/decode-ipc.js' */
 /** @import { Table } from '@uwdata/flechette' */
 import * as duckdb from '@duckdb/duckdb-wasm';
 import { decodeIPC } from '../util/decode-ipc.js';
@@ -11,6 +12,8 @@ import { decodeIPC } from '../util/decode-ipc.js';
 /**
  * @typedef {object} DuckDBWASMConnectorOptions
  * @property {boolean} [log] Flag to enable logging.
+ * @property {ExtractionOptions} [ipc]
+ *  Arrow IPC extraction options.
  * @property {duckdb.AsyncDuckDB} [duckdb]
  *  Optional pre-existing DuckDB-WASM instance.
  * @property {duckdb.AsyncDuckDBConnection} [connection]
@@ -19,7 +22,7 @@ import { decodeIPC } from '../util/decode-ipc.js';
 
 /**
  * Connect to a DuckDB-WASM instance.
- * @param {DuckDBWASMConnectorOptions} options Connector options.
+ * @param {DuckDBWASMConnectorOptions} [options] Connector options.
  * @returns {DuckDBWASMConnector} A connector instance.
  */
 export function wasmConnector(options = {}) {
@@ -33,10 +36,12 @@ export function wasmConnector(options = {}) {
 export class DuckDBWASMConnector {
   /**
    * Create a new DuckDB-WASM connector instance.
-   * @param {DuckDBWASMConnectorOptions} options
+   * @param {DuckDBWASMConnectorOptions} [options]
    */
   constructor(options = {}) {
-    const { duckdb, connection, ...opts } = options;
+    const { ipc, duckdb, connection, ...opts } = options;
+    /** @type {ExtractionOptions} */
+    this._ipc = ipc;
     /** @type {DuckDBWASMOptions} */
     this._options = opts;
     /** @type {duckdb.AsyncDuckDB} */
@@ -88,7 +93,7 @@ export class DuckDBWASMConnector {
     const con = await this.getConnection();
     const result = await getArrowIPC(con, sql);
     return type === 'exec' ? undefined
-      : type === 'arrow' ? decodeIPC(result)
+      : type === 'arrow' ? decodeIPC(result, this._ipc)
       : decodeIPC(result).toArray();
   };
 }

--- a/packages/core/src/util/decode-ipc.js
+++ b/packages/core/src/util/decode-ipc.js
@@ -1,8 +1,6 @@
 /** @import { ExtractionOptions, Table } from '@uwdata/flechette' */
 import { tableFromIPC } from '@uwdata/flechette';
 
-/** @export { ExtractionOptions } */
-
 /**
  * Decode Arrow IPC bytes to a table instance.
  * The default options map date and timestamp values to JS Date objects.

--- a/packages/core/src/util/decode-ipc.js
+++ b/packages/core/src/util/decode-ipc.js
@@ -1,11 +1,17 @@
+/** @import { ExtractionOptions, Table } from '@uwdata/flechette' */
 import { tableFromIPC } from '@uwdata/flechette';
 
+/** @export { ExtractionOptions } */
+
 /**
- * Decode Arrow IPC bytes to a table instance, with an option to map date and
- * timestamp values to JS Date objects.
+ * Decode Arrow IPC bytes to a table instance.
+ * The default options map date and timestamp values to JS Date objects.
  * @param {ArrayBuffer | Uint8Array} data Arrow IPC bytes.
- * @returns {import('@uwdata/flechette').Table} A table instance.
+ * @param {ExtractionOptions} [options] Arrow IPC extraction options.
+ *  If unspecified, the default options will extract date and timestamp
+ *  values to JS Date objects.
+ * @returns {Table} A table instance.
  */
-export function decodeIPC(data) {
-  return tableFromIPC(data, { useDate: true });
+export function decodeIPC(data, options = { useDate: true }) {
+  return tableFromIPC(data, options);
 }

--- a/packages/core/test/util/node-connector.js
+++ b/packages/core/test/util/node-connector.js
@@ -1,7 +1,7 @@
 import { DuckDB } from '@uwdata/mosaic-duckdb';
 import { decodeIPC } from '../../src/util/decode-ipc.js';
 
-export function nodeConnector(db = new DuckDB()) {
+export function nodeConnector(db = new DuckDB(), ipc) {
   return {
     /**
      * Query an in-process DuckDB instance.
@@ -16,7 +16,7 @@ export function nodeConnector(db = new DuckDB()) {
         case 'exec':
           return db.exec(sql);
         case 'arrow':
-          return decodeIPC(await db.arrowBuffer(sql));
+          return decodeIPC(await db.arrowBuffer(sql), ipc);
         default:
           return db.query(sql);
       }


### PR DESCRIPTION
- **Breaking** Change Rest and Socket connectors to accept options object, not URI string.
- Add `ipc` option to connectors to pass Flechette extraction options for Arrow IPC decoding.