### PR TITLE
v0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -855,15 +855,6 @@
         }
       }
     },
-    "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.29.0.tgz",
-      "integrity": "sha512-8Zq7vafQuIz9gklC/9375KE38UlkaS2n8+yvG+/JK7irm3DjwYNJHL4xfplIj0bSHFIg6we5XhWYFqtE/vO3+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "apache-arrow": "^17.0.0"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
@@ -16491,6 +16482,15 @@
       },
       "devDependencies": {
         "@uwdata/mosaic-duckdb": "^0.15.0"
+      }
+    },
+    "packages/core/node_modules/@duckdb/duckdb-wasm": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.29.0.tgz",
+      "integrity": "sha512-8Zq7vafQuIz9gklC/9375KE38UlkaS2n8+yvG+/JK7irm3DjwYNJHL4xfplIj0bSHFIg6we5XhWYFqtE/vO3+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "apache-arrow": "^17.0.0"
       }
     },
     "packages/duckdb": {


### PR DESCRIPTION
**Changelog**

- **Breaking**: Modify Rest and Socket connector methods to accept an options object, not a URI string. The server `uri` is now passed as an option instead.
- Add `ipc` option to connectors to pass Flechette extraction options for Arrow IPC decoding.
- Add types for database connectors, move to class-based implementations.
- Add types for inputs package.
- Add DuckDB `ENUM` type interpretion support. (thanks @kwonoh!)
- Fix Param mutation issue in Jupyter widget.
- Fix some Mosaic client types. (thanks @kwonoh!)
- Update dependencies.
