### PR TITLE
ci: fix docs build by using the same aliases as vite

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,10 +1,18 @@
 import { defineConfig } from 'vitepress'
+import viteConfig from '../../vite.config.js';
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: 'Mosaic',
   description: 'Scalable, interactive data visualization',
   base: '/mosaic/',
+  vite: {
+    resolve: {
+      alias: Object.fromEntries(
+        Object.entries(viteConfig.resolve.alias).map(([key, value]) => [key, `.${value}`])
+      )
+    }
+  },
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     logo: {


### PR DESCRIPTION
Follow up from #792. The issue was that I didn't upset vitepress to use the source files. 

Should fix https://github.com/uwdata/mosaic/actions/runs/15714123543.