### PR TITLE
fix: explicitly list files for core package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docs:schema": "node bin/publish-schema.js && bin/push-schema.sh",
     "build": "tsc --build && lerna run build",
     "lint": "lerna run lint",
-    "test": "vitest run && lerna run tsc",
+    "test": "vitest run && tsc --build",
     "server": "cd packages/duckdb-server && npm run dev",
     "server:rust": "cd packages/duckdb-server-rust && cargo run",
     "server:node": "nodemon packages/duckdb/bin/run-server.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"
   },
-    "files": [
+  "files": [
     "dist",
     "!dist/tsconfig.tsbuildinfo",
     "src"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,11 @@
     "types": "./dist/src/index.d.ts",
     "default": "./dist/src/index.js"
   },
+    "files": [
+    "dist",
+    "!dist/tsconfig.tsbuildinfo",
+    "src"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/uwdata/mosaic.git"

--- a/packages/inputs/package.json
+++ b/packages/inputs/package.json
@@ -13,6 +13,11 @@
     "types": "./dist/src/index.d.ts",
     "default": "./src/index.js"
   },
+  "files": [
+    "dist",
+    "!dist/tsconfig.tsbuildinfo",
+    "src"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/uwdata/mosaic.git"

--- a/packages/plot/package.json
+++ b/packages/plot/package.json
@@ -16,6 +16,11 @@
     "types": "./dist/src/index.d.ts",
     "default": "./src/index.js"
   },
+  "files": [
+    "dist",
+    "!dist/tsconfig.tsbuildinfo",
+    "src"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/uwdata/mosaic.git"

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -16,6 +16,11 @@
     "types": "./dist/src/index.d.ts",
     "default": "./src/index.js"
   },
+  "files": [
+    "dist",
+    "!dist/tsconfig.tsbuildinfo",
+    "src"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/uwdata/mosaic.git"

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -14,6 +14,11 @@
     "types": "./dist/src/index-types.d.ts",
     "default": "./src/index.js"
   },
+  "files": [
+    "dist",
+    "!dist/tsconfig.tsbuildinfo",
+    "src"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/uwdata/mosaic.git"

--- a/packages/vgplot/package.json
+++ b/packages/vgplot/package.json
@@ -18,6 +18,11 @@
     "types": "./dist/src/index.d.ts",
     "default": "./src/index.js"
   },
+  "files": [
+    "dist",
+    "!dist/tsconfig.tsbuildinfo",
+    "src"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/uwdata/mosaic.git"


### PR DESCRIPTION
fixes #796

At least this now includes the files in `dist` in the package. I don't know exactly what runs for a deploy but somehow the tsc build needs to run as well (which it should because it's in `prepublishOnly`).