### PR TITLE
chore: improve build and test scripts

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -7,11 +7,7 @@ export default defineConfig({
   description: 'Scalable, interactive data visualization',
   base: '/mosaic/',
   vite: {
-    resolve: {
-      alias: Object.fromEntries(
-        Object.entries(viteConfig.resolve.alias).map(([key, value]) => [key, `.${value}`])
-      )
-    }
+    resolve: viteConfig.resolve
   },
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,8 +29,7 @@
     "clean": "rimraf dist && mkdir dist",
     "lint": "eslint src test",
     "test": "vitest run",
-    "tsc": "tsc",
-    "prepublishOnly": "npm run test && npm run lint && npm run tsc"
+    "prepublishOnly": "npm run test && npm run lint && tsc --build"
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "^1.29.0",

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,3 +1,6 @@
 import { defineConfig } from 'vite';
+import viteConfig from '../../vite.config.js';
 
-export default defineConfig({});
+export default defineConfig({
+  resolve: viteConfig.resolve,
+});

--- a/packages/duckdb/package.json
+++ b/packages/duckdb/package.json
@@ -36,8 +36,7 @@
     "lint": "eslint src test",
     "server": "node bin/run-server.js",
     "test": "vitest run",
-    "tsc": "tsc",
-    "prepublishOnly": "npm run test && npm run lint && npm run tsc"
+    "prepublishOnly": "npm run test && npm run lint && tsc --build"
   },
   "dependencies": {
     "@uwdata/mosaic-sql": "^0.17.0",

--- a/packages/duckdb/vitest.config.ts
+++ b/packages/duckdb/vitest.config.ts
@@ -1,3 +1,6 @@
 import { defineConfig } from 'vite';
+import viteConfig from '../../vite.config.js';
 
-export default defineConfig({});
+export default defineConfig({
+  resolve: viteConfig.resolve,
+});

--- a/packages/inputs/package.json
+++ b/packages/inputs/package.json
@@ -27,8 +27,7 @@
     "prebuild": "npm run clean",
     "lint": "eslint src test",
     "test": "vitest run",
-    "tsc": "tsc",
-    "prepublishOnly": "npm run test && npm run lint && npm run tsc"
+    "prepublishOnly": "npm run test && npm run lint && tsc --build"
   },
   "dependencies": {
     "@uwdata/mosaic-core": "^0.17.0",

--- a/packages/inputs/vitest.config.ts
+++ b/packages/inputs/vitest.config.ts
@@ -1,3 +1,6 @@
 import { defineConfig } from 'vite';
+import viteConfig from '../../vite.config.js';
 
-export default defineConfig({});
+export default defineConfig({
+  resolve: viteConfig.resolve,
+});

--- a/packages/plot/package.json
+++ b/packages/plot/package.json
@@ -30,8 +30,7 @@
     "prebuild": "npm run clean",
     "lint": "eslint src test",
     "test": "vitest run",
-    "tsc": "tsc",
-    "prepublishOnly": "npm run test && npm run lint && npm run tsc"
+    "prepublishOnly": "npm run test && npm run lint && tsc --build"
   },
   "dependencies": {
     "@observablehq/plot": "^0.6.17",

--- a/packages/plot/vitest.config.ts
+++ b/packages/plot/vitest.config.ts
@@ -1,3 +1,6 @@
 import { defineConfig } from 'vite';
+import viteConfig from '../../vite.config.js';
 
-export default defineConfig({});
+export default defineConfig({
+  resolve: viteConfig.resolve,
+});

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -30,7 +30,7 @@
     "prebuild": "npm run clean",
     "build": "npm run schema",
     "lint": "eslint src test",
-    "preschema": "tsc",
+    "preschema": "tsc --build",
     "schema": "ts-json-schema-generator -f tsconfig.json -p src/spec/Spec.ts -t Spec --no-type-check --no-ref-encode --functions hide > dist/mosaic-schema.json",
     "test": "npm run schema && vitest run",
 

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -30,10 +30,10 @@
     "prebuild": "npm run clean",
     "build": "npm run schema",
     "lint": "eslint src test",
-    "preschema": "npm run tsc",
+    "preschema": "tsc",
     "schema": "ts-json-schema-generator -f tsconfig.json -p src/spec/Spec.ts -t Spec --no-type-check --no-ref-encode --functions hide > dist/mosaic-schema.json",
     "test": "npm run schema && vitest run",
-    "tsc": "tsc",
+
     "version": "cd ../.. && npm run docs:schema",
     "prepublishOnly": "npm run test && npm run lint && npm run build"
   },

--- a/packages/spec/vitest.config.ts
+++ b/packages/spec/vitest.config.ts
@@ -1,3 +1,6 @@
 import { defineConfig } from 'vite';
+import viteConfig from '../../vite.config.js';
 
-export default defineConfig({});
+export default defineConfig({
+  resolve: viteConfig.resolve,
+});

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -27,7 +27,6 @@
     "clean": "rimraf dist && mkdir dist",
     "lint": "eslint src test",
     "test": "vitest run",
-    "tsc": "tsc",
-    "prepublishOnly": "npm run test && npm run lint && npm run tsc"
+    "prepublishOnly": "npm run test && npm run lint && tsc --build"
   }
 }

--- a/packages/sql/vitest.config.ts
+++ b/packages/sql/vitest.config.ts
@@ -1,3 +1,6 @@
 import { defineConfig } from 'vite';
+import viteConfig from '../../vite.config.js';
 
-export default defineConfig({});
+export default defineConfig({
+  resolve: viteConfig.resolve
+});

--- a/packages/vgplot/package.json
+++ b/packages/vgplot/package.json
@@ -32,8 +32,7 @@
     "prebuild": "npm run clean",
     "lint": "eslint src test",
     "test": "vitest run",
-    "tsc": "tsc",
-    "prepublishOnly": "npm run test && npm run lint && npm run tsc"
+    "prepublishOnly": "npm run test && npm run lint && tsc --build"
   },
   "dependencies": {
     "@uwdata/mosaic-core": "^0.17.0",

--- a/packages/vgplot/vitest.config.ts
+++ b/packages/vgplot/vitest.config.ts
@@ -1,3 +1,6 @@
 import { defineConfig } from 'vite';
+import viteConfig from '../../vite.config.js';
 
-export default defineConfig({});
+export default defineConfig({
+  resolve: viteConfig.resolve,
+});

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -10,11 +10,11 @@
     "url": "https://github.com/uwdata/mosaic.git"
   },
   "scripts": {
+    "clean": "rimraf mosaic_widget/static",
     "build": "esbuild --bundle --format=esm --outdir=mosaic_widget/static src/index.js",
     "dev": "npm run build -- --watch",
-    "test": "npm run tsc",
+    "test": "tsc --build",
     "lint": "eslint src",
-    "tsc": "tsc",
     "prerelease": "npm run test && npm run lint && uv run ruff check && uv run ruff format --check && npm run build",
     "release": "uv build && uvx twine upload --skip-existing ../../dist/mosaic_widget*"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,4 @@
-import path from "path";
+import path from 'path';
 
 /** @type {import('vite').UserConfig} */
 export default {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,5 @@
+import path from "path";
+
 /** @type {import('vite').UserConfig} */
 export default {
   server: {
@@ -6,12 +8,12 @@ export default {
   resolve: {
     alias: {
       // Define aliases so that vite picks up the source files.
-      '@uwdata/mosaic-core': '/packages/core/src/index.ts',
-      '@uwdata/mosaic-sql': '/packages/sql/src/index.js',
-      '@uwdata/vgplot': '/packages/vgplot/src/index.js',
-      '@uwdata/mosaic-spec': '/packages/spec/src/index.js',
-      '@uwdata/mosaic-inputs': '/packages/inputs/src/index.js',
-      '@uwdata/mosaic-plot': '/packages/plot/src/index.js',
+      '@uwdata/mosaic-core': path.resolve(__dirname, './packages/core/src/index.ts'),
+      '@uwdata/mosaic-sql': path.resolve(__dirname, './packages/sql/src/index.ts'),
+      '@uwdata/vgplot': path.resolve(__dirname, './packages/vgplot/src/index.js'),
+      '@uwdata/mosaic-spec': path.resolve(__dirname, './packages/spec/src/index.js'),
+      '@uwdata/mosaic-inputs': path.resolve(__dirname, './packages/inputs/src/index.js'),
+      '@uwdata/mosaic-plot': path.resolve(__dirname, './packages/plot/src/index.js'),
     }
   },
   test: {


### PR DESCRIPTION
Tests and the docs now use aliases to run Vite so they will pick up the source files---no need to compile/run tsc after making changes. This should also make it easy to use watch tasks without having to worry about picking up the latest changes.

I tested running `npx run clean` at the top level and then compiling the individual packages/running tests etc. 

As a note, `tsc` just runs typescript in the current package, `tsc --build` also compiles dependencies (if they need to be updated).

You can run `npx tsc --build` or `npx tsc` (if other dependencies are already compiled) to type check any package.