### PR TITLE
chore: update duckdb rust client to 1.3.1

### DIFF
--- a/packages/server/duckdb-server-rust/Cargo.lock
+++ b/packages/server/duckdb-server-rust/Cargo.lock
@@ -1025,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379464d1fbb69d1bbda7c11d96fafde6f2bdb78c67e630e6339b048e6e45107e"
+checksum = "45bb1ff45dea0ba559e9d25b768631f41a6061b0b76760deef09094659b691c8"
 dependencies = [
  "arrow",
  "cast",
@@ -1777,9 +1777,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3f1defe457d1ac0fbaef0fe6926953cb33419dd3c8dbac53882d020bee697"
+checksum = "ce15e3fe359068a9a3a687e074e7e32d2954f0a3dd138a0f529c779176b7e661"
 dependencies = [
  "autocfg",
  "cc",

--- a/packages/server/duckdb-server-rust/Cargo.toml
+++ b/packages/server/duckdb-server-rust/Cargo.toml
@@ -20,7 +20,7 @@ axum = { version = "0.8", features = ["http1", "http2", "ws", "json", "tokio", "
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 axum-server-dual-protocol = "0.7"
 clap = { version = "4.5", features = ["derive"] }
-duckdb = { version = "1.3.0", features = ["bundled", "csv", "json", "parquet", "url", "r2d2"] }
+duckdb = { version = "1.3.1", features = ["bundled", "csv", "json", "parquet", "url", "r2d2"] }
 futures = "0.3"
 listenfd = "1.0"
 lru = "0.14"


### PR DESCRIPTION
There was [a regression in DuckDB 1.3.0 affecting DECIMAL types](https://github.com/duckdb/duckdb-rs/releases/tag/v1.3.0). [DuckDB 1.3.1 introduced a new option, arrow_output_version](https://github.com/duckdb/duckdb/pull/17791), which can be used to work around this issue.

Ultimately, [`Decimal32` and `Decimal64` need to be added to `arrow-rs`](https://github.com/apache/arrow-rs/pull/7098), which is expected in the next major arrow-rs release.