### PR TITLE
Fix typescript lint errors in core package, adjust other packages.

### DIFF
--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -8,6 +8,13 @@ import { type Logger, type QueryType } from './types.js';
 import { type QueryResult } from './util/query-result.js';
 import { type MosaicClient } from './MosaicClient.js';
 import { type SelectionClause } from './SelectionClause.js';
+import { MaybeArray } from '@uwdata/mosaic-sql';
+
+interface FilterGroupEntry {
+  selection: Selection;
+  clients: Set<MosaicClient>;
+  disconnect(): void;
+}
 
 /**
  * The singleton Coordinator instance.
@@ -38,9 +45,9 @@ export function coordinator(
 export class Coordinator {
   public manager: QueryManager;
   public preaggregator: PreAggregator;
-  public clients?: Set<MosaicClient>;
-  public filterGroups?: Map<Selection, any>;
-  protected _logger?: Logger;
+  public clients: Set<MosaicClient> = new Set;
+  public filterGroups: Map<Selection, FilterGroupEntry> = new Map;
+  protected _logger: Logger = voidLogger();
 
   /**
    * @param db Database connector. Defaults to a web socket connection.
@@ -103,7 +110,9 @@ export class Coordinator {
   databaseConnector(): Connector | null;
   databaseConnector(db: Connector): Connector;
   databaseConnector(db?: Connector): Connector | null {
-    return this.manager.connector(db as any);
+    return db
+      ? this.manager.connector(db)
+      : this.manager.connector();
   }
 
   /**
@@ -138,7 +147,7 @@ export class Coordinator {
    * @returns A query result promise.
    */
   exec(
-    query: QueryType[] | QueryType,
+    query: MaybeArray<QueryType>,
     options: { priority?: number } = {}
   ): QueryResult {
     const { priority = Priority.Normal } = options;
@@ -164,7 +173,7 @@ export class Coordinator {
       cache?: boolean;
       persist?: boolean;
       priority?: number;
-      [key: string]: any;
+      [key: string]: unknown;
     } = {}
   ): QueryResult {
     const {
@@ -186,15 +195,15 @@ export class Coordinator {
    */
   prefetch(
     query: QueryType,
-    options: { type?: 'arrow' | 'json'; [key: string]: any } = {}
+    options: { type?: 'arrow' | 'json'; [key: string]: unknown } = {}
   ): QueryResult {
-    return this.query(query, { ...options, cache: true, priority: Priority.Low as any });
+    return this.query(query, { ...options, cache: true, priority: Priority.Low });
   }
 
   // -- Client Management ----
 
   /**
-   * Update client data by submitting the given query and returning the
+   * Update client data by submitting the given query and returning the()
    * data (or error) to the client.
    * @param client A Mosaic client.
    * @param query The data query.
@@ -205,7 +214,7 @@ export class Coordinator {
     client: MosaicClient,
     query: QueryType,
     priority: number = Priority.Normal
-  ): Promise<void> {
+  ): Promise<unknown> {
     client.queryPending();
     return client._pending = this.query(query, { priority })
       .then(
@@ -222,7 +231,7 @@ export class Coordinator {
    * @param client The client to update.
    * @param query The query to issue.
    */
-  requestQuery(client: MosaicClient, query?: QueryType | null): Promise<void> {
+  requestQuery(client: MosaicClient, query?: QueryType | null): Promise<unknown> {
     this.preaggregator.clear();
     return query
       ? this.updateClient(client, query)
@@ -287,6 +296,7 @@ function connectSelection(
     const activate = (clause: SelectionClause) => activateSelection(mc, selection, clause);
     const value = () => updateSelection(mc, selection);
 
+    // @ts-expect-error todo: update selection dispatch types
     selection.addEventListener('activate', activate);
     selection.addEventListener('value', value);
 
@@ -294,6 +304,7 @@ function connectSelection(
       selection,
       clients: new Set,
       disconnect() {
+        // @ts-expect-error todo: update selection dispatch types
         selection.removeEventListener('activate', activate);
         selection.removeEventListener('value', value);
       }
@@ -317,7 +328,7 @@ function activateSelection(
   clause: SelectionClause
 ): void {
   const { preaggregator, filterGroups } = mc;
-  const { clients } = filterGroups!.get(selection);
+  const { clients } = filterGroups.get(selection)!;
   for (const client of clients) {
     if (client.enabled) {
       preaggregator.request(client, selection, clause);
@@ -335,9 +346,9 @@ function activateSelection(
 function updateSelection(
   mc: Coordinator,
   selection: Selection
-): Promise<PromiseSettledResult<any>[]> {
+): Promise<PromiseSettledResult<unknown>[]> {
   const { preaggregator, filterGroups } = mc;
-  const { clients } = filterGroups!.get(selection);
+  const { clients } = filterGroups!.get(selection)!;
   const { active } = selection;
   return Promise.allSettled(Array.from(clients, (client: MosaicClient) => {
     if (!client.enabled) return client.requestQuery();

--- a/packages/mosaic/core/src/MosaicClient.ts
+++ b/packages/mosaic/core/src/MosaicClient.ts
@@ -1,7 +1,13 @@
-import { type Query } from '@uwdata/mosaic-sql';
+import { FilterExpr, type Query } from '@uwdata/mosaic-sql';
 import { type Coordinator } from './Coordinator.js';
 import { type Selection } from './Selection.js';
 import { throttle } from './util/throttle.js';
+
+export type ClientQuery = Query | string | null;
+
+export function isMosaicClient(x: unknown): x is MosaicClient {
+  return x instanceof MosaicClient;
+}
 
 /**
  * A Mosaic client is a data consumer that indicates its data needs to a
@@ -23,7 +29,7 @@ export class MosaicClient {
   _filterBy: Selection | undefined;
   _requestUpdate: (event?: unknown) => void;
   _coordinator: Coordinator | null;
-  _pending: Promise<any>;
+  _pending: Promise<unknown>;
   _enabled: boolean;
   _initialized: boolean;
   _request: Query | boolean | null;
@@ -88,7 +94,7 @@ export class MosaicClient {
   /**
    * Return a Promise that resolves once the client has updated.
    */
-  get pending(): Promise<any> {
+  get pending(): Promise<unknown> {
     return this._pending;
   }
 
@@ -122,7 +128,7 @@ export class MosaicClient {
    * @param filter The filtering criteria to apply in the query.
    * @returns The client query
    */
-  query(filter?: any): any { // eslint-disable-line no-unused-vars
+  query(filter?: FilterExpr | null): ClientQuery { // eslint-disable-line @typescript-eslint/no-unused-vars
     return null;
   }
 
@@ -139,7 +145,7 @@ export class MosaicClient {
    * @param data The query result.
    * @returns this
    */
-  queryResult(data: any): this { // eslint-disable-line no-unused-vars
+  queryResult(data: unknown): this { // eslint-disable-line @typescript-eslint/no-unused-vars
     return this;
   }
 
@@ -148,7 +154,7 @@ export class MosaicClient {
    * @param error
    * @returns this
    */
-  queryError(error: any): this { // eslint-disable-line no-unused-vars
+  queryError(error: Error): this { // eslint-disable-line @typescript-eslint/no-unused-vars
     // do nothing, the coordinator logs the error
     return this;
   }
@@ -164,7 +170,7 @@ export class MosaicClient {
    *  will be determined by the client's `query` method and the current
    *  `filterBy` selection state.
    */
-  requestQuery(query?: Query): Promise<void> | null {
+  requestQuery(query?: Query): Promise<unknown> | null {
     if (this._enabled) {
       const q = query || this.query(this.filterBy?.predicate(this));
       return this._coordinator!.requestQuery(this, q);
@@ -221,7 +227,7 @@ export class MosaicClient {
    * Requests a client update, for example to (re-)render an interface
    * component.
    */
-  update(): this | Promise<any> {
+  update(): this | Promise<unknown> {
     return this;
   }
 }

--- a/packages/mosaic/core/src/connectors/Connector.ts
+++ b/packages/mosaic/core/src/connectors/Connector.ts
@@ -1,23 +1,23 @@
 import type { Table } from '@uwdata/flechette';
 
-export interface QueryRequest {
+export interface ConnectorQueryRequest {
   /** The query type. */
   type?: string;
   /** A SQL query string. */
   sql: string;
 }
 
-export interface ArrowQueryRequest extends QueryRequest {
+export interface ArrowQueryRequest extends ConnectorQueryRequest {
   /** The query type. */
   type?: 'arrow';
 }
 
-export interface ExecQueryRequest extends QueryRequest {
+export interface ExecQueryRequest extends ConnectorQueryRequest {
   /** The query type. */
   type: 'exec';
 }
 
-export interface JSONQueryRequest extends QueryRequest {
+export interface JSONQueryRequest extends ConnectorQueryRequest {
   /** The query type. */
   type: 'json';
 }
@@ -26,5 +26,5 @@ export interface Connector {
   /** Issue a query and return the result. */
   query(query: ArrowQueryRequest): Promise<Table>;
   query(query: ExecQueryRequest): Promise<void>;
-  query(query: JSONQueryRequest): Promise<Record<string, any>[]>;
+  query(query: JSONQueryRequest): Promise<Record<string, unknown>[]>;
 }

--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -1,6 +1,11 @@
-import type { ExtractionOptions } from '@uwdata/flechette';
-import type { Connector } from './Connector.js';
+import type { ExtractionOptions, Table } from '@uwdata/flechette';
+import type { ArrowQueryRequest, Connector, ExecQueryRequest, JSONQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import { decodeIPC } from '../util/decode-ipc.js';
+
+interface RestOptions {
+  uri?: string;
+  ipc?: ExtractionOptions;
+}
 
 /**
  * Connect to a DuckDB server over an HTTP REST interface.
@@ -9,33 +14,43 @@ import { decodeIPC } from '../util/decode-ipc.js';
  * @param options.ipc Arrow IPC extraction options.
  * @returns A connector instance.
  */
-export function restConnector({
-  uri = 'http://localhost:3000/',
-  ipc = undefined,
-}: {
-  uri?: string;
-  ipc?: ExtractionOptions;
-} = {}): Connector {
-  return {
-    async query(query: any): Promise<any> {
-      const req = fetch(uri, {
-        method: 'POST',
-        mode: 'cors',
-        cache: 'no-cache',
-        credentials: 'omit',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(query)
-      });
+export function restConnector(options: RestOptions = {}) {
+  return new RestConnector(options.uri, options.ipc);
+}
 
-      const res = await req;
+class RestConnector implements Connector {
+  private _uri: string;
+  private _ipc?: ExtractionOptions;
 
-      if (!res.ok) {
-        throw new Error(`Query failed with HTTP status ${res.status}: ${await res.text()}`);
-      }
+  constructor(
+    uri: string = 'http://localhost:3000/',
+    ipc?: ExtractionOptions
+  ) {
+    this._uri = uri;
+    this._ipc = ipc;
+  }
 
-      return query.type === 'exec' ? req
-        : query.type === 'arrow' ? decodeIPC(await res.arrayBuffer(), ipc)
-        : res.json();
+  async query(query: ArrowQueryRequest): Promise<Table>;
+  async query(query: ExecQueryRequest): Promise<void>;
+  async query(query: JSONQueryRequest): Promise<Record<string, unknown>[]>;
+  async query(query: ConnectorQueryRequest): Promise<unknown> {
+    const req = fetch(this._uri, {
+      method: 'POST',
+      mode: 'cors',
+      cache: 'no-cache',
+      credentials: 'omit',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(query)
+    });
+
+    const res = await req;
+
+    if (!res.ok) {
+      throw new Error(`Query failed with HTTP status ${res.status}: ${await res.text()}`);
     }
-  };
+
+    return query.type === 'exec' ? req
+      : query.type === 'arrow' ? decodeIPC(await res.arrayBuffer(), this._ipc)
+      : res.json();
+  }
 }

--- a/packages/mosaic/core/src/connectors/wasm.ts
+++ b/packages/mosaic/core/src/connectors/wasm.ts
@@ -1,5 +1,5 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
-import type { ArrowQueryRequest, Connector, ExecQueryRequest, JSONQueryRequest } from './Connector.js';
+import type { ArrowQueryRequest, Connector, ExecQueryRequest, JSONQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import * as duckdb from '@duckdb/duckdb-wasm';
 import { decodeIPC } from '../util/decode-ipc.js';
 
@@ -70,9 +70,8 @@ export class DuckDBWASMConnector implements Connector {
 
   async query(query: ArrowQueryRequest): Promise<Table>;
   async query(query: ExecQueryRequest): Promise<void>;
-  async query(query: JSONQueryRequest): Promise<Record<string, any>[]>;
-  async query(query: ArrowQueryRequest | ExecQueryRequest | JSONQueryRequest): Promise<Table | void | Record<string, any>[]>;
-  async query(query: any): Promise<any> {
+  async query(query: JSONQueryRequest): Promise<Record<string, unknown>[]>;
+  async query(query: ConnectorQueryRequest): Promise<unknown> {
     const { type, sql } = query;
     const con = await this.getConnection();
     const result = await getArrowIPC(con, sql);

--- a/packages/mosaic/core/src/index.ts
+++ b/packages/mosaic/core/src/index.ts
@@ -29,7 +29,7 @@ export { isActivatable } from './util/is-activatable.js';
 export type { QueryResult } from './util/query-result.js';
 
 export * from './types.js';
-export * from './connectors/Connector.js';
 
+export type * from './connectors/Connector.js';
 export type * from './Selection.js';
 export type * from './SelectionClause.js';

--- a/packages/mosaic/core/src/make-client.ts
+++ b/packages/mosaic/core/src/make-client.ts
@@ -1,6 +1,7 @@
 import type { Coordinator } from './Coordinator.js';
 import type { Selection } from './Selection.js';
-import { MosaicClient } from './MosaicClient.js';
+import type { FilterExpr } from '@uwdata/mosaic-sql';
+import { type ClientQuery, MosaicClient } from './MosaicClient.js';
 import { coordinator as defaultCoordinator } from './Coordinator.js';
 
 export interface MakeClientOptions {
@@ -10,19 +11,19 @@ export interface MakeClientOptions {
   selection?: Selection;
   /** A flag (default `true`) indicating if the client should initially be enabled or not. */
   enabled?: boolean;
-  /** A flag (default `true`) indicating if client queries can be sped up using pre-aggregated data. 
+  /** A flag (default `true`) indicating if client queries can be sped up using pre-aggregated data.
    * Should be set to `false` if filtering changes the groupby domain of the query. */
   filterStable?: boolean;
   /** An async function to prepare the client before running queries. */
   prepare?: () => Promise<void>;
   /** A function that returns a query from a list of selection predicates. */
-  query?: (filter: any) => any;
+  query?: (filter: FilterExpr) => ClientQuery;
   /** Called by the coordinator to return a query result. */
-  queryResult?: (data: any) => void;
+  queryResult?: (data: unknown) => void;
   /** Called by the coordinator to inform the client that a query is pending. */
   queryPending?: () => void;
   /** Called by the coordinator to report a query execution error. */
-  queryError?: (error: any) => void;
+  queryError?: (error: Error) => void;
 }
 
 /**
@@ -71,11 +72,11 @@ class ProxyClient extends MosaicClient {
     await this._methods.prepare?.();
   }
 
-  query(filter: any): any {
+  query(filter: FilterExpr): ClientQuery {
     return this._methods.query?.(filter) ?? null;
   }
 
-  queryResult(data: any): this {
+  queryResult(data: unknown): this {
     this._methods.queryResult?.(data);
     return this;
   }
@@ -85,7 +86,7 @@ class ProxyClient extends MosaicClient {
     return this;
   }
 
-  queryError(error: any): this {
+  queryError(error: Error): this {
     this._methods.queryError?.(error);
     return this;
   }

--- a/packages/mosaic/core/src/types.ts
+++ b/packages/mosaic/core/src/types.ts
@@ -1,4 +1,19 @@
 import type { DescribeQuery, ExprNode, Query } from '@uwdata/mosaic-sql';
+import type { QueryResult } from './util/query-result.js';
+
+/** Type for a query request. */
+export interface QueryRequest {
+  type: 'exec' | 'json' | 'arrow';
+  query: string | Query | DescribeQuery;
+  cache?: boolean;
+  options?: Record<string, unknown>;
+}
+
+/** Type for an entry within a query manager. */
+export interface QueryEntry {
+  request: QueryRequest;
+  result: QueryResult;
+}
 
 /** Query type accepted by a coordinator. */
 export type QueryType =
@@ -67,8 +82,8 @@ export interface Activatable {
  * Interface for cache implementations.
  */
 export interface Cache {
-  get(key: string): any;
-  set(key: string, value: any): any;
+  get(key: string): unknown;
+  set(key: string, value: unknown): unknown;
   clear(): void;
 }
 
@@ -76,12 +91,12 @@ export interface Cache {
  * Interface for logger implementations
  */
 export interface Logger {
-  debug(...args: any[]): void;
-  info(...args: any[]): void;
-  log(...args: any[]): void;
-  warn(...args: any[]): void;
-  error(...args: any[]): void;
-  group(label?: any): void;
-  groupCollapsed(label?: any): void;
+  debug(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  log(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+  group(label?: unknown): void;
+  groupCollapsed(label?: unknown): void;
   groupEnd(): void;
 }

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -4,7 +4,7 @@ const requestIdle = typeof requestIdleCallback !== 'undefined'
   ? requestIdleCallback
   : setTimeout;
 
-interface CacheEntry<T> {
+interface CacheEntry<T = unknown> {
   last: number;
   value: T;
 }
@@ -35,7 +35,7 @@ export function lruCache({
   max?: number;
   ttl?: number;
 } = {}): Cache {
-  let cache = new Map<string, CacheEntry<any>>();
+  let cache = new Map<string, CacheEntry>();
 
   function evict(): void {
     const expire = performance.now() - ttl;
@@ -64,20 +64,20 @@ export function lruCache({
   }
 
   return {
-    get(key: string): any {
+    get(key: string): unknown {
       const entry = cache.get(key);
       if (entry) {
         entry.last = performance.now();
         return entry.value;
       }
     },
-    set(key: string, value: any): any {
+    set(key: string, value: unknown): unknown {
       cache.set(key, { last: performance.now(), value });
       if (cache.size > max) requestIdle(evict);
       return value;
     },
-    clear(): void { 
-      cache = new Map(); 
+    clear(): void {
+      cache = new Map();
     }
   };
 }

--- a/packages/mosaic/core/src/util/distinct.ts
+++ b/packages/mosaic/core/src/util/distinct.ts
@@ -1,11 +1,11 @@
-export function distinct(a: any, b: any): boolean {
+export function distinct(a: unknown, b: unknown): boolean {
   return a === b ? false
     : a instanceof Date && b instanceof Date ? +a !== +b
     : Array.isArray(a) && Array.isArray(b) ? distinctArray(a, b)
     : true;
 }
 
-export function distinctArray(a: any[], b: any[]): boolean {
+export function distinctArray(a: unknown[], b: unknown[]): boolean {
   if (a.length !== b.length) return true;
   for (let i = 0; i < a.length; ++i) {
     if (a[i] !== b[i]) return true;

--- a/packages/mosaic/core/src/util/is-activatable.ts
+++ b/packages/mosaic/core/src/util/is-activatable.ts
@@ -5,6 +5,7 @@ import type { Activatable } from '../types.js';
  * @param value The value to test.
  * @returns True if value implements Activatable interface.
  */
-export function isActivatable(value: any): value is Activatable {
+export function isActivatable(value: unknown): value is Activatable {
+  // @ts-expect-error check properties of unknown value
   return typeof value?.activate === 'function' && value.activate.length === 0;
 }

--- a/packages/mosaic/core/src/util/is-arrow-table.ts
+++ b/packages/mosaic/core/src/util/is-arrow-table.ts
@@ -6,6 +6,7 @@ import type { Table } from '@uwdata/flechette';
  * @param values The value to test
  * @returns true if the value duck types as Arrow data
  */
-export function isArrowTable(values: any): values is Table {
+export function isArrowTable(values: unknown): values is Table {
+  // @ts-expect-error check property of unknown value
   return typeof values?.getChild === 'function';
 }

--- a/packages/mosaic/core/src/util/priority-queue.ts
+++ b/packages/mosaic/core/src/util/priority-queue.ts
@@ -8,7 +8,7 @@ interface List<T> {
   tail: ListNode<T> | null;
 }
 
-export class PriorityQueue<T = any> {
+export class PriorityQueue<T = unknown> {
   private queue: List<T>[];
 
   /**

--- a/packages/mosaic/core/src/util/query-result.ts
+++ b/packages/mosaic/core/src/util/query-result.ts
@@ -11,9 +11,9 @@ type QueryStateType = typeof QueryState[keyof typeof QueryState];
  * A query result Promise that can allows external callers
  * to resolve or reject the Promise.
  */
-export class QueryResult<T = any> extends Promise<T> {
+export class QueryResult<T = unknown> extends Promise<T> {
   private _resolve!: (value: T | PromiseLike<T>) => void;
-  private _reject!: (reason?: any) => void;
+  private _reject!: (reason?: unknown) => void;
   private _state: QueryStateType;
   private _value: T | undefined;
 
@@ -22,7 +22,7 @@ export class QueryResult<T = any> extends Promise<T> {
    */
   constructor() {
     let resolve: (value: T | PromiseLike<T>) => void;
-    let reject: (reason?: any) => void;
+    let reject: (reason?: unknown) => void;
     super((r, e) => {
       resolve = r;
       reject = e;
@@ -72,7 +72,7 @@ export class QueryResult<T = any> extends Promise<T> {
    * @param error The error value.
    * @returns This QueryResult instance.
    */
-  reject(error: any): this {
+  reject(error: unknown): this {
     this._state = QueryState.error;
     this._reject(error);
     return this;
@@ -88,4 +88,4 @@ export class QueryResult<T = any> extends Promise<T> {
 }
 
 // necessary to make Promise subclass act like a Promise
-(QueryResult.prototype as any).constructor = Promise;
+QueryResult.prototype.constructor = Promise;

--- a/packages/mosaic/core/src/util/synchronizer.ts
+++ b/packages/mosaic/core/src/util/synchronizer.ts
@@ -1,7 +1,7 @@
 /**
  * Synchronizer class to aid synchronization of updates on multiple pending operations.
  */
-export class Synchronizer<T = any> {
+export class Synchronizer<T = unknown> {
   private _set: Set<T>;
   private _done: () => void;
   private _promise: Promise<void>;
@@ -54,4 +54,3 @@ export class Synchronizer<T = any> {
     return this._promise;
   }
 }
-

--- a/packages/mosaic/core/src/util/throttle.ts
+++ b/packages/mosaic/core/src/util/throttle.ts
@@ -18,7 +18,7 @@ export function throttle<E, T>(
   callback: (event?: E) => Promise<T> | null,
   debounce: boolean = false
 ): (event?: E) => void {
-  let curr: Promise<any> | null;
+  let curr: Promise<unknown> | null;
   let next: QueueItem<E> | undefined | null;
   let pending: E | undefined | typeof NIL = NIL;
 
@@ -41,7 +41,7 @@ export function throttle<E, T>(
   }
 
   function process(event?: E): void {
-    curr ? enqueue(event!) : invoke(event);
+    if (curr) enqueue(event!); else invoke(event);
   }
 
   function delay(event?: E): void {

--- a/packages/mosaic/core/src/util/to-data-columns.ts
+++ b/packages/mosaic/core/src/util/to-data-columns.ts
@@ -4,14 +4,14 @@ import type { Table } from '@uwdata/flechette';
 /**
  * An Array or TypedArray
  */
-type Arrayish = Array<any> | Int8Array | Uint8Array | Uint8ClampedArray
+type Arrayish = Array<unknown> | Int8Array | Uint8Array | Uint8ClampedArray
   | Int16Array | Uint16Array | Int32Array | Uint32Array
   | Float32Array | Float64Array;
 
 /**
  * Data columns structure with either named columns or values array
  */
-type DataColumns = 
+type DataColumns =
   | { numRows: number; columns: Record<string, Arrayish> }
   | { numRows: number; values: Arrayish };
 
@@ -20,10 +20,14 @@ type DataColumns =
  * @param data The input data.
  * @returns An object with named column arrays.
  */
-export function toDataColumns(data: any): DataColumns {
-  return isArrowTable(data)
-    ? arrowToColumns(data)
-    : arrayToColumns(data);
+export function toDataColumns(data: unknown): DataColumns {
+  if (isArrowTable(data)) {
+    return arrowToColumns(data);
+  } else if (Array.isArray(data)) {
+    return arrayToColumns(data);
+  } else {
+    throw new Error('Unrecognized data format.');
+  }
 }
 
 /**
@@ -44,11 +48,11 @@ function arrowToColumns(data: Table): DataColumns {
  * @param data An array of data objects.
  * @returns An object with named column arrays.
  */
-function arrayToColumns(data: any[]): DataColumns {
+function arrayToColumns(data: Record<string,unknown>[]): DataColumns {
   const numRows = data.length;
   if (typeof data[0] === 'object') {
-    const names = numRows ? Object.keys(data[0]) : [];
-    const columns: Record<string, any[]> = {};
+    const names = numRows ? Object.keys(data[0]!) : [];
+    const columns: Record<string, unknown[]> = {};
     if (names.length > 0) {
       names.forEach(name => {
         columns[name] = data.map(d => d[name]);

--- a/packages/mosaic/core/src/util/void-logger.ts
+++ b/packages/mosaic/core/src/util/void-logger.ts
@@ -1,9 +1,9 @@
 interface Logger {
-  debug(...args: any[]): void;
-  info(...args: any[]): void;
-  log(...args: any[]): void;
-  warn(...args: any[]): void;
-  error(...args: any[]): void;
+  debug(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  log(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
   group(label?: string): void;
   groupCollapsed(label?: string): void;
   groupEnd(): void;
@@ -11,13 +11,13 @@ interface Logger {
 
 export function voidLogger(): Logger {
   return {
-    debug(..._: any[]): void {},
-    info(..._: any[]): void {},
-    log(..._: any[]): void {},
-    warn(..._: any[]): void {},
-    error(..._: any[]): void {},
-    group(label?: string): void {},
-    groupCollapsed(label?: string): void {},
+    debug(): void {},
+    info(): void {},
+    log(): void {},
+    warn(): void {},
+    error(): void {},
+    group(): void {},
+    groupCollapsed(): void {},
     groupEnd(): void {}
   };
 }

--- a/packages/mosaic/core/test/client.test.ts
+++ b/packages/mosaic/core/test/client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Query, count } from '@uwdata/mosaic-sql';
 import { nodeConnector } from './util/node-connector.js';
-import { Coordinator, MosaicClient, Selection, clauseInterval } from '../src/index.js';
+import { ClauseSource, Coordinator, MosaicClient, Selection, clauseInterval } from '../src/index.js';
 import { QueryResult } from '../src/util/query-result.js';
 
 describe('MosaicClient', () => {
@@ -30,7 +30,7 @@ describe('MosaicClient', () => {
       private columnName: string;
       private pendingResult: QueryResult;
 
-      constructor(tableName: string, columnName: string, filterBy?: any) {
+      constructor(tableName: string, columnName: string, filterBy?: Selection) {
         super(filterBy);
         this.tableName = tableName;
         this.columnName = columnName;
@@ -84,7 +84,7 @@ describe('MosaicClient', () => {
     // crossfilter should skip client1, indicated by undefined result
     // client2 should be filtered by HourOfDay
     selection.update(
-      clauseInterval('HourOfDay', [0, 24], { source: client1 })
+      clauseInterval('HourOfDay', [0, 24], { source: client1 as ClauseSource })
     );
     expect(selection.active?.source).toBe(client1);
     expect(selection.predicate(client1)).toBeUndefined();
@@ -108,7 +108,7 @@ describe('MosaicClient', () => {
     // client1 should be filtered by DayOfWeek
     // crossfilter should skip client2, indicated by undefined result
     selection.update(
-      clauseInterval('DayOfWeek', [0, 7], { source: client2 })
+      clauseInterval('DayOfWeek', [0, 7], { source: client2 as ClauseSource })
     );
     expect(selection.active?.source).toBe(client2);
     expect(selection.predicate(client1)+'').toBe(

--- a/packages/mosaic/core/test/preaggregator.test.ts
+++ b/packages/mosaic/core/test/preaggregator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { Query, add, argmax, argmin, avg, corr, count, covarPop, covariance, geomean, gt, isNotDistinct, literal, loadObjects, max, min, mul, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, stddev, stddevPop, sum, varPop, variance } from '@uwdata/mosaic-sql';
-import { Coordinator, Selection } from '../src/index.js';
+import { Coordinator, Selection, SelectionClause } from '../src/index.js';
 import { nodeConnector } from './util/node-connector.js';
 import { TestClient } from './util/test-client.js';
 
@@ -13,6 +13,8 @@ async function setup(loadQuery) {
   await mc.exec(loadQuery);
   return mc;
 }
+
+type Datum = { measure: number };
 
 async function run(measure): Promise<[number, boolean]> {
   const loadQuery = loadObjects('testData', [
@@ -33,10 +35,10 @@ async function run(measure): Promise<[number, boolean]> {
           ? measure(filter)
           : Query.from('testData').select({ measure }).where(filter);
       },
-      queryResult(data: any) {
+      queryResult(data: unknown) {
         if (iter) {
           resolve([
-            (Array.from(data) as any)[0].measure, // query result
+            (Array.from(data as Iterable<Datum>))[0].measure, // query result
             !!mc.preaggregator.entries.get(this) // optimized?
           ]);
         }
@@ -49,7 +51,7 @@ async function run(measure): Promise<[number, boolean]> {
         source: 'test',
         meta: { type: 'point' },
         predicate: isNotDistinct('dim', literal('b'))
-      } as any);
+      } as unknown as SelectionClause);
     });
   });
 }

--- a/packages/mosaic/core/test/query-manager.test.ts
+++ b/packages/mosaic/core/test/query-manager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { QueryManager } from '../src/QueryManager.js';
 import { QueryResult } from '../src/util/query-result.js';
+import { QueryRequest } from '../src/types.js';
 
 describe('QueryManager', () => {
   it('should run a simple query', async () => {
@@ -8,13 +9,14 @@ describe('QueryManager', () => {
 
     // Mock the connector
     queryManager.connector({
+      // @ts-expect-error assumes type value
       query: async ({ sql }) => {
         expect(sql).toBe('SELECT 1');
-        return [{ column: 1 }] as any;
+        return [{ column: 1 }];
       }
     });
 
-    const request = {
+    const request: QueryRequest = {
       type: 'arrow',
       query: 'SELECT 1'
     };
@@ -31,18 +33,19 @@ describe('QueryManager', () => {
 
     // Mock the connector
     queryManager.connector({
+      // @ts-expect-error assumes type value
       query: ({ sql }) => {
         expect(sql).toBe('CREATE TABLE test (id INT)');
-        return new Promise(() => {}) as Promise<any>;
+        return new Promise(() => {});
       }
     });
 
-    const request1 = {
+    const request1: QueryRequest = {
       type: 'exec',
       query: 'CREATE TABLE test (id INT)'
     };
 
-    const request2 = {
+    const request2: QueryRequest = {
       type: 'arrow',
       query: 'SELECT * FROM test'
     };

--- a/packages/mosaic/core/test/util/test-client.ts
+++ b/packages/mosaic/core/test/util/test-client.ts
@@ -1,16 +1,20 @@
-import { MosaicClient } from '../../src/index.js';
-import type { Query, SelectQuery } from '@uwdata/mosaic-sql';
+import { MosaicClient, Selection } from '../../src/index.js';
+import type { FilterExpr, SelectQuery } from '@uwdata/mosaic-sql';
 
 export class TestClient extends MosaicClient {
   private _query: SelectQuery | null;
 
-  constructor(query: SelectQuery | null, filterBy?: any, callbacks: Record<string, any> = {}) {
+  constructor(
+    query: SelectQuery | null,
+    filterBy?: Selection,
+    callbacks: Record<string, unknown> = {}
+  ) {
     super(filterBy);
     this._query = query;
     Object.assign(this, callbacks);
   }
 
-  query(filter: any[] = []): SelectQuery | null {
+  query(filter: FilterExpr = []): SelectQuery | null {
     return this._query?.clone().where(filter) || null;
   }
 }

--- a/packages/mosaic/sql/src/types.ts
+++ b/packages/mosaic/sql/src/types.ts
@@ -82,6 +82,6 @@ export type FromEntry =
 
 export type FromExpr = MaybeArray<FromEntry>;
 
-export type FilterExpr = MaybeArray<string | ExprNode>;
+export type FilterExpr = MaybeArray<string | boolean | ExprNode>;
 export type GroupByExpr = MaybeArray<string | ExprNode>;
 export type OrderByExpr = MaybeArray<string | ExprNode>;

--- a/packages/vgplot/inputs/src/Slider.js
+++ b/packages/vgplot/inputs/src/Slider.js
@@ -1,4 +1,4 @@
-/** @import { Param, Selection } from '@uwdata/mosaic-core' */
+/** @import { ClauseSource, Param, Selection } from '@uwdata/mosaic-core' */
 import { clauseInterval, clausePoint, isParam, isSelection } from '@uwdata/mosaic-core';
 import { Query, max, min } from '@uwdata/mosaic-sql';
 import { Input, input } from './input.js';
@@ -186,13 +186,13 @@ export class Slider extends Input {
       /** @type {[number, number]} */
       const domain = [this.min ?? 0, value];
       return clauseInterval(field, domain, {
-        source: this,
+        source: /** @type {ClauseSource} */(this),
         bin: 'ceil',
         scale: { type: 'identity', domain },
         pixelSize: this.step
       });
     } else {
-      return clausePoint(field, value, { source: this });
+      return clausePoint(field, value, { source: /** @type {ClauseSource} */(this) });
     }
   }
 

--- a/packages/vgplot/inputs/src/Table.js
+++ b/packages/vgplot/inputs/src/Table.js
@@ -1,4 +1,7 @@
-/** @import { Selection } from '@uwdata/mosaic-core' */
+/**
+ * @import { ClauseSource, Selection } from '@uwdata/mosaic-core'
+ * @import { FilterExpr } from '@uwdata/mosaic-sql'
+ */
 import { clausePoints, coordinator, isParam, isSelection, queryFieldInfo, toDataColumns } from '@uwdata/mosaic-core';
 import { Query, desc } from '@uwdata/mosaic-sql';
 import { formatDate, formatLocaleAuto, formatLocaleNumber } from './util/format.js';
@@ -122,7 +125,7 @@ export class Table extends Input {
     let prevScrollTop = -1;
     this.element.addEventListener('scroll', evt => {
       const { isPending, loaded } = this;
-      // @ts-ignore
+      // @ts-expect-error unpack event
       const { scrollHeight, scrollTop, clientHeight } = evt.target;
 
       const back = scrollTop < prevScrollTop;
@@ -173,7 +176,7 @@ export class Table extends Input {
       const { columns } = data[~~(row / limit)];
       return fields.map(f => columns[f][row % limit]);
     });
-    return clausePoints(fields, values, { source: this });
+    return clausePoints(fields, values, { source: /** @type {ClauseSource} */(this) });
   }
 
   requestData(offset = 0) {
@@ -218,6 +221,9 @@ export class Table extends Input {
     );
   }
 
+  /**
+   * @param {FilterExpr} filter
+   */
   query(filter = []) {
     const { limit, offset, schema, sortColumn, sortDesc } = this;
     return Query.from(this.sourceTable())

--- a/packages/vgplot/plot/src/interactors/Nearest.js
+++ b/packages/vgplot/plot/src/interactors/Nearest.js
@@ -1,3 +1,4 @@
+/** @import { ClauseSource } from '@uwdata/mosaic-core' */
 import { clausePoint, clausePoints, isSelection } from '@uwdata/mosaic-core';
 import { select, pointer, min } from 'd3';
 import { getField } from './util/get-field.js';
@@ -28,7 +29,7 @@ export class Nearest {
 
   clause(value) {
     const { clients, fields } = this;
-    const opt = { source: this, clients };
+    const opt = { source: /** @type {ClauseSource} */(this), clients };
     // if only one field, use a simpler clause that passes the value
     // this allows a single field selection value to act like a param
     return fields.length > 1
@@ -37,6 +38,7 @@ export class Nearest {
   }
 
   init(svg) {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const that = this;
     const { mark, channels, selection, maxRadius } = this;
     const { data: { columns } } = mark;

--- a/packages/vgplot/plot/src/interactors/PanZoom.js
+++ b/packages/vgplot/plot/src/interactors/PanZoom.js
@@ -1,3 +1,4 @@
+/** @import { ClauseSource } from '@uwdata/mosaic-core' */
 import { Selection, clauseInterval } from '@uwdata/mosaic-core';
 import { select, zoom, ZoomTransform } from 'd3';
 import { getField } from './util/get-field.js';
@@ -53,7 +54,7 @@ export class PanZoom {
 
   clause(value, field, scale) {
     return clauseInterval(field, value, {
-      source: this,
+      source: /** @type {ClauseSource} */(this),
       clients: this.mark.plot.markSet,
       scale
     });

--- a/packages/vgplot/plot/src/interactors/Toggle.js
+++ b/packages/vgplot/plot/src/interactors/Toggle.js
@@ -1,3 +1,4 @@
+/** @import { ClauseSource } from '@uwdata/mosaic-core' */
 import { clausePoints } from '@uwdata/mosaic-core';
 import { getDatum } from './util/get-datum.js';
 import { neq, neqSome } from './util/neq.js';
@@ -42,7 +43,7 @@ export class Toggle {
   clause(value) {
     const { fields, mark } = this;
     return clausePoints(fields, value, {
-      source: this,
+      source: /** @type {ClauseSource} */(this),
       clients: this.peers ? mark.plot.markSet : new Set().add(mark)
     });
   }


### PR DESCRIPTION
- Fix typescript lint errors in core package.
- Loosen sql `FilterExpr` type to allow boolean values.
- Adjust vgplot packages to use `ClauseSource` type.