### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @jheer @domoritz
+
+/packages/server/duckdb-server-rust/ @domoritz
+/packages/server/duckdb-server-go/ @derekperkins


### PR DESCRIPTION
CODEOWNERS has been useful on the Vitess team to understand who the right people are to ping for various parts of the codebase. I'm not quite sure what, if any, directories are worth adding here, I mostly did it to mark myself as the right person for questions about the Go implementation. You can also use it to scope reviews, so that I could approve things like dependabot updates (#826) only for the Go server. If you're not interested, go ahead and close this PR.