### PR TITLE
feat: support list functions in menu.js

### DIFF
--- a/packages/mosaic/sql/src/ast/list.ts
+++ b/packages/mosaic/sql/src/ast/list.ts
@@ -1,0 +1,23 @@
+import { LIST } from '../constants.js';
+import { ExprNode } from './node.js';
+
+export class ListNode extends ExprNode {
+  /** The array of values. */
+  readonly values: ExprNode[];
+
+  /**
+   * Instantiate a list node.
+   * @param values
+   */
+  constructor(values: ExprNode[]) {
+    super(LIST);
+    this.values = values;
+  }
+
+  /**
+   * Generate a SQL query string for this node.
+   */
+  toString() {
+    return `[${this.values.join(', ')}]`;
+  }
+}

--- a/packages/mosaic/sql/src/constants.ts
+++ b/packages/mosaic/sql/src/constants.ts
@@ -3,6 +3,7 @@ export const COLUMN_PARAM = 'COLUMN_PARAM';
 export const TABLE_REF = 'TABLE_REF';
 export const LITERAL = 'LITERAL';
 export const INTERVAL = 'INTERVAL';
+export const LIST = 'LIST';
 
 export const ORDER_BY = 'ORDER_BY';
 export const CAST = 'CAST';

--- a/packages/mosaic/sql/src/functions/list.ts
+++ b/packages/mosaic/sql/src/functions/list.ts
@@ -1,9 +1,21 @@
 import type {ExprValue, MaybeArray} from '../types.js';
 import { asLiteral } from '../util/ast.js';
 import { argsList, fn } from '../util/function.js';
+import { ListNode } from "../ast/list.js";
+import {ExprNode} from "../ast/node";
 
 function listFn(name: string, expr: MaybeArray<ExprValue>, ...args: unknown[]) {
   return fn(name, expr, ...(argsList(args).map(asLiteral)));
+}
+
+/**
+ * Return a SQL AST node for a literal value. The supported types are
+ * null, string, number, boolean, Date, and RegExp. Otherwise, the
+ * input value will be directly coerced to a string.
+ * @param values
+ */
+export function list(values: ExprNode) {
+  return new ListNode(values);
 }
 
 /**

--- a/packages/mosaic/sql/src/functions/list.ts
+++ b/packages/mosaic/sql/src/functions/list.ts
@@ -2,7 +2,7 @@ import type {ExprValue, MaybeArray} from '../types.js';
 import { asLiteral } from '../util/ast.js';
 import { argsList, fn } from '../util/function.js';
 import { ListNode } from "../ast/list.js";
-import {ExprNode} from "../ast/node";
+import {ExprNode} from "../ast/node.js";
 
 function listFn(name: string, expr: MaybeArray<ExprValue>, ...args: unknown[]) {
   return fn(name, expr, ...(argsList(args).map(asLiteral)));
@@ -14,7 +14,7 @@ function listFn(name: string, expr: MaybeArray<ExprValue>, ...args: unknown[]) {
  * input value will be directly coerced to a string.
  * @param values
  */
-export function list(values: ExprNode) {
+export function list(values: ExprNode[]) {
   return new ListNode(values);
 }
 

--- a/packages/mosaic/sql/src/functions/list.ts
+++ b/packages/mosaic/sql/src/functions/list.ts
@@ -19,7 +19,7 @@ export function list(...values: ExprValue[]) {
  * @param values
  */
 function exprValuesToExprNode(values: ExprValue | ExprValue[]) {
-  return Array.isArray(values) ? list(values) : asNode(values);
+  return Array.isArray(values) ? list(...values) : asNode(values);
 }
 
 /**

--- a/packages/mosaic/sql/src/functions/list.ts
+++ b/packages/mosaic/sql/src/functions/list.ts
@@ -1,0 +1,46 @@
+import type {ExprValue, MaybeArray} from '../types.js';
+import { asLiteral } from '../util/ast.js';
+import { argsList, fn } from '../util/function.js';
+
+function listFn(name: string, expr: MaybeArray<ExprValue>, ...args: unknown[]) {
+  return fn(name, expr, ...(argsList(args).map(asLiteral)));
+}
+
+/**
+ * Function that returns true if the list contains the element,
+ * false otherwise.
+ * @param list
+ * @param element
+ */
+export function list_contains(
+  list: MaybeArray<ExprValue>,
+  element: ExprValue
+) {
+  return listFn('list_contains', list, element);
+}
+
+/**
+ * Function that returns true if all elements of sub-list exist in list,
+ * false otherwise.
+ * @param list
+ * @param sub_list
+ */
+export function list_has_all(
+  list: MaybeArray<ExprValue>,
+  sub_list: ExprValue[]
+) {
+  return listFn('list_has_all', list, sub_list);
+}
+
+/**
+ * Function that returns true if any elements exist in both lists,
+ * false otherwise.
+ * @param list1
+ * @param list2
+ */
+export function list_has_any(
+  list1: MaybeArray<ExprValue>,
+  list2: ExprValue[]
+) {
+  return listFn('list_has_any', list1, list2);
+}

--- a/packages/mosaic/sql/test/list.test.ts
+++ b/packages/mosaic/sql/test/list.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, it } from 'vitest';
 import {literal, column} from '../src/index.js';
 import { columns } from './util/columns.js';
-import {list_contains, list_has_all, list_has_any} from "../src/functions/list";
+import {list, list_contains, list_has_all, list_has_any} from "../src/functions/list";
 
 describe('List functions', () => {
   it('include list_contains', () => {
@@ -13,7 +13,7 @@ describe('List functions', () => {
   });
 
   it('include list_has_all', () => {
-    const expr = list_has_all(column("foo"), [literal('bar'), literal('baz')])
+    const expr = list_has_all(column("foo"), list([literal('bar'), literal('baz')]))
     expect(String(expr)).toBe(`list_has_all("foo", ['bar', 'baz'])`);
     expect(expr.name).toBe('list_has_all');
     expect(expr.args.length).toBe(2);
@@ -21,7 +21,7 @@ describe('List functions', () => {
   });
 
   it('include list_has_any', () => {
-    const expr = list_has_any(column("foo"), [literal('bar'), literal('baz')])
+    const expr = list_has_any(column("foo"), list([literal('bar'), literal('baz')]))
     expect(String(expr)).toBe(`list_has_any("foo", ['bar', 'baz'])`);
     expect(expr.name).toBe('list_has_any');
     expect(expr.args.length).toBe(2);

--- a/packages/mosaic/sql/test/list.test.ts
+++ b/packages/mosaic/sql/test/list.test.ts
@@ -1,0 +1,30 @@
+import { expect, describe, it } from 'vitest';
+import {literal, column} from '../src/index.js';
+import { columns } from './util/columns.js';
+import {list_contains, list_has_all, list_has_any} from "../src/functions/list";
+
+describe('List functions', () => {
+  it('include list_contains', () => {
+    const expr = list_contains(column("foo"), literal('bar'))
+    expect(String(expr)).toBe(`list_contains("foo", 'bar')`);
+    expect(expr.name).toBe('list_contains');
+    expect(expr.args.length).toBe(2);
+    expect(columns(expr)).toStrictEqual(['foo']);
+  });
+
+  it('include list_has_all', () => {
+    const expr = list_has_all(column("foo"), [literal('bar'), literal('baz')])
+    expect(String(expr)).toBe(`list_has_all("foo", ['bar', 'baz'])`);
+    expect(expr.name).toBe('list_has_all');
+    expect(expr.args.length).toBe(2);
+    expect(columns(expr)).toStrictEqual(['foo']);
+  });
+
+  it('include list_has_any', () => {
+    const expr = list_has_any(column("foo"), [literal('bar'), literal('baz')])
+    expect(String(expr)).toBe(`list_has_any("foo", ['bar', 'baz'])`);
+    expect(expr.name).toBe('list_has_any');
+    expect(expr.args.length).toBe(2);
+    expect(columns(expr)).toStrictEqual(['foo']);
+  });
+});

--- a/packages/mosaic/sql/test/list.test.ts
+++ b/packages/mosaic/sql/test/list.test.ts
@@ -1,30 +1,74 @@
-import { expect, describe, it } from 'vitest';
-import {literal, column} from '../src/index.js';
-import { columns } from './util/columns.js';
-import {list, list_contains, list_has_all, list_has_any} from "../src/functions/list";
+import { expect, describe, it } from "vitest";
+import { columns } from "./util/columns.js";
+import {
+  list,
+  listContains,
+  listHasAll,
+  listHasAny,
+} from "../src/functions/list";
 
-describe('List functions', () => {
-  it('include list_contains', () => {
-    const expr = list_contains(column("foo"), literal('bar'))
+describe("List functions", () => {
+  it("include listContains", () => {
+    const expr = listContains("foo", "bar");
     expect(String(expr)).toBe(`list_contains("foo", 'bar')`);
-    expect(expr.name).toBe('list_contains');
+    expect(expr.name).toBe("list_contains");
     expect(expr.args.length).toBe(2);
-    expect(columns(expr)).toStrictEqual(['foo']);
+    expect(columns(expr)).toStrictEqual(["foo"]);
   });
 
-  it('include list_has_all', () => {
-    const expr = list_has_all(column("foo"), list([literal('bar'), literal('baz')]))
+  it("include listContains no columns", () => {
+    const expr = listContains(list("foo", "bar"), "bar");
+    expect(String(expr)).toBe(`list_contains(['foo', 'bar'], 'bar')`);
+    expect(expr.name).toBe("list_contains");
+    expect(expr.args.length).toBe(2);
+    expect(columns(expr)).toStrictEqual([]);
+  });
+
+  it("include listHasAll one column", () => {
+    const expr = listHasAll("foo", list("bar", "baz"));
     expect(String(expr)).toBe(`list_has_all("foo", ['bar', 'baz'])`);
-    expect(expr.name).toBe('list_has_all');
+    expect(expr.name).toBe("list_has_all");
     expect(expr.args.length).toBe(2);
-    expect(columns(expr)).toStrictEqual(['foo']);
+    expect(columns(expr)).toStrictEqual(["foo"]);
   });
 
-  it('include list_has_any', () => {
-    const expr = list_has_any(column("foo"), list([literal('bar'), literal('baz')]))
-    expect(String(expr)).toBe(`list_has_any("foo", ['bar', 'baz'])`);
-    expect(expr.name).toBe('list_has_any');
+  it("include listHasAll no columns", () => {
+    const expr = listHasAll(list("bar", "baz"), list("bar", "baz"));
+    expect(String(expr)).toBe(`list_has_all(['bar', 'baz'], ['bar', 'baz'])`);
+    expect(expr.name).toBe("list_has_all");
     expect(expr.args.length).toBe(2);
-    expect(columns(expr)).toStrictEqual(['foo']);
+    expect(columns(expr)).toStrictEqual([]);
+  });
+
+  it("include listHasAll two columns", () => {
+    const expr = listHasAll("foo", "bar");
+    expect(String(expr)).toBe(`list_has_all("foo", "bar")`);
+    expect(expr.name).toBe("list_has_all");
+    expect(expr.args.length).toBe(2);
+    expect(columns(expr)).toStrictEqual(["foo", "bar"]);
+  });
+
+  it("include listHasAny", () => {
+    const expr = listHasAny("foo", list("bar", "baz"));
+    expect(String(expr)).toBe(`list_has_any("foo", ['bar', 'baz'])`);
+    expect(expr.name).toBe("list_has_any");
+    expect(expr.args.length).toBe(2);
+    expect(columns(expr)).toStrictEqual(["foo"]);
+  });
+
+  it("include listHasAny no columns", () => {
+    const expr = listHasAny(list("bar", "baz"), list("bar", "baz"));
+    expect(String(expr)).toBe(`list_has_any(['bar', 'baz'], ['bar', 'baz'])`);
+    expect(expr.name).toBe("list_has_any");
+    expect(expr.args.length).toBe(2);
+    expect(columns(expr)).toStrictEqual([]);
+  });
+
+  it("include listHasAny two columns", () => {
+    const expr = listHasAny("foo", "bar");
+    expect(String(expr)).toBe(`list_has_any("foo", "bar")`);
+    expect(expr.name).toBe("list_has_any");
+    expect(expr.args.length).toBe(2);
+    expect(columns(expr)).toStrictEqual(["foo", "bar"]);
   });
 });


### PR DESCRIPTION
This builds on #837. Again, I'm just checking to see if this seems like a reasonable direction to take. I'm thinking that inputs can be a little smarter about supporting list columns, they just need a little introspection to know if they're targeting a list column. The column is just a string, so introspection would require a query. I added an additional input necessary to set `any` or `or` for the `listMatch` type.

I also added a hardcoded `UNNEST()`, but it seems like adding an `unnest` js function to the query builder would probably be useful in the future.

The menu is a simpler case, where there is still just a single selection value, but whatever patterns we decide on should be relatively easy to translate to a `select` that allows multiple selections.