### PR TITLE
feat: add list support to spec + menu

### DIFF
--- a/packages/vgplot/spec/src/spec/Input.ts
+++ b/packages/vgplot/spec/src/spec/Input.ts
@@ -28,6 +28,11 @@ export interface Menu {
    */
   column?: string;
   /**
+   * Required if the database column is an list, this property determines how
+   * to match the selected menu option against the list values.
+   */
+  listMatch?: 'any' | 'all';
+  /**
    * A selection to filter the database table indicated by the `from` property.
    */
   filterBy?: ParamRef;


### PR DESCRIPTION
This adds `listMatch` as a new option to the spec, and adds support to the menu.js input

> It might be cleaner to create a separate (or sub-classed) Menu component (ListMenu?) specific to list-type data

@jheer My pitch to not subclass it differently is that the UI/UX is the same, whether using `isIn` to filter by rows, or `list_has_any` to filter by a nested list. The implementation ended up being only ~10 lines. Here's a working implementation from spec to mosaic dev, with the `Keyword Group` dropdown populated from a list, and `Domain` populated normally, and the user couldn't tell the difference in the underlying data model.

<img width="614" alt="image" src="https://github.com/user-attachments/assets/c0fdc32c-e2eb-440d-9633-7f1f21af5d32" />

To make the experience even more seamless, I think it would be awesome to have column metadata available and automatically handle list columns, with `listMatch` only necessary to override the default behavior, but that isn't necessary for this discussion.

The naming for `listMatch` was the best I could come up with, but I'm not married to it. I think `all` or `any` handles the vast majority of use cases. Maybe there are some use cases for "at least 2 out of 3 matching" or "exactly 2 out of 3 matching". That could be extended later as `listMatch: exactly` and `listMatchCount: 2` or something like that. 

There are additional [list functions](https://duckdb.org/docs/stable/sql/functions/list) that DuckDB supports, like [list_filter](https://duckdb.org/docs/stable/sql/functions/list#list_filterlist-lambda), or [list_intersect](https://duckdb.org/docs/stable/sql/functions/list#list_intersectlist1-list2), that could also make sense down the road if someone requested it, but over-engineering the specifics now seems premature.

If you still prefer a different implementation style, where the user picks a different input for list fields, I'm happy to make the changes. The codebase is beautiful, and you clearly have the overall architecture in mind, so I trust whatever you feel is best.

Related issues:
- #830 
- #837