### PR TITLE
feat: query method returns Table when query type is arrow

### DIFF
--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -180,7 +180,7 @@ export class Coordinator {
   query(
     query: QueryType,
     options?: {
-      type?: 'arrow' | 'json';
+      type?: 'json';
       cache?: boolean;
       persist?: boolean;
       priority?: number;
@@ -216,8 +216,16 @@ export class Coordinator {
    */
   prefetch(
     query: QueryType,
-    options: { type?: 'arrow' | 'json'; [key: string]: unknown } = {}
-  ): QueryResult {
+    options?: { type?: 'arrow'; [key: string]: unknown }
+  ): QueryResult<Table>
+  prefetch(
+    query: QueryType,
+    options?: { type?: 'json'; [key: string]: unknown }
+  ): QueryResult<unknown>
+  prefetch(
+    query: QueryType,
+    options: any = {}
+  ): QueryResult<any> {
     return this.query(query, { ...options, cache: true, priority: Priority.Low });
   }
 

--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -9,6 +9,7 @@ import { type QueryResult } from './util/query-result.js';
 import { type MosaicClient } from './MosaicClient.js';
 import { type SelectionClause } from './SelectionClause.js';
 import { MaybeArray } from '@uwdata/mosaic-sql';
+import { Table } from '@uwdata/flechette';
 
 interface FilterGroupEntry {
   selection: Selection;
@@ -168,6 +169,26 @@ export class Coordinator {
    */
   query(
     query: QueryType,
+    options?: {
+      type?: 'arrow';
+      cache?: boolean;
+      persist?: boolean;
+      priority?: number;
+      [key: string]: unknown;
+    }
+  ): QueryResult<Table>;
+  query(
+    query: QueryType,
+    options?: {
+      type?: 'arrow' | 'json';
+      cache?: boolean;
+      persist?: boolean;
+      priority?: number;
+      [key: string]: unknown;
+    }
+  ): QueryResult<unknown>;
+  query(
+    query: QueryType,
     options: {
       type?: 'arrow' | 'json';
       cache?: boolean;
@@ -175,7 +196,7 @@ export class Coordinator {
       priority?: number;
       [key: string]: unknown;
     } = {}
-  ): QueryResult {
+  ): QueryResult<any> {
     const {
       type = 'arrow',
       cache = true,

--- a/packages/mosaic/core/src/util/field-info.ts
+++ b/packages/mosaic/core/src/util/field-info.ts
@@ -66,7 +66,7 @@ async function getFieldInfo(mc: Coordinator, { table, column, stats }: FieldInfo
     .groupby(isNode(column) && isAggregateExpression(column) ? sql`ALL` : []);
 
   const [desc] = Array.from(
-    await mc.query(Query.describe(q)) as Table
+    await mc.query(Query.describe(q))
   ) as ColumnDescription[];
   const info: FieldInfo = {
     table,
@@ -83,7 +83,7 @@ async function getFieldInfo(mc: Coordinator, { table, column, stats }: FieldInfo
   const [result] = await mc.query(
     summarize({ table, column, stats }),
     { persist: true }
-  ) as Table;
+  );
 
   // extract summary stats, copy to field info, and return
   return Object.assign(info, result);
@@ -97,7 +97,7 @@ async function getFieldInfo(mc: Coordinator, { table, column, stats }: FieldInfo
  */
 async function getTableInfo(mc: Coordinator, table: string): Promise<FieldInfo[]> {
   const result = Array.from(
-    await mc.query(`DESCRIBE ${asTableRef(table)}`) as Table
+    await mc.query(`DESCRIBE ${asTableRef(table)}`)
   ) as ColumnDescription[];
   return result.map(desc => ({
     table,


### PR DESCRIPTION
With this change, you don't need to override the return type anymore. It defaults to `Table` unless you explicitly set the type to `json`. This should also make it easy to transition to a future where we remove the json response support. 