### PR TITLE
fix: destroy is part of MosaicClient

### DIFF
--- a/packages/mosaic/core/src/make-client.ts
+++ b/packages/mosaic/core/src/make-client.ts
@@ -30,9 +30,9 @@ export interface MakeClientOptions {
  * Make a new client with the given options, and connect the client to the
  * provided coordinator.
  * @param options The options for making the client.
- * @returns The resulting client, along with a method to destroy the client when no longer needed.
+ * @returns The resulting client.
  */
-export function makeClient(options: MakeClientOptions): MosaicClient & { destroy: () => void } {
+export function makeClient(options: MakeClientOptions): MosaicClient {
   const {
     coordinator = defaultCoordinator(),
     ...clientOptions


### PR DESCRIPTION
From the MosaicClient class, I understand there is no need to add a destroy method manually. 

https://github.com/uwdata/mosaic/blob/3ef701b545160e69704888eab2d50867ef45fdc8/packages/mosaic/core/src/MosaicClient.ts#L214-L224