### PR TITLE
fix: clause.source doesn't accept a MosaicClient

### DIFF
--- a/packages/mosaic/core/src/SelectionClause.ts
+++ b/packages/mosaic/core/src/SelectionClause.ts
@@ -59,9 +59,7 @@ export interface IntervalMetadata extends ClauseMetadata {
   bin?: BinMethod
 }
 
-export interface ClauseSource {
-  reset?: () => void;
-}
+export type ClauseSource = object & { reset?: () => void; };
 
 /**
  * A selection clause representing filtering criteria

--- a/packages/mosaic/core/test/client.test.ts
+++ b/packages/mosaic/core/test/client.test.ts
@@ -85,7 +85,7 @@ describe('MosaicClient', () => {
     // crossfilter should skip client1, indicated by undefined result
     // client2 should be filtered by HourOfDay
     selection.update(
-      clauseInterval('HourOfDay', [0, 24], { source: client1 as ClauseSource })
+      clauseInterval('HourOfDay', [0, 24], { source: client1 })
     );
     expect(selection.active?.source).toBe(client1);
     expect(selection.predicate(client1)).toBeUndefined();
@@ -109,7 +109,7 @@ describe('MosaicClient', () => {
     // client1 should be filtered by DayOfWeek
     // crossfilter should skip client2, indicated by undefined result
     selection.update(
-      clauseInterval('DayOfWeek', [0, 7], { source: client2 as ClauseSource })
+      clauseInterval('DayOfWeek', [0, 7], { source: client2 })
     );
     expect(selection.active?.source).toBe(client2);
     expect(selection.predicate(client1)+'').toBe(

--- a/packages/mosaic/core/test/make-client.test.ts
+++ b/packages/mosaic/core/test/make-client.test.ts
@@ -1,6 +1,6 @@
 import { Query } from "@uwdata/mosaic-sql";
 import { describe, expect, it } from "vitest";
-import { Coordinator, makeClient } from "../src/index.js";
+import { Coordinator, makeClient, Selection } from "../src/index.js";
 import { NodeConnector } from "./util/node-connector.js";
 
 describe("makeClient", () => {
@@ -23,6 +23,15 @@ describe("makeClient", () => {
     });
 
     expect(mc.clients).toContain(client);
+
+    // should be able to use the client as a source in a clause.
+    let selection = Selection.single();
+    selection.update({
+      source: client,
+      clients: new Set([client]),
+      predicate: null,
+      value: null
+    });
 
     // await pending queries before destroying the client
     await client.pending;

--- a/packages/mosaic/core/test/make-client.test.ts
+++ b/packages/mosaic/core/test/make-client.test.ts
@@ -24,9 +24,8 @@ describe("makeClient", () => {
 
     expect(mc.clients).toContain(client);
 
-    // should be able to use the client as a source in a clause.
-    let selection = Selection.single();
-    selection.update({
+    // should be able to use the client as a clause source.
+    Selection.single().update({
       source: client,
       clients: new Set([client]),
       predicate: null,


### PR DESCRIPTION
The symptom: clause.source doesn't accept a MosaicClient. If you define a simple client like:

```js
let client = makeClient(...);

selection.update({
  source: client,
  ...
});
```

You'll get a type error on "Type 'MosaicClient' has no properties in common with type 'ClauseSource'". Right now we have to cast the client to `ClauseSource` like `client as ClauseSource`.

I think we can fix it by changing `ClauseSource` to:

```ts
export type ClauseSource = object & { reset?: () => void; };
```

This should match any object, but also objects with a reset method (and if there is a reset method, it must match be of type `() => void`) .