### PR TITLE
Various bug fixes.

### DIFF
--- a/packages/mosaic/sql/src/ast/query.ts
+++ b/packages/mosaic/sql/src/ast/query.ts
@@ -366,7 +366,7 @@ export class SelectQuery extends Query {
    * @param seed The random seed.
    */
   sample(
-    value: number | SampleClauseNode,
+    value?: number | SampleClauseNode | null,
     method?: SampleMethod,
     seed?: number
   ): this {
@@ -378,7 +378,7 @@ export class SelectQuery extends Query {
     } else {
       clause = value;
     }
-    this._sample = clause;
+    this._sample = clause ?? undefined;
     return this;
   }
 

--- a/packages/vgplot/inputs/src/Table.js
+++ b/packages/vgplot/inputs/src/Table.js
@@ -172,11 +172,13 @@ export class Table extends Input {
   clause(rows = []) {
     const { data, limit, schema } = this;
     const fields = schema.map(s => s.column);
-    const values = rows.map(row => {
-      const { columns } = data[~~(row / limit)];
-      return fields.map(f => columns[f][row % limit]);
-    });
-    return clausePoints(fields, values, { source: /** @type {ClauseSource} */(this) });
+    const values = rows.length
+      ? rows.map(row => {
+          const { columns } = data[~~(row / limit)];
+          return fields.map(f => columns[f][row % limit]);
+        })
+      : null;
+    return clausePoints(fields, values, { source: this });
   }
 
   requestData(offset = 0) {

--- a/packages/vgplot/vgplot/src/plot/marks.js
+++ b/packages/vgplot/vgplot/src/plot/marks.js
@@ -104,7 +104,7 @@ export const hexgrid = (...args) => mark('hexgrid', ...args);
 export const regressionY = (...args) => implicitType(RegressionMark, ...args);
 
 export const errorbarX = (...args) => explicitType(ErrorBarMark, 'ruleY', ...args);
-export const errorbarY = (...args) => implicitType(ErrorBarMark, 'ruleX', ...args);
+export const errorbarY = (...args) => explicitType(ErrorBarMark, 'ruleX', ...args);
 
 export const voronoi = (...args) => mark('voronoi', ...args);
 export const voronoiMesh = (...args) => mark('voronoiMesh', ...args);


### PR DESCRIPTION
- Fix `Query.sample` to accept `null` or `undefined` values to remove sample settings.
- Fix `table` input to use `null` clause value (not empty array) for empty selections. (Fix #849)
- Fix `errorbarY` mark method to use explicit type. (Fix #851)