### PR TITLE
chore: update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
         "rimraf": "^6.0.1",
         "timezone-mock": "^1.3.6",
         "typescript": "^5.9.2",
-        "typescript-eslint": "^8.42.0",
-        "vite": "^7.1.4",
+        "typescript-eslint": "^8.43.0",
+        "vite": "^7.1.5",
         "vitepress": "1.6.4",
         "vitest": "^3.2.4",
         "yaml": "^2.8.1"
@@ -794,9 +794,9 @@
       }
     },
     "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.29.1-dev283.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.29.1-dev283.0.tgz",
-      "integrity": "sha512-E+7UdUNmyQNYUVJ8zNN8D0P+gIuAjNECnZuWO3j4EHX2SleeQaGNIW7kgoZYhzeCxwjbFsWSWWTJ5nGwQQLBBA==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.30.0.tgz",
+      "integrity": "sha512-9aWrm+4ayl4sTlvGtl/b+LxrUyXaac3yyVqkoJ3F7Vkd62PoS8PcQIRJ/KjXBW36LP1CnPY5jjvFyIcTFLtcXA==",
       "license": "MIT",
       "dependencies": {
         "apache-arrow": "^17.0.0"
@@ -6632,9 +6632,9 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-1.3.2.tgz",
-      "integrity": "sha512-a2Y0kz7HOR36RMlxdCVQ6fnNZaaXjvdVFzi03T6bRLb6trvW8OuHDNBCHZ4XanRCeT0J7w7FvpuAVbgz0r5CYA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-1.3.4.tgz",
+      "integrity": "sha512-dt9KOxYm+RIOyPWVPVo1A/o4Gs5+8S1EpkU4bkQ81wBFTXbZUnSXdmM9MpO1SXPliuUxw4yBBoRlRrMkpzerKQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -9789,21 +9789,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -11933,37 +11918,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -12656,18 +12610,6 @@
       },
       "engines": {
         "node": ">=v12.22.7"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/search-insights": {
@@ -16065,7 +16007,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "svelte": "^5.38.7",
-        "vite": "^7.1.4"
+        "vite": "^7.1.5"
       }
     },
     "packages/examples/svelte-example/node_modules/react": {
@@ -16107,7 +16049,7 @@
         "@uwdata/vgplot": "^0.18.0"
       },
       "devDependencies": {
-        "vite": "^7.1.4"
+        "vite": "^7.1.5"
       }
     },
     "packages/examples/vega-example": {
@@ -16122,7 +16064,7 @@
         "vega-lite": "^6.3.0"
       },
       "devDependencies": {
-        "vite": "^7.1.4"
+        "vite": "^7.1.5"
       }
     },
     "packages/mosaic/core": {
@@ -16130,8 +16072,8 @@
       "version": "0.18.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@duckdb/duckdb-wasm": "1.29.1-dev283.0",
-        "@uwdata/flechette": "^2.1.0",
+        "@duckdb/duckdb-wasm": "1.30.0",
+        "@uwdata/flechette": "^2.2.0",
         "@uwdata/mosaic-sql": "^0.18.0"
       },
       "devDependencies": {
@@ -16149,7 +16091,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@uwdata/mosaic-sql": "^0.18.0",
-        "duckdb": "~1.3.2",
+        "duckdb": "~1.3.4",
         "ws": "^8.18.3"
       },
       "bin": {
@@ -16210,7 +16152,7 @@
       "dependencies": {
         "@uwdata/mosaic-core": "^0.18.0",
         "@uwdata/mosaic-spec": "^0.18.0",
-        "uuid": "^11.1.0"
+        "uuid": "^13.0.0"
       },
       "devDependencies": {
         "anywidget": "0.9.18",
@@ -16218,16 +16160,16 @@
       }
     },
     "packages/vgplot/widget/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "rimraf": "^6.0.1",
     "timezone-mock": "^1.3.6",
     "typescript": "^5.9.2",
-    "typescript-eslint": "^8.42.0",
-    "vite": "^7.1.4",
+    "typescript-eslint": "^8.43.0",
+    "vite": "^7.1.5",
     "vitepress": "1.6.4",
     "vitest": "^3.2.4",
     "yaml": "^2.8.1"

--- a/packages/examples/svelte-example/package.json
+++ b/packages/examples/svelte-example/package.json
@@ -14,7 +14,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "svelte": "^5.38.7",
-    "vite": "^7.1.4"
+    "vite": "^7.1.5"
   },
   "dependencies": {
     "@uwdata/mosaic-core": "^0.18.0",

--- a/packages/examples/vanilla-example/package.json
+++ b/packages/examples/vanilla-example/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^7.1.4"
+    "vite": "^7.1.5"
   },
   "dependencies": {
     "@uwdata/mosaic-core": "^0.18.0",

--- a/packages/examples/vega-example/package.json
+++ b/packages/examples/vega-example/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^7.1.4"
+    "vite": "^7.1.5"
   },
   "dependencies": {
     "@uwdata/mosaic-core": "^0.18.0",

--- a/packages/mosaic/core/package.json
+++ b/packages/mosaic/core/package.json
@@ -32,8 +32,8 @@
     "prepublishOnly": "npm run test && npm run lint && tsc --build"
   },
   "dependencies": {
-    "@duckdb/duckdb-wasm": "1.29.1-dev283.0",
-    "@uwdata/flechette": "^2.1.0",
+    "@duckdb/duckdb-wasm": "1.30.0",
+    "@uwdata/flechette": "^2.2.0",
     "@uwdata/mosaic-sql": "^0.18.0"
   },
   "devDependencies": {

--- a/packages/server/duckdb/package.json
+++ b/packages/server/duckdb/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@uwdata/mosaic-sql": "^0.18.0",
-    "duckdb": "~1.3.2",
+    "duckdb": "~1.3.4",
     "ws": "^8.18.3"
   }
 }

--- a/packages/vgplot/widget/package.json
+++ b/packages/vgplot/widget/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@uwdata/mosaic-core": "^0.18.0",
     "@uwdata/mosaic-spec": "^0.18.0",
-    "uuid": "^11.1.0"
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "anywidget": "0.9.18",


### PR DESCRIPTION
update all dependencies to avoid matching any of the compromised duckdb deps (https://github.com/duckdb/duckdb-node/security/advisories/GHSA-w62p-hx95-gf2c)