### PR TITLE
feat: support additional SQL dialects in mosaic-sql

### DIFF
--- a/packages/mosaic/sql/src/ast/node.ts
+++ b/packages/mosaic/sql/src/ast/node.ts
@@ -9,13 +9,17 @@ export function isNode(value: unknown): value is SQLNode {
 export class SQLNode {
   /** The SQL AST node type. */
   readonly type: string;
+  /** The SQL dialect. */
+  readonly dialect: string;
 
   /**
    * Instantiate a SQL AST node.
    * @param type The SQL AST node type.
+   * @param dialect The SQL dialect (defaults to "duckdb").
    */
-  constructor(type: string) {
+  constructor(type: string, dialect: string = "duckdb") {
     this.type = type;
+    this.dialect = dialect;
   }
 
   /**


### PR DESCRIPTION
This is very much a proof of concept, primarily for the purpose of driving discussion of how to add additional support for other SQL engines. The primary concern with #681 is that it requires a python dependency for sqlglot. As we already have a well defined AST, it feels unnecessary to stringify the duckdb SQL statement, to then just parse it into another AST for translation. Specific SQL overlap will vary between engines, but a primary assumption I am making here is that most basic AST nodes will share the same SQL output, with overrides for more engine specific functions.

I had thought about possibly sending the AST over the wire to the server, as opposed to the stringified SQL, so translation could happen there, but that leaves a similar issue to #681, where you'd either have to run node to manage it on the backend, or recreate the AST and SQL generation in whatever language you were using.

I added a `dialect` field to `SQLNode`, which defaults to `duckdb` (could also use an empty value if that saves memory for the common case), which all other nodes inherit from. Then inside each `toString`, there is a dialect specific override. For the purposes of this PoC, I chose ClickHouse, StarRocks, and BigQuery as alternative dialects, and specifically list functions, as it shows significant edge cases. 

ClickHouse has equivalent functions to DuckDB, but differently named functions for all three:
- `list_contains` => `has`
- `list_contains_any` => `hasAny`
- `list_contains_all` => `hasAll`

StarRocks is similar to ClickHouse, with equivalent but differently named functions:
- `list_contains` => `array_contains`
- `list_contains_any` => `arrays_overlap`
- `list_contains_all` => `array_contains_all`

BigQuery however has no convenience functions, so it requires a nested statement for 2 of the three cases. I'm not 100% sure that the AST as currently constituted can express all of these, so they are pseudocoded strings for the purposes of this PoC, but I'm assuming it should work returned as an expression function:
- `list_contains` => `element IN UNNEST(list1)`
- `list_contains_any` => `EXISTS(SELECT * FROM UNNEST(list1) AS l1 WHERE l1 IN UNNEST(list2))`
- `list_contains_all` => `(SELECT COUNT(l2) = ARRAY_LENGTH(list2) FROM UNNEST(list1) AS l1 JOIN UNNEST(list1) AS l2 ON l1 = l2)`

As written, the data flows don't actually work. The functions themselves don't actually inherit from `SQLNode`, so the `switch (this.dialect)` isn't actually going to work, I'm just not sure where the best place to set that and make it available to all functions, without necessarily requiring dialect to be passed through at every callsite. Is there some global / coordinator scope that the functions might have access to?

This has the benefit of requiring zero dependencies on other libraries, and should be the most targeted approach, but also requires manual support for any dialects we want to add. Since the AST is already targeting the most common subset of SQL functionality, my gut feeling is that overrides won't be required for most expressions.

Co-locating the SQL dialect translations per node should make it relatively simple to add overrides as necessary, but since there is no common place where all the per dialect overrides live, it might be harder to verify full coverage. Once we determine a way to actually pipe the dialect through SQL generation, maybe there is a different architecture that makes sense. I'm not a JavaScript guru, so I'm not tied to any implementation details.

Let me know @jheer if you think this is worth chasing down, or if there's another approach to test out.

Fixes #399 