### PR TITLE
Do not consolidate DISTINCT queries.

### DIFF
--- a/packages/mosaic/core/src/QueryConsolidator.ts
+++ b/packages/mosaic/core/src/QueryConsolidator.ts
@@ -103,11 +103,11 @@ function consolidationKey(query: QueryType, cache: Cache): string {
   const sql = `${query}`;
   if (isSelectQuery(query) && !cache.get(sql)) {
     if (
-      query._orderby.length || query._where.length ||
-      query._qualify.length || query._having.length
+      query._where.length || query._qualify.length || query._having.length ||
+      query._orderby.length || query._distinct
     ) {
-      // do not try to analyze if query includes clauses
-      // that may refer to *derived* columns we can't resolve
+      // bail if query includes clauses that may refer to *derived* columns
+      // that we can't resolve. also do not consolidate distinct queries
       return sql;
     }
 

--- a/packages/mosaic/core/test/query-consolidator.test.ts
+++ b/packages/mosaic/core/test/query-consolidator.test.ts
@@ -9,6 +9,7 @@ describe('QueryConsolidation', () => {
     const consolidated: string[] = [];
     const c = consolidator(q => consolidated.push(q.request.query.toString()), voidCache());
     for(const q of qs) {
+      // @ts-expect-error stub entry for test
       c.add({request: { type: 'arrow', query: q }}, Priority.Normal);
     }
     await new Promise(resolve => setImmediate(resolve));
@@ -40,6 +41,17 @@ describe('QueryConsolidation', () => {
     expect(consolidated).toEqual([
       q1.toString(),
       q2.toString(),
+    ]);
+  });
+
+  it('should not consolidate select distinct queries', async () => {
+    const q1 = Query.from({ source: 'table' }).select({ u: 'x' }).distinct();
+    const q2 = Query.from({ source: 'table' }).select({ v: 'y' });
+    const q3 = Query.from({ source: 'table' }).select({ w: 'z' });
+    const consolidated = await getConsolidatedQueries(q1, q2, q3);
+    expect(consolidated).toEqual([
+      q1.toString(),
+      Query.from({ source: 'table' }).select({ col0: 'y', col1: 'z' }).toString(),
     ]);
   });
 });


### PR DESCRIPTION
- Fix query consolidator to skip DISTINCT queries. Consolidating such queries can change the semantics and produce incorrect results.
