### PR TITLE
Update flechette to 2.2.3.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4021,9 +4021,9 @@
       "license": "ISC"
     },
     "node_modules/@uwdata/flechette": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@uwdata/flechette/-/flechette-2.2.2.tgz",
-      "integrity": "sha512-MeuBgJqJh202M46cCsQTR3H9rg+DfG8kxQ2l2IADGoEuqkMYbZjteMKVilUPTFE4O4bntJx2pQJDk3d3JjN1bg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@uwdata/flechette/-/flechette-2.2.3.tgz",
+      "integrity": "sha512-5qMO+KT+udDFwgh+HxQ2memj27bPeCXlJ7bWnmI1wvW8RaoHhSJtI7PHVDd2AONhqXuuDLVkWKaV0G51ozrpWw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@uwdata/mosaic-core": {
@@ -16073,7 +16073,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@duckdb/duckdb-wasm": "1.30.0",
-        "@uwdata/flechette": "^2.2.2",
+        "@uwdata/flechette": "^2.2.3",
         "@uwdata/mosaic-sql": "^0.19.0"
       },
       "devDependencies": {

--- a/packages/mosaic/core/package.json
+++ b/packages/mosaic/core/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.30.0",
-    "@uwdata/flechette": "^2.2.2",
+    "@uwdata/flechette": "^2.2.3",
     "@uwdata/mosaic-sql": "^0.19.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Fix unsafe reference to SharedArrayBuffer that can crash an app.

Close #884.