### PR TITLE
Fixes to SQL code gen.

### DIFF
--- a/packages/mosaic/sql/src/index.ts
+++ b/packages/mosaic/sql/src/index.ts
@@ -60,7 +60,7 @@ export { deepClone } from './visit/clone.js';
 export { rewrite } from './visit/rewrite.js';
 export { collectAggregates, collectColumns, collectParams, isAggregateExpression } from './visit/visitors.js';
 export { walk, type VisitorCallback, type VisitorResult } from './visit/walk.js';
-export { SQLCodeGenerator as ToStringVisitor } from './visit/codegen/sql.js';
+export { SQLCodeGenerator } from './visit/codegen/sql.js';
 export { DuckDBCodeGenerator, duckDBCodeGenerator } from './visit/codegen/duckdb.js';
 
 export { createTable, createSchema } from './load/create.js';

--- a/packages/mosaic/sql/src/visit/codegen/sql.ts
+++ b/packages/mosaic/sql/src/visit/codegen/sql.ts
@@ -101,8 +101,9 @@ export abstract class SQLCodeGenerator {
       throw new Error(`Node type is not a string: ${typeof node.type}, value: ${node.type}`);
     }
     if (node.type === 'CUSTOM') {
-      // custom node types may bypass visitor
-      return node.toString();
+      // custom node types provide their own handling
+      // pass the visitor through to apply to child nodes
+      return node.toString(this);
     }
     const method = this.getVisitMethod(node.type);
     if (typeof method === 'function') {
@@ -164,7 +165,7 @@ export abstract class SQLCodeGenerator {
    * @param nodes Array of child nodes.
    * @returns Array of SQL strings.
    */
-  protected mapToString(nodes: SQLNode[]): string[] {
+  mapToString(nodes: SQLNode[]): string[] {
     return nodes.map(node => this.toString(node));
   }
 

--- a/packages/mosaic/sql/test/query.test.ts
+++ b/packages/mosaic/sql/test/query.test.ts
@@ -564,12 +564,12 @@ describe('Query', () => {
 
   it('supports describe queries', () => {
     const q = Query.select('foo', 'bar').from('data');
-    expect(Query.describe(q).toString()).toBe(`DESCRIBE ${q}`);
+    expect(Query.describe(q).toString()).toBe(`DESC ${q}`);
 
     const u = Query.unionAll(
       Query.select('foo', 'bar').from('data1'),
       Query.select('foo', 'bar').from('data2')
     );
-    expect(Query.describe(u).toString()).toBe(`DESCRIBE ${u}`);
+    expect(Query.describe(u).toString()).toBe(`DESC ${u}`);
   });
 });

--- a/packages/vgplot/plot/src/transforms/bin.js
+++ b/packages/vgplot/plot/src/transforms/bin.js
@@ -1,4 +1,5 @@
-import { ExprNode, binDate, binHistogram } from '@uwdata/mosaic-sql';
+/** @import { SQLCodeGenerator } from '@uwdata/mosaic-sql'; */
+import { ExprNode, binDate, binHistogram, duckDBCodeGenerator } from '@uwdata/mosaic-sql';
 import { Transform } from '../symbols.js';
 import { channelScale } from '../marks/util/channel-scale.js';
 
@@ -49,7 +50,10 @@ class BinTransformNode extends ExprNode {
     return { column: this.column, stats: ['min', 'max'] };
   }
 
-  toString() {
+  /**
+   * @param {SQLCodeGenerator} visitor
+   */
+  toString(visitor = duckDBCodeGenerator) {
     const { mark, channel, column, options } = this;
     const { type, min, max } = mark.channelField(channel);
     const isDate = options.interval
@@ -58,6 +62,6 @@ class BinTransformNode extends ExprNode {
     const result = isDate
       ? binDate(column, [min, max], options)
       : binHistogram(column, [min, max], options, channelScale(mark, channel));
-    return `${result}`;
+    return visitor.toString(result);
   }
 }


### PR DESCRIPTION
- Update `CUSTOM` node handling to pass through SQL codegen visitor.
- Update vgplot `bin` transform to use pass-through visitor.
- Use `DESC` rather than `DESCRIBE` for broader compatibility.
- Fix SQL codegen to ensure application of current visitor, not default node `toString()`.
