### PR TITLE
feat: add BigQuery dialect

### DIFF
--- a/packages/mosaic/sql/src/visit/codegen/bigquery.ts
+++ b/packages/mosaic/sql/src/visit/codegen/bigquery.ts
@@ -1,0 +1,106 @@
+import {
+  AggregateNode,
+  CastNode,
+  FunctionNode,
+  JoinNode,
+  SampleClauseNode,
+  UnnestNode,
+} from "../../index.js";
+import { DuckDBCodeGenerator } from "./duckdb.js";
+
+/**
+ * BigQuery SQL dialect visitor for converting AST nodes to BigQuery-compatible SQL.
+ */
+export class BigQueryCodeGenerator extends DuckDBCodeGenerator {
+  visitAggregate(node: AggregateNode): string {
+    const { filter } = node;
+    // TODO: it might be possible to emulate filters using an IF statement
+    if (filter) {
+      throw new Error(`BigQuery does not support aggregate filters. Node: ${JSON.stringify(node)}`);
+    }
+    return super.visitAggregate(node);
+  }
+
+  visitCast(node: CastNode): string {
+    const { expr, cast } = node;
+    return `CAST(${this.toString(expr)} AS ${cast})`;
+  }
+
+  visitFunction(node: FunctionNode): string {
+    const { name, args } = node;
+    switch (name) {
+      case "epoch_ms":
+        return `UNIX_MILLIS(${this.mapToString(args).join(', ')})`;
+
+      case "list_contains":
+        return `${this.toString(args[1])} IN UNNEST(${this.toString(args[0])})`;
+
+      case "list_has_all":
+        return `(SELECT COUNT(l2) = ARRAY_LENGTH(${this.toString(args[1])}) FROM UNNEST(${this.toString(args[0])}) AS l1 JOIN UNNEST(${this.toString(args[1])}) AS l2 ON l1 = l2)"`;
+
+      case "list_has_any":
+        return `EXISTS(SELECT * FROM UNNEST(${this.toString(args[0])}) AS l1 WHERE l1 IN UNNEST(${this.toString(args[1])}))`;
+
+      case "make_date":
+        return `$DATE(${this.mapToString(args).join(', ')})`;
+
+      case "time_bucket":
+        return `TIMESTAMP_BUCKET(${this.toString(args[0])}, ${this.toString(args[1])})`;
+
+      default:
+        return super.visitFunction(node);
+    }
+  }
+
+  visitJoinClause(node: JoinNode): string {
+    const { joinVariant, joinType, sample } = node;
+
+    if (joinVariant !== "REGULAR") {
+      throw new Error(`BigQuery does not support (${joinVariant}) joins (variant). Node: ${JSON.stringify(node)}`);
+    }
+
+    if (joinType === "SEMI" || joinType === "ANTI") {
+      throw new Error(`BigQuery does not support (${joinType}) joins (type). Node: ${JSON.stringify(node)}`);
+    }
+
+    if (sample) {
+      throw new Error(`BigQuery does not support join sampling (${sample}). Node: ${JSON.stringify(node)}`);
+    }
+
+    return super.visitJoinClause(node);
+  }
+
+  visitSampleClause(node: SampleClauseNode): string {
+    const { size, perc, method, seed } = node;
+
+    if (!perc) {
+      throw new Error(`BigQuery does not support row based sampling. Node: ${JSON.stringify(node)}`);
+    }
+
+    if (method !== "system") {
+      throw new Error(`BigQuery does not support (${method}) sampling. Node: ${JSON.stringify(node)}`);
+    }
+
+    if (seed !== null) {
+      throw new Error(`BigQuery does not support setting a seed (${seed}) for sampling. Node: ${JSON.stringify(node)}`);
+    }
+
+    return `TABLESAMPLE SYSTEM (${size} PERCENT)`;
+  }
+
+  visitUnnest(node: UnnestNode): string {
+    const { expr, recursive, maxDepth } = node;
+
+    if (recursive) {
+      throw new Error(`BigQuery does not support recursive unnesting. Node: ${JSON.stringify(node)}`);
+    }
+
+    if (maxDepth != null && maxDepth > 0) {
+      throw new Error(`BigQuery does not support max depth when unnesting. Node: ${JSON.stringify(node)}`);
+    }
+
+    const args = [this.toString(expr)];
+
+    return `UNNEST(${args.join(", ")})`;
+  }
+}


### PR DESCRIPTION
This isn't tested yet, I just wanted to make sure I'm heading in the right direction. This may not be 100% comprehensive with all the language differences, but it should be pretty close, at least for the major functions.

### Function node
The function node is probably going to be the hairiest to support, since it's an untyped string match, and requires some arg reordering, but wasn't bad. Do you see any issues with the direct arg references?

### Types
There were a few untyped strings I ran across that would be easier to translate if they were a string union. I should've kept a better list, but these are the ones I remember:
- CastNode.cast
- IntervalNode.name

Maybe the function names in the function node could be too?

### Casing
DuckDB by convention uses lowercase, BigQuery uses uppercase. I wrote the override functions in uppercase, not sure if those should still all be lowercase. I don't feel strongly about it.

### Unsupported errors
Right now I'm checking for unsupported cases and throwing errors, following the example of a single throw in the DuckDB visitor. Not sure if there's a pattern otherwise to follow.

### Testing
We moved the visitor out, but not the tests. Should these sql tests be moved into per visitor files? I can add specific BigQuery tests once we decide on that organization.
https://github.com/uwdata/mosaic/tree/c381a4422193464aad796d741ad371dd460863ca/packages/mosaic/sql/test

### AST manipulation
There are a few operations that could be supported, but not while walking through `toString`. One example is `SEMI|ANTI JOIN`. BigQuery and Snowflake don't support them, but they can be trivially added by adding a `WHERE` condition. The database engine shouldn't leak into the AST creation, where individual nodes have to run a `supportsSemiJoin` type of scenario, which is the other place I can think to add it. Maybe an optional method like `manipulateAst` could be exposed, and executed if the visitor needed to. There's nothing urgent on this, as Mosaic just barely got join support yesterday, so I wouldn't spend any time on it unless there was a materialized view use case for the coordinator. In the meantime, I filed an issue with Google to add syntax support. (https://issuetracker.google.com/issues/446157721)