### PR TITLE
Overhaul mark-to-svg indexing.

### DIFF
--- a/docs/public/specs/esm/region-tests.js
+++ b/docs/public/specs/esm/region-tests.js
@@ -31,6 +31,8 @@ export default vg.vconcat(
     vg.marginLeft(24),
     vg.xLabel(null),
     vg.xTicks(10),
+    vg.xLine(true),
+    vg.yLine(true),
     vg.yLabel("Unemployment (%)"),
     vg.yGrid(true),
     vg.marginRight(0)

--- a/docs/public/specs/json/region-tests.json
+++ b/docs/public/specs/json/region-tests.json
@@ -70,6 +70,8 @@
       "marginLeft": 24,
       "xLabel": null,
       "xTicks": 10,
+      "xLine": true,
+      "yLine": true,
       "yLabel": "Unemployment (%)",
       "yGrid": true,
       "marginRight": 0

--- a/docs/public/specs/yaml/region-tests.yaml
+++ b/docs/public/specs/yaml/region-tests.yaml
@@ -40,6 +40,8 @@ vconcat:
   marginLeft: 24
   xLabel: null
   xTicks: 10
+  xLine: true
+  yLine: true
   yLabel: Unemployment (%)
   yGrid: true
   marginRight: 0

--- a/packages/vgplot/plot/src/marks/util/guide-marks.js
+++ b/packages/vgplot/plot/src/marks/util/guide-marks.js
@@ -1,0 +1,6 @@
+export const guideMarks = new Set([
+  'frame',
+  'axisX', 'axisY', 'axisFx', 'axisFy',
+  'gridX', 'gridY', 'gridFx', 'gridFy',
+  'hexgrid'
+]);

--- a/packages/vgplot/plot/src/plot-renderer.js
+++ b/packages/vgplot/plot/src/plot-renderer.js
@@ -43,7 +43,7 @@ export async function plotRenderer(plot) {
 
       // instantiate Plot mark and add to spec
       spec.marks.push(Plot[type](...arg));
-      indices.push(mark.index);
+      if (mark.index > -1) indices.push(mark.index);
     }
   }
 
@@ -144,12 +144,11 @@ function annotatePlot(svg, indices) {
   for (const child of svg.children) {
     const aria = child.getAttribute('aria-label') || '';
     const skip = child.nodeName === 'style'
-      // skip axis and grid marks
+      // skip axis, grid, and frame marks
       || aria.includes('-axis')
       || aria.includes('-grid')
-      // skip frame lines, such as those generated for axes
-      // imperfect fix, as explicit anchored frames will fail :(
-      || (child.nodeName === 'line' && aria === 'frame');
+      || aria === 'frame'
+      || aria === 'hexgrid';
     if (!skip) {
       child.setAttribute('data-index', indices[++index]);
     }

--- a/packages/vgplot/plot/src/plot-renderer.js
+++ b/packages/vgplot/plot/src/plot-renderer.js
@@ -144,8 +144,12 @@ function annotatePlot(svg, indices) {
   for (const child of svg.children) {
     const aria = child.getAttribute('aria-label') || '';
     const skip = child.nodeName === 'style'
+      // skip axis and grid marks
       || aria.includes('-axis')
-      || aria.includes('-grid');
+      || aria.includes('-grid')
+      // skip frame lines, such as those generated for axes
+      // imperfect fix, as explicit anchored frames will fail :(
+      || (child.nodeName === 'line' && aria === 'frame');
     if (!skip) {
       child.setAttribute('data-index', indices[++index]);
     }

--- a/packages/vgplot/plot/src/plot.js
+++ b/packages/vgplot/plot/src/plot.js
@@ -1,5 +1,6 @@
 import { distinct, Synchronizer } from '@uwdata/mosaic-core';
 import { plotRenderer } from './plot-renderer.js';
+import { guideMarks } from './marks/util/guide-marks.js';
 
 const DEFAULT_ATTRIBUTES = {
   width: 640,
@@ -151,7 +152,13 @@ export class Plot {
   }
 
   addMark(mark) {
-    mark.setPlot(this, this.marks.length);
+    // determine index for annotating marks
+    // we use this to match marks with SVG output
+    // skip all guides (axis, grid, frame, etc)
+    const idx = guideMarks.has(mark.type)
+      ? -1
+      : this.marks.reduce((sum, mark) => sum + (guideMarks.has(mark.type) ? 0 : 1), 0);
+    mark.setPlot(this, idx);
     this.marks.push(mark);
     this.markset = null;
     return this;

--- a/specs/esm/region-tests.js
+++ b/specs/esm/region-tests.js
@@ -31,6 +31,8 @@ export default vg.vconcat(
     vg.marginLeft(24),
     vg.xLabel(null),
     vg.xTicks(10),
+    vg.xLine(true),
+    vg.yLine(true),
     vg.yLabel("Unemployment (%)"),
     vg.yGrid(true),
     vg.marginRight(0)

--- a/specs/json/region-tests.json
+++ b/specs/json/region-tests.json
@@ -71,6 +71,8 @@
       "marginLeft": 24,
       "xLabel": null,
       "xTicks": 10,
+      "xLine": true,
+      "yLine": true,
       "yLabel": "Unemployment (%)",
       "yGrid": true,
       "marginRight": 0

--- a/specs/ts/region-tests.ts
+++ b/specs/ts/region-tests.ts
@@ -72,6 +72,8 @@ export const spec : Spec = {
       "marginLeft": 24,
       "xLabel": null,
       "xTicks": 10,
+      "xLine": true,
+      "yLine": true,
       "yLabel": "Unemployment (%)",
       "yGrid": true,
       "marginRight": 0

--- a/specs/yaml/region-tests.yaml
+++ b/specs/yaml/region-tests.yaml
@@ -40,6 +40,8 @@ vconcat:
   marginLeft: 24
   xLabel: null
   xTicks: 10
+  xLine: true
+  yLine: true
   yLabel: Unemployment (%)
   yGrid: true
   marginRight: 0


### PR DESCRIPTION
- Overhaul mark-to-svg indexing.

Interactors (such as `region`) look up the SVG for a mark based on a provided index. This PR updates this indexing scheme to always skip "guide" marks such as axes, grids, and frames. This avoids potential interactions with automatically added (as opposed to explicitly specified) guides, removing errors that can cause interactors to fail.

Close #897.