### PR TITLE
fix: remove cache from fetch options

### DIFF
--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -37,7 +37,6 @@ export class RestConnector implements Connector {
     const req = fetch(this._uri, {
       method: 'POST',
       mode: 'cors',
-      cache: 'no-cache',
       credentials: 'omit',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(query)


### PR DESCRIPTION
Remove `cache: 'no-cache'` from RestConnector. 

Having `cache: 'no-cache'` causes repeated OPTIONS requests to check CORS status unnecessarily. This increases overall response time.

Also, I believe HTTP caching rarely applies to POST anyway. 

With `cache: 'no-cache'`:
<img width="1526" height="962" alt="Screenshot 2025-10-15 at 15 32 54" src="https://github.com/user-attachments/assets/0676c03f-6910-4c58-91e8-ab844f0d27f1" />

Without setting `cache` option:
<img width="1350" height="962" alt="Screenshot 2025-10-15 at 15 31 14" src="https://github.com/user-attachments/assets/9361b117-d818-4ca0-9f1f-0102e56c9b72" />

Alternatively, we could add a param for `fetch` call in the constructor of RestConnector similar to `ipc` 