### PR TITLE
feat: Add timezone function to mosaic-sql.

### DIFF
--- a/packages/mosaic/sql/src/functions/datetime.ts
+++ b/packages/mosaic/sql/src/functions/datetime.ts
@@ -2,6 +2,7 @@ import type { ExprValue } from '../types.js';
 import { asNode } from '../util/ast.js';
 import { fn } from '../util/function.js';
 import { interval } from './interval.js';
+import { literal } from './literal.js';
 
 /**
  * Given a date/time value, return the milliseconds since the UNIX epoch.
@@ -47,4 +48,15 @@ export function dateMonthDay(expr: ExprValue) {
  */
 export function dateDay(expr: ExprValue) {
   return fn('make_date', 2012, 1, fn('day', expr));
+}
+
+/**
+ * Convert a timestamp to the specified time zone.
+ * See https://duckdb.org/docs/stable/sql/data_types/timezones for
+ * supported time zone identifiers.
+ * @param tz The time zone identifier string.
+ * @param expr The timestamp expression to convert.
+ */
+export function timezone(tz: string, expr: ExprValue) {
+  return fn('timezone', literal(tz), expr);
 }

--- a/packages/mosaic/sql/src/index.ts
+++ b/packages/mosaic/sql/src/index.ts
@@ -39,7 +39,7 @@ export { cast, float32, float64, int32 } from './functions/cast.js';
 export { collate } from './functions/collate.js';
 export { column } from './functions/column.js';
 export { cte } from './functions/cte.js';
-export { dateBin, dateMonth, dateMonthDay, dateDay, epoch_ms } from './functions/datetime.js';
+export { dateBin, dateMonth, dateMonthDay, dateDay, epoch_ms, timezone } from './functions/datetime.js';
 export { from } from './functions/from.js';
 export { days, hours, interval, microseconds, minutes, milliseconds, months, seconds, years } from './functions/interval.js';
 export { asof_join, cross_join, join, positional_join } from './functions/join.js';

--- a/packages/mosaic/sql/test/datetime.test.ts
+++ b/packages/mosaic/sql/test/datetime.test.ts
@@ -1,0 +1,18 @@
+import { expect, describe, it } from 'vitest';
+import { FunctionNode, timezone, verbatim } from '../src/index.js';
+
+describe('Datetime functions', () => {
+  it('include timezone', () => {
+    const tz1 = timezone('America/Los_Angeles', verbatim(`TIMESTAMP '2001-02-16 20:38:40'`));
+    expect(tz1).toBeInstanceOf(FunctionNode);
+    expect(tz1.name).toBe('timezone');
+    expect(String(tz1)).toBe(`timezone('America/Los_Angeles', TIMESTAMP '2001-02-16 20:38:40')`);
+
+    const d = new Date(2001, 1, 16, 20, 38, 40);
+    const tz2 = timezone('America/Los_Angeles', d);
+    expect(tz2).toBeInstanceOf(FunctionNode);
+    expect(tz2.name).toBe('timezone');
+    expect(String(tz2)).toBe(`timezone('America/Los_Angeles', epoch_ms(${+d}))`);
+  });
+
+});


### PR DESCRIPTION
- Add `timezone` function to mosaic-sql.

Close #915.