### PR TITLE
Update SQL helpers.

### DIFF
--- a/packages/mosaic/sql/src/index.ts
+++ b/packages/mosaic/sql/src/index.ts
@@ -69,11 +69,11 @@ export { loadCSV, loadJSON, loadObjects, loadParquet, loadSpatial } from './load
 
 export { bin1d } from './transforms/bin-1d.js';
 export { bin2d } from './transforms/bin-2d.js';
-export { binDate } from './transforms/bin-date.js';
-export { binHistogram } from './transforms/bin-histogram.js';
+export { binDate, type BinDateOptions } from './transforms/bin-date.js';
+export { binHistogram, type BinHistogramOptions } from './transforms/bin-histogram.js';
 export { binLinear1d } from './transforms/bin-linear-1d.js';
 export { binLinear2d } from './transforms/bin-linear-2d.js';
-export { filterQuery } from './transforms/filter-query.js';
+export { filterQuery, filterPushdown } from './transforms/filter-query.js';
 export { lineDensity } from './transforms/line-density.js';
 export { m4 } from './transforms/m4.js';
 export { scaleTransform, type Scale, type ScaleDomain, type ScaleOptions, type ScaleTransform, type ScaleType } from './transforms/scales.js';

--- a/packages/mosaic/sql/src/transforms/filter-query.ts
+++ b/packages/mosaic/sql/src/transforms/filter-query.ts
@@ -1,33 +1,48 @@
 import type { FilterExpr } from '../types.js';
+import { FromClauseNode } from '../ast/from.js';
 import { isSelectQuery, type Query } from '../ast/query.js';
 import { isTableRef, type TableRefNode } from '../ast/table-ref.js';
+import { asTableRef } from '../util/ast.js';
 import { deepClone } from '../visit/clone.js';
 import { walk } from '../visit/walk.js';
-import { FromClauseNode } from '../ast/from.js';
+
+/**
+ * Perform filter pushdown on a query: clones the given query and adds a
+ * WHERE clause for the specified base table.
+ * @param query The query to clone and extend.
+ * @param table The base table as a table name or table reference node.
+ * @param filter The filter predicate expression to add.
+ */
+export function filterPushdown(
+  query: Query,
+  table: string | TableRefNode,
+  filter: FilterExpr
+) {
+  const clone = deepClone(query);
+  const tableRef = asTableRef(table)!;
+  walk(clone, (node) => {
+    if (
+      isSelectQuery(node) &&
+      node._from.length === 1 &&
+      node._from[0] instanceof FromClauseNode &&
+      isTableRef(node._from[0].expr) &&
+      arrayEquals(node._from[0].expr.table, tableRef.table)
+    ) {
+      node.where(filter);
+    }
+  });
+  return clone;
+}
 
 /**
  * Returns a generator function that clones the given query and adds
- * a WHERE clause for the specified table reference.
+ * a WHERE clause for the specified base table.
  * @param query The query to clone and extend.
- * @param tableRef The table to filter.
+ * @param table The base table as a table name or table reference node.
  * @returns The generator function.
  */
-export function filterQuery(query: Query, tableRef: TableRefNode) {
-  return (filter: FilterExpr) => {
-    const clone = deepClone(query);
-    walk(clone, (node) => {
-      if (
-        isSelectQuery(node) &&
-        node._from.length === 1 &&
-        node._from[0] instanceof FromClauseNode &&
-        isTableRef(node._from[0].expr) &&
-        arrayEquals(node._from[0].expr.table, tableRef.table)
-      ) {
-        node.where(filter);
-      }
-    });
-    return clone;
-  };
+export function filterQuery(query: Query, table: string | TableRefNode) {
+  return (filter: FilterExpr) => filterPushdown(query, table, filter);
 }
 
 function arrayEquals(a: unknown[], b: unknown[]) {

--- a/packages/mosaic/sql/src/transforms/scales.ts
+++ b/packages/mosaic/sql/src/transforms/scales.ts
@@ -25,7 +25,7 @@ export type ScaleType =
   | 'pow'
   | 'time'
   | 'utc'
-  ;
+  | (string & Record<never, never>);
 
 export type ScaleDomain = [number, number] | [Date, Date];
 
@@ -136,9 +136,9 @@ const scales = {
 };
 
 export function scaleTransform<T>(options: ScaleOptions): Scale<T> {
+  // @ts-expect-error scale type lookup
   const scale = scales[options.type];
   if (!scale) throw new Error(`Unrecognized scale type: ${options.type}`);
-  // @ts-expect-error suppress error, revisit later?
   return { ...options, ...scale(options) };
 }
 


### PR DESCRIPTION
- Add `filterPushdown` SQL helper.
- Export bin option types `DateBinOptions` and `HistogramBinOptions`.
- Loosen scale name types for SQL scale transform.
