### PR TITLE
v0.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4777,9 +4777,9 @@
       "license": "ISC"
     },
     "node_modules/@uwdata/flechette": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@uwdata/flechette/-/flechette-2.2.4.tgz",
-      "integrity": "sha512-fNnR5uGz+c7FwUFNEFxMwss+xMM60d2plgyEY311lzyJDHgWfdTRM74wFa9wZxQoB9LRJ6oM+XDzXrg/IVNq7w==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@uwdata/flechette/-/flechette-2.2.5.tgz",
+      "integrity": "sha512-dhPf8474P7NS+r88y/Xy5zUyXweDQgdJMv1zopXVQFNAluwWAB3CTXUXXcuHbL00gSOWdXlCOfZfmcA9PiMsVQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@uwdata/mosaic-core": {
@@ -17400,7 +17400,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@duckdb/duckdb-wasm": "1.30.0",
-        "@uwdata/flechette": "^2.2.4",
+        "@uwdata/flechette": "^2.2.5",
         "@uwdata/mosaic-sql": "^0.20.1"
       },
       "devDependencies": {

--- a/packages/mosaic/core/package.json
+++ b/packages/mosaic/core/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.30.0",
-    "@uwdata/flechette": "^2.2.4",
+    "@uwdata/flechette": "^2.2.5",
     "@uwdata/mosaic-sql": "^0.20.1"
   },
   "devDependencies": {


### PR DESCRIPTION
**Changelog**

- Add `timezone` SQL function.
- Add `filterPushdown` SQL function.
- Export SQL types `DateBinOptions` and `HistogramBinOptions`.
- Loosen scale name types for SQL scale transforms.
- Fix: escape quotes in SQL identifier strings.
- Fix: selection reset should fully reset downstream selections. (thanks @alexBaizeau!)
- Fix: remove cache from fetch options (thanks @kwonoh!)
- Fix: redesign vgplot mark-to-svg indexing.
- Update Go packages, migrate to duckdb-go (thanks @derekperkins!)
- Update CI runs to use node 22.
- Update dependencies.