### PR TITLE
fix: Use floor on degenerate bins.

### DIFF
--- a/packages/mosaic/sql/src/transforms/bin-histogram.ts
+++ b/packages/mosaic/sql/src/transforms/bin-histogram.ts
@@ -3,7 +3,6 @@ import type { ExprValue } from '../types.js';
 import { float64 } from '../functions/cast.js';
 import { floor } from '../functions/numeric.js';
 import { add, div, mul, sub } from '../functions/operators.js';
-import { asNode } from '../util/ast.js';
 import { binSpec } from './util/bin-step.js';
 import { Scale, scaleTransform } from './scales.js';
 
@@ -50,7 +49,7 @@ export function binHistogram(
   const { offset = 0 } = options;
 
   // handle degenerate extent
-  if (max === min) return offset ? add(offset, field) : asNode(field);
+  if (max === min) return offset ? add(offset, floor(field)) : floor(field);
 
   const { apply, sqlApply, sqlInvert } = transform;
   const b = binSpec(apply(min), apply(max), options);

--- a/packages/mosaic/sql/test/bin.test.ts
+++ b/packages/mosaic/sql/test/bin.test.ts
@@ -31,8 +31,8 @@ describe('Binning transforms', () => {
     });
 
     it('handles degenerate span', () => {
-      expect(`${binHistogram('foo', [1, 1])}`).toBe('"foo"');
-      expect(`${binHistogram('foo', [1, 1], { offset: 1 })}`).toBe('(1 + "foo")');
+      expect(`${binHistogram('foo', [1, 1])}`).toBe('floor("foo")');
+      expect(`${binHistogram('foo', [1, 1], { offset: 1 })}`).toBe('(1 + floor("foo"))');
     });
   });
 


### PR DESCRIPTION
- Apply floor function to `binHistogram` domain to ensure integer-aligned float64 values for consistent output types.