### PR TITLE
fix minor typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repository contains a set of related packages, spanning the core Mosaic arc
 
 ### vgplot Libraries (`packages/vgplot`)
 
-**vgplot** is a visualization grammaer API that demonstrates the features and performance of the Mosaic architecture. It includes a layered grammar of interactive graphics alongside table and input widget components. For convenience, the `vgplot` package re-exports much of the `mosaic-core`, `mosaic-sql`, `mosaic-plot`, and `mosaic-inputs` packages. For most vgplot applications, it is sufficient to either import `@uwdata/vgplot` alone or in conjunction with `@uwdata/mosaic-spec`.
+**vgplot** is a visualization grammar API that demonstrates the features and performance of the Mosaic architecture. It includes a layered grammar of interactive graphics alongside table and input widget components. For convenience, the `vgplot` package re-exports much of the `mosaic-core`, `mosaic-sql`, `mosaic-plot`, and `mosaic-inputs` packages. For most vgplot applications, it is sufficient to either import `@uwdata/vgplot` alone or in conjunction with `@uwdata/mosaic-spec`.
 
 * [`vgplot`](https://github.com/uwdata/mosaic/tree/main/packages/vgplot/vgplot): A visualization grammar API for building interactive Mosaic-powered visualizations and dashboards. This package provides convenient, composable methods that combine multiple Mosaic packages (core, inputs, plot, etc.) in an integrated API. This API re-exports much of the `mosaic-core`, `mosaic-sql`, `mosaic-plot`, and `mosaic-inputs` packages, enabling use in a stand-alone fashion.
 * [`mosaic-inputs`](https://github.com/uwdata/mosaic/tree/main/packages/vgplot/inputs): Standalone data-driven components such as input menus, text search boxes, and sortable, load-on-scroll data tables.
@@ -59,7 +59,7 @@ This repository contains a set of related packages, spanning the core Mosaic arc
 ### Examples (`packages/examples`)
 
 * [`vanilla-example`](https://github.com/uwdata/mosaic/tree/main/packages/examples/vanilla-example): A basic example demonstrating how to deploy Mosaic in a website.
-* [`svelte-example`](https://github.com/uwdata/mosaic/tree/main/packages/examples/svelte-example): An example application that demonstrates  howto create Mosaic components within web frameworks such as Svelte and React.
+* [`svelte-example`](https://github.com/uwdata/mosaic/tree/main/packages/examples/svelte-example): An example application that demonstrates how to create Mosaic components within web frameworks such as Svelte and React.
 * [`vega-example`](https://github.com/uwdata/mosaic/tree/main/packages/examples/vega-example): A proof-of-concept example integrating Vega-Lite with Mosaic for data management and cross-view linking.
 
 ## Build and Usage Instructions


### PR DESCRIPTION
Hi,

I found a couple of minor typos in `README.md` while reading through the documentation.

This PR fixes the following:

grammaer -> grammar

howto -> how to

Cheers!