### PR TITLE
Fix unnesting in vgplot

### DIFF
--- a/packages/mosaic/core/src/SelectionClause.ts
+++ b/packages/mosaic/core/src/SelectionClause.ts
@@ -352,6 +352,10 @@ export function clauseList(
   }
 ): SelectionClause {
   const listFn = listMatch === 'all' ? listHasAll : listHasAny;
-  const predicate = value !== undefined ? listFn(field, literal(value)) : null;
+  const predicate = value != null
+    ? Array.isArray(value)
+      ? listFn(field, value as ExprValue[])
+      : listFn(field, literal(value))
+    : null;
   return { source, clients, value, predicate };
 }

--- a/packages/vgplot/plot/src/interactors/Nearest.js
+++ b/packages/vgplot/plot/src/interactors/Nearest.js
@@ -1,5 +1,5 @@
 /** @import { ClauseSource } from '@uwdata/mosaic-core' */
-import { clausePoint, clausePoints, isSelection } from '@uwdata/mosaic-core';
+import { clauseList, clausePoint, clausePoints, isSelection } from '@uwdata/mosaic-core';
 import { select, pointer, min } from 'd3';
 import { getField } from './util/get-field.js';
 
@@ -28,13 +28,17 @@ export class Nearest {
   }
 
   clause(value) {
-    const { clients, fields } = this;
+    const { clients, fields, mark } = this;
     const opt = { source: /** @type {ClauseSource} */(this), clients };
     // if only one field, use a simpler clause that passes the value
     // this allows a single field selection value to act like a param
-    return fields.length > 1
-      ? clausePoints(fields, value ? [value] : value, opt)
-      : clausePoint(fields[0], value?.[0], opt);
+    if (fields.length === 1) {
+      if (mark.isUnnested(fields[0])) {
+        return clauseList(fields[0], value?.[0], opt);
+      }
+      return clausePoint(fields[0], value?.[0], opt);
+    }
+    return clausePoints(fields, value ? [value] : value, opt);
   }
 
   init(svg) {

--- a/packages/vgplot/plot/src/interactors/Toggle.js
+++ b/packages/vgplot/plot/src/interactors/Toggle.js
@@ -1,5 +1,5 @@
 /** @import { ClauseSource } from '@uwdata/mosaic-core' */
-import { clausePoints } from '@uwdata/mosaic-core';
+import { clauseList, clausePoints } from '@uwdata/mosaic-core';
 import { getDatum } from './util/get-datum.js';
 import { neq, neqSome } from './util/neq.js';
 
@@ -42,10 +42,16 @@ export class Toggle {
 
   clause(value) {
     const { fields, mark } = this;
-    return clausePoints(fields, value, {
-      source: /** @type {ClauseSource} */(this),
-      clients: this.peers ? mark.plot.markSet : new Set().add(mark)
-    });
+    const clients = this.peers ? mark.plot.markSet : new Set().add(mark);
+    const source = /** @type {ClauseSource} */(this);
+
+    // if the field is unnested, use clauseList to generate list_has_any() predicate
+    if (fields.length === 1 && mark.isUnnested(fields[0])) {
+      const v = value?.length ? value.map(v => v[0]) : undefined;
+      return clauseList(fields[0], v, { source, clients });
+    }
+
+    return clausePoints(fields, value, { source, clients });
   }
 
   init(svg, selector, accessor) {

--- a/packages/vgplot/plot/src/marks/Mark.js
+++ b/packages/vgplot/plot/src/marks/Mark.js
@@ -1,6 +1,6 @@
 /** @import { SelectQuery } from '@uwdata/mosaic-sql' */
 import { isParam, MosaicClient, queryFieldInfo, toDataColumns } from '@uwdata/mosaic-core';
-import { Query, collectParams, column, isAggregateExpression, isColumnParam, isColumnRef, isNode, isParamLike } from '@uwdata/mosaic-sql';
+import { Query, collectParams, column, isAggregateExpression, isColumnParam, isColumnRef, isNode, isParamLike, unnest } from '@uwdata/mosaic-sql';
 import { isColor } from './util/is-color.js';
 import { isConstantOption } from './util/is-constant-option.js';
 import { isSymbol } from './util/is-symbol.js';
@@ -104,6 +104,13 @@ export class Mark extends MosaicClient {
     return table ? (isParam(table) ? table.value : table) : null;
   }
 
+  isUnnested(field) {
+    const { unnest } = this.source?.options || {};
+    if (!unnest) return false;
+    const unnested = Array.isArray(unnest) ? unnest : [unnest];
+    return unnested.includes(field?.column || field);
+  }
+
   hasOwnData() {
     return this.source == null || isDataArray(this.source);
   }
@@ -160,6 +167,19 @@ export class Mark extends MosaicClient {
    */
   query(filter = []) {
     if (this.hasOwnData()) return null;
+    const unnestOption = this.source?.options?.unnest;
+    if (unnestOption) {
+      // wrap unnested fields in UNNEST() so DuckDB expands array values
+      const unnestFields = Array.isArray(unnestOption) ? unnestOption : [unnestOption];
+      const channels = this.channels.map(c => {
+        const fieldName = c.field?.column ?? c.field;
+        if (c.field && unnestFields.includes(fieldName)) {
+          return { ...c, field: unnest(c.field) };
+        }
+        return c;
+      });
+      return markQuery(channels, this.sourceTable()).where(filter);
+    }
     return markQuery(this.channels, this.sourceTable()).where(filter);
   }
 


### PR DESCRIPTION
Closes issue #977. 

## Summary of changes:

- __`Mark.js`__: Added `isUnnested()` method and modified `query()` to wrap unnested fields in `UNNEST()` in the select clause so DuckDB expands arrays into individual rows. This prevents the chart from rendering the entire array stringified (like `Roads,Lakes`) as bar labels.

- __`Toggle.js` & `Nearest.js`__: When the interactor's field is from an unnested source (`mark.isUnnested(field)`), switch from `clausePoints()` to `clauseList()`, which generates `list_has_any("tags", ['Roads'])` SQL instead of an unquoted `IN` predicate.

- __`SelectionClause.ts`__: Fixed `clauseList()` to pass array values directly to `listHasAny`/`listHasAll` (which wraps them in a properly-quoted `ListNode`), rather than through `literal()` which coerces arrays to unquoted strings via `Array.toString()`.

## Testing

When I ran `npm run test` everything passed. I tried to get this PR built in StackBlitz to drop a link to test it there, but couldn't get it to work. After updating the vgplot import in my standalone example HTML file from the issue ([unnest-bug.html](https://github.com/user-attachments/files/25950551/unnest-bug.html)) and putting it in the `dev` directory, when you go to `http://localhost:5173/dev/unnest-bug.html` the tags chart works as expected:

https://github.com/user-attachments/assets/11a1bfd8-3629-44f1-9c13-c75c765f0a12