### PR TITLE
fix: make npm run docs:examples work again

### DIFF
--- a/packages/vgplot/spec/package.json
+++ b/packages/vgplot/spec/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "exports": {
     "types": "./dist/src/index.d.ts",
-    "default": "./src/index.js"
+    "default": "./dist/src/index.js"
   },
   "files": [
     "dist",

--- a/packages/vgplot/spec/tsconfig.json
+++ b/packages/vgplot/spec/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../tsconfig.base.json",
   "include": ["src/**/*"],
   "compilerOptions": {
-    "emitDeclarationOnly": true,
     "outDir": "dist"
   },
   "references": [


### PR DESCRIPTION
`npm run docs:examples` was broken since it was reading from a ts file. This probably also is needed to make the spec package work on if installed as a stand alone package. 