### PR TITLE
feat: Add client initialized flag, fix selection updates and vgplot interval fields.

### DIFF
--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { SocketConnector } from './connectors/socket.js';
 import { type Connector } from './connectors/Connector.js';
-import { PreAggregator, type PreAggregateOptions } from './preagg/PreAggregator.js';
+import { PreAggregator, type PreAggregateInfo, type PreAggregateOptions } from './preagg/PreAggregator.js';
 import { voidLogger } from './util/void-logger.js';
 import { QueryManager, Priority } from './QueryManager.js';
 import { type Selection } from './Selection.js';
@@ -381,16 +381,22 @@ function updateSelection(
   const { preaggregator, filterGroups } = mc;
   const { clients } = filterGroups!.get(selection)!;
   const { active } = selection;
-  return Promise.allSettled(Array.from(clients, (client: MosaicClient) => {
+  return Promise.allSettled(Array.from(clients, async (client: MosaicClient) => {
+    // if client is not enabled, register a request for later
     if (!client.enabled) return client.requestQuery();
+
+    // if client is initializing, wait for it to complete
+    if (!client.initialized) await client.pending;
+
+    // check if we can handle selection update via preaggregation
     const info = preaggregator.request(client, selection, active);
     const filter = info ? null : selection.predicate(client);
 
     // skip due to cross-filtering
     if (info?.skip || (!info && !filter)) return;
 
-    // @ts-expect-error FIXME
-    const query = info?.query(active.predicate) ?? client.query(filter);
+    // generate and issue update query    
+    const query = (info as PreAggregateInfo)?.query(active.predicate!) ?? client.query(filter);
     return mc.updateClient(client, query);
   }));
 }

--- a/packages/mosaic/core/src/MosaicClient.ts
+++ b/packages/mosaic/core/src/MosaicClient.ts
@@ -32,12 +32,10 @@ export class MosaicClient {
   _pending: Promise<unknown>;
   _enabled: boolean;
   /**
-   * Initialization state. One of:
-   *  - `0` uninitialized
-   *  - `-1` preparing
-   *  - `1` initialized
+   * Initialization state. One of `0` (uninitialized), `-1` (preparing),
+   * or `1` (initialized).
    */
-  _initialized: number;
+  _initialized: -1 | 0 | 1;
   _request: Query | boolean | null;
 
   /**

--- a/packages/mosaic/core/src/MosaicClient.ts
+++ b/packages/mosaic/core/src/MosaicClient.ts
@@ -31,7 +31,13 @@ export class MosaicClient {
   _coordinator: Coordinator | null;
   _pending: Promise<unknown>;
   _enabled: boolean;
-  _initialized: boolean;
+  /**
+   * Initialization state. One of:
+   *  - `0` uninitialized
+   *  - `-1` preparing
+   *  - `1` initialized
+   */
+  _initialized: number;
   _request: Query | boolean | null;
 
   /**
@@ -46,7 +52,7 @@ export class MosaicClient {
     this._coordinator = null;
     this._pending = Promise.resolve();
     this._enabled = true;
-    this._initialized = false;
+    this._initialized = 0;
     this._request = null;
   }
 
@@ -69,6 +75,14 @@ export class MosaicClient {
    */
   get enabled(): boolean {
     return this._enabled;
+  }
+
+  /**
+   * Return this client's initialization state:
+   * `true` if initialization is complete, `false` otherwise.
+   */
+  get initialized(): boolean {
+    return this._initialized > 0;
   }
 
   /**
@@ -203,11 +217,14 @@ export class MosaicClient {
   initialize(): void {
     if (!this._enabled) {
       // clear flag so we initialize when enabled again
-      this._initialized = false;
+      this._initialized = 0;
     } else if (this._coordinator) {
       // if connected, let's initialize
-      this._initialized = true;
-      this._pending = this.prepare().then(() => this.requestQuery());
+      this._initialized = -1;
+      this._pending = this.prepare().then(() => {
+        this._initialized = 1;
+        return this.requestQuery();
+      });
     }
   }
 

--- a/packages/mosaic/core/test/coordinator.test.ts
+++ b/packages/mosaic/core/test/coordinator.test.ts
@@ -1,5 +1,6 @@
+import { Query } from '@uwdata/mosaic-sql';
 import { describe, it, expect } from 'vitest';
-import { Coordinator, coordinator } from '../src/index.js';
+import { clausePoint, type Connector, Coordinator, coordinator, type JSONQueryRequest, makeClient, Selection } from '../src/index.js';
 import { QueryResult, QueryState } from '../src/util/query-result.js';
 
 async function wait() {
@@ -8,10 +9,17 @@ async function wait() {
 
 describe('coordinator', () => {
   it('has accessible singleton', () => {
-    const mc = coordinator();
+    // Mock the connector, avoid instantiating default socket connector
+    const connector = {
+      async query() {
+        return null;
+      },
+    } as unknown as Connector;
+
+    const mc = coordinator(new Coordinator(connector));
     expect(mc).toBeInstanceOf(Coordinator);
 
-    const mc2 = new Coordinator();
+    const mc2 = new Coordinator(connector);
     coordinator(mc2);
 
     expect(coordinator()).toBe(mc2);
@@ -27,7 +35,7 @@ describe('coordinator', () => {
         promises.push(promise);
         return promise;
       },
-    };
+    } as unknown as Connector;
 
     const coord = new Coordinator(connector, { logger: null });
 
@@ -82,5 +90,60 @@ describe('coordinator', () => {
     expect(r1.state).toEqual(QueryState.done);
     expect(r2.state).toEqual(QueryState.done);
     expect(r3.state).toEqual(QueryState.done);
+  });
+
+  it('awaits initializing clients before selection updates', async () => {
+    const events: string[] = [];
+
+    // Mock the connector
+    const connector = {
+      async query(req: JSONQueryRequest) {
+        const index = req.sql.includes("WHERE") ? 1 : 0;
+        events.push(`CONNECT ${index}`);
+        return { index };
+      },
+    } as unknown as Connector;
+
+    // disable cache to ensure routing through connector
+    const coord = new Coordinator(connector, {
+      logger: null,
+      cache: false,
+      preagg: { enabled: false }
+    });
+    const filterBy = Selection.crossfilter();
+    let prepared = false;
+
+    // create and connect client
+    const client = makeClient({
+      coordinator: coord,
+      selection: filterBy,
+      async prepare() {
+        await wait(); // force wait
+        prepared = true;
+        events.push("PREPARE");
+      },
+      query(filter = []) {
+        events.push(`QUERY ${prepared}`);
+        return Query.select("*").from("foo").where(filter);
+      }
+    });
+
+    // fire selection update
+    filterBy.update(clausePoint("foo", 1, { source: {} }));
+
+    // await initial query, then selection update
+    await client.pending;
+    await client.pending;
+
+    // prepare should be first
+    // query calls should come post-initialization
+    // all queries should include filter clause
+    expect(events).toStrictEqual([
+      "PREPARE",
+      "QUERY true",
+      "CONNECT 1",
+      "QUERY true",
+      "CONNECT 1",
+    ]);
   });
 });

--- a/packages/vgplot/plot/src/interactors/util/get-field.js
+++ b/packages/vgplot/plot/src/interactors/util/get-field.js
@@ -8,6 +8,9 @@ function extractField(field) {
     } else if (field.type === 'AGGREGATE') {
       // @ts-ignore
       return field.args[0] ?? field;
+    } else if (field.type === 'CUSTOM' && "column" in field) {
+      // handle custom transforms (like bin) that expose a column
+      return field.column;
     }
   }
   return field;


### PR DESCRIPTION
- Add `initialized` flag to Mosaic clients, is true when initialization is complete.
- Fix selection event dispatch to await clients that are still initializing, preventing query access race condition.
- Add tests for client prepare and query event ordering.
- Fix vgplot field extraction for bin transform, by supporting custom AST nodes with a `column` property.
