### PR TITLE
feat: Add isInDistinct operator, fix point clauses.

### DIFF
--- a/packages/mosaic/core/src/SelectionClause.ts
+++ b/packages/mosaic/core/src/SelectionClause.ts
@@ -1,5 +1,6 @@
 import { isMosaicClient, MosaicClient } from './MosaicClient.js';
-import { type ExprNode, type ExprValue, type ScaleOptions, type ScaleDomain, and, contains, isBetween, isIn, isNotDistinct, literal, or, prefix, regexp_matches, suffix, listHasAny, listHasAll, lower } from '@uwdata/mosaic-sql';
+import type { ExprNode, ExprValue, ScaleOptions, ScaleDomain } from '@uwdata/mosaic-sql';
+import { and, contains, isBetween, isInDistinct, isNotDistinct, listHasAll, listHasAny, literal, lower, or, prefix, regexp_matches, suffix } from '@uwdata/mosaic-sql';
 
 /**
  * Selection clause metadata to guide possible query optimizations.
@@ -119,7 +120,7 @@ export function clausePoint(
   }: PointOptions
 ): SelectionClause {
   const predicate: ExprNode | null = value !== undefined
-    ? isIn(field, [literal(value)])
+    ? isInDistinct(field, [literal(value)])
     : null;
   return {
     meta: { type: 'point' },
@@ -153,7 +154,7 @@ export function clausePoints(
   let predicate: ExprNode | null = null;
   if (value?.length) {
     const clauses = value.length && fields.length === 1
-      ? [isIn(fields[0], value.map(v => literal(v[0])))]
+      ? [isInDistinct(fields[0], value.map(v => literal(v[0])))]
       : value.map(v => and(v.map((_, i) => isNotDistinct(fields[i], literal(_)))));
     predicate = value.length === 0 ? literal(false)
       : clauses.length > 1 ? or(clauses)

--- a/packages/mosaic/sql/src/functions/operators.ts
+++ b/packages/mosaic/sql/src/functions/operators.ts
@@ -1,4 +1,7 @@
+
+import type { LiteralNode } from '../ast/literal.js';
 import type { ExprValue, ExprVarArgs } from '../types.js';
+import { LITERAL } from '../constants.js';
 import { BetweenOpNode, Extent, NotBetweenOpNode } from '../ast/between-op.js';
 import { BinaryOpNode } from '../ast/binary-op.js';
 import { InOpNode } from '../ast/in-op.js';
@@ -6,6 +9,7 @@ import { AndNode, OrNode } from '../ast/logical-op.js';
 import { UnaryOpNode, UnaryPostfixOpNode } from '../ast/unary-op.js';
 import { asNode } from '../util/ast.js';
 import { nodeList } from '../util/function.js';
+import { literal } from './literal.js';
 
 function unaryOp(op: string, expr: unknown) {
   return new UnaryOpNode(op, asNode(expr));
@@ -269,4 +273,21 @@ export function isNotBetween(expr: ExprValue, extent?: ExprValue[] | null) {
  */
 export function isIn(expr: ExprValue, values: ExprValue[]) {
   return new InOpNode(asNode(expr), values.map(asNode));
+}
+
+/**
+ * Null-safe set inclusion. Unlike the IN operator, the returned expression
+ * can test for included NULL values. When a NULL literal is included in the
+ * set values, it is checked explcity via `OR expr IS NULL`.
+ * @param expr The expression to test.
+ * @param values The included values.
+ */
+export function isInDistinct(expr: ExprValue, values: ExprValue[]) {
+  const test = asNode(expr);
+  const nodes = values.map(asNode)
+    .filter(node => !(node.type === LITERAL && (node as LiteralNode).value == null));
+  const inOp = isIn(test, nodes);
+  return nodes.length === values.length ? inOp
+    : nodes.length === 0 ? (values.length === 0 ? literal(false) : isNull(test))
+    : or(inOp, isNull(test));
 }

--- a/packages/mosaic/sql/src/index.ts
+++ b/packages/mosaic/sql/src/index.ts
@@ -16,7 +16,7 @@ export { asof_join, cross_join, join, positional_join } from './functions/join.j
 export { list, listContains, listHasAll, listHasAny } from './functions/list.js';
 export { literal, verbatim } from './functions/literal.js';
 export { abs, ceil, exp, floor, greatest, isFinite, isInfinite, isNaN, least, ln, log, round, sign, sqrt, trunc } from './functions/numeric.js';
-export { and, or, not, isNull, isNotNull, bitNot, bitAnd, bitOr, bitLeft, bitRight, add, sub, mul, div, idiv, mod, pow, eq, neq, lt, gt, lte, gte, isDistinct, isNotDistinct, isBetween, isNotBetween, isIn } from './functions/operators.js';
+export { and, or, not, isNull, isNotNull, bitNot, bitAnd, bitOr, bitLeft, bitRight, add, sub, mul, div, idiv, mod, pow, eq, neq, lt, gt, lte, gte, isDistinct, isNotDistinct, isBetween, isNotBetween, isIn, isInDistinct } from './functions/operators.js';
 export { asc, desc } from './functions/order-by.js';
 export { geojson, x, y, centroid, centroidX, centroidY } from './functions/spatial.js';
 export { sql } from './functions/sql-template-tag.js';

--- a/packages/mosaic/sql/test/operators.test.ts
+++ b/packages/mosaic/sql/test/operators.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { add, and, column, div, eq, gt, gte, idiv, isBetween, isDistinct, isNotBetween, isNotDistinct, isNotNull, isNull, lt, lte, mod, mul, neq, not, or, pow, sub } from '../src/index.js';
+import { add, and, column, div, eq, gt, gte, idiv, isBetween, isDistinct, isIn, isInDistinct, isNotBetween, isNotDistinct, isNotNull, isNull, literal, lt, lte, mod, mul, neq, not, or, pow, sub } from '../src/index.js';
 
 describe('Logical operators', () => {
   it('include AND expressions', () => {
@@ -103,6 +103,23 @@ describe('Binary operators', () => {
   it('include IS NOT DISTINCT FROM comparisons', () => {
     expect(String(isNotDistinct(column('foo'), null))).toBe('("foo" IS NOT DISTINCT FROM NULL)');
     expect(String(isNotDistinct('foo', null))).toBe('("foo" IS NOT DISTINCT FROM NULL)');
+  });
+});
+
+describe('Set inclusion operators', () => {
+  it('include IN operator', () => {
+    const set = [literal('a'), literal('b'), literal('c')];
+    expect(String(isIn(column('foo'), set))).toBe(`("foo" IN ('a', 'b', 'c'))`);
+    expect(String(isIn('foo', set))).toBe(`("foo" IN ('a', 'b', 'c'))`);
+  });
+  it('include null-safe IN test', () => {
+    const set = [literal('a'), literal('b'), literal('c')];
+    expect(String(isInDistinct(column('foo'), set))).toBe(`("foo" IN ('a', 'b', 'c'))`);
+    expect(String(isInDistinct('foo', set))).toBe(`("foo" IN ('a', 'b', 'c'))`);
+    expect(String(isInDistinct(column('foo'), [...set, literal(null)]))).toBe(`(("foo" IN ('a', 'b', 'c')) OR ("foo" IS NULL))`);
+    expect(String(isInDistinct('foo', [...set, null]))).toBe(`(("foo" IN ('a', 'b', 'c')) OR ("foo" IS NULL))`);
+    expect(String(isInDistinct(column('foo'), [literal(null)]))).toBe(`("foo" IS NULL)`);
+    expect(String(isInDistinct('foo', [null]))).toBe(`("foo" IS NULL)`);
   });
 });
 


### PR DESCRIPTION
- Add `isInDistinct` operator to mosaic-sql for null-safe set inclusion tests.
- Add corresponding test cases to mosaic-sql.
- Fix point selection clause helpers in mosaic-core to use null-safe set inclusion checks.
