### PR TITLE
feat: Do not parse table/column identifiers by default.

### DIFF
--- a/packages/mosaic/sql/src/index.ts
+++ b/packages/mosaic/sql/src/index.ts
@@ -48,7 +48,7 @@ export { lineDensity } from './transforms/line-density.js';
 export { m4 } from './transforms/m4.js';
 export { scaleTransform, type Scale, type ScaleDomain, type ScaleOptions, type ScaleTransform, type ScaleType } from './transforms/scales.js';
 
-export { asLiteral, asNode, asTableRef, asVerbatim, over } from './util/ast.js';
+export { asLiteral, asNode, asTableRef, asVerbatim, parseColumnRef, parseTableRef, over } from './util/ast.js';
 export { isParamLike } from './util/type-check.js';
 
 export { binSpec, binStep, type BinOptions } from './transforms/util/bin-step.js';

--- a/packages/mosaic/sql/src/util/ast.ts
+++ b/packages/mosaic/sql/src/util/ast.ts
@@ -17,9 +17,7 @@ import { isArray, isParamLike, isString } from './type-check.js';
  * @param value The value to interpret as a SQL AST node.
  */
 export function asNode(value: unknown): ExprNode {
-  return isString(value)
-    ? parseColumnRef(value)
-    : asLiteral(value);
+  return isString(value) ? column(value) : asLiteral(value);
 }
 
 /**
@@ -48,10 +46,9 @@ export function asLiteral(value: unknown): ExprNode {
 }
 
 /**
- * Interpret a value as a table reference AST node. String values are parsed
- * assuming dot ('.') delimiters (as in `schema.table`). Array values are
- * interpreted as pre-parsed name paths (as in `['schema', 'table']`). Any
- * other values are left as-is.
+ * Interpret a value as a table reference AST node. String values are
+ * used as-is as a single table name. Array values are interpreted as name
+ * paths (as in `['schema', 'table']`). Any other values are left as-is.
  * @param value The value to interpret as a table reference AST node.
  */
 export function asTableRef(value?: string | string[] | TableRefNode): TableRefNode | undefined {
@@ -60,9 +57,8 @@ export function asTableRef(value?: string | string[] | TableRefNode): TableRefNo
 
 /**
  * Try to interpret a value as a table reference AST node. String values are
- * parsed assuming dot ('.') delimiters (as in `schema.table`). Array values
- * are interpreted as pre-parsed name paths (as in `['schema', 'table']`). Any
- * other values are left as-is.
+ * used as-is as a single table name. Array values are interpreted as name
+ * paths (as in `['schema', 'table']`). Any other values are left as-is.
  * @param value The value to interpret as a table reference.
  */
 export function maybeTableRef(value: string | string[] | SQLNode): SQLNode {
@@ -70,7 +66,7 @@ export function maybeTableRef(value: string | string[] | SQLNode): SQLNode {
 }
 
 function getTableRef<T>(value?: string | string[] | T): TableRefNode | T | undefined {
-  return isString(value) ? parseTableRef(value)
+  return isString(value) ? tableRef(value)
     : isArray(value) ? tableRef(value)!
     : value;
 }

--- a/packages/mosaic/sql/test/column-ref.test.ts
+++ b/packages/mosaic/sql/test/column-ref.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { column, asNode, ColumnRefNode, TableRefNode, deepClone, ColumnNameRefNode } from '../src/index.js';
+import { column, asNode, ColumnRefNode, TableRefNode, deepClone, ColumnNameRefNode, parseColumnRef } from '../src/index.js';
 
 describe('Column references', () => {
   it('serialize to SQL', () => {
@@ -32,6 +32,16 @@ describe('Column references', () => {
     const node2 = asNode('tab.foo');
     expect(node2).toBeInstanceOf(ColumnRefNode);
     expect(String(node2)).toBe(`"tab.foo"`);
+  });
+
+  it('are created from strings by parseColumnRef', () => {
+    const node = parseColumnRef('foo');
+    expect(node).toBeInstanceOf(ColumnRefNode);
+    expect(String(node)).toBe(`"foo"`);
+
+    const node2 = parseColumnRef('tab.foo');
+    expect(node2).toBeInstanceOf(ColumnRefNode);
+    expect(String(node2)).toBe(`"tab"."foo"`);
   });
 
   it('clone successfully', () => {

--- a/packages/mosaic/sql/test/column-ref.test.ts
+++ b/packages/mosaic/sql/test/column-ref.test.ts
@@ -28,6 +28,10 @@ describe('Column references', () => {
     const node = asNode('foo');
     expect(node).toBeInstanceOf(ColumnRefNode);
     expect(String(node)).toBe(`"foo"`);
+
+    const node2 = asNode('tab.foo');
+    expect(node2).toBeInstanceOf(ColumnRefNode);
+    expect(String(node2)).toBe(`"tab.foo"`);
   });
 
   it('clone successfully', () => {

--- a/packages/mosaic/sql/test/query.test.ts
+++ b/packages/mosaic/sql/test/query.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { asNode, asTableRef, column, desc, gt, lt, max, min, sql, Query, sum, lead, over, cte, add, FromClauseNode, SampleClauseNode, frameRows, div, mul } from '../src/index.js';
+import { asTableRef, column, desc, gt, lt, max, min, sql, Query, sum, lead, over, cte, add, FromClauseNode, SampleClauseNode, frameRows, div, mul } from '../src/index.js';
 
 describe('Query', () => {
   it('selects column name strings', () => {
@@ -442,8 +442,8 @@ describe('Query', () => {
     expect(
       Query
         .select({
-          foo: asNode('a.foo'),
-          bar: asNode('b.bar')
+          foo: column('foo', 'a'),
+          bar: column('bar', 'b')
         })
         .from({ a: 'data1', b: 'data2' })
         .toString()

--- a/packages/mosaic/sql/test/table-ref.test.ts
+++ b/packages/mosaic/sql/test/table-ref.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { asTableRef, deepClone, TableRefNode } from '../src/index.js';
+import { asTableRef, deepClone, parseTableRef, TableRefNode } from '../src/index.js';
 
 describe('Table references', () => {
   it('serialize to SQL', () => {
@@ -11,8 +11,14 @@ describe('Table references', () => {
 
   it('are created by asTableRef', () => {
     expect(asTableRef('foo')?.table).toStrictEqual(['foo']);
-    expect(asTableRef('foo.bar')?.table).toStrictEqual(['foo', 'bar']);
-    expect(asTableRef('foo.bar.baz')?.table).toStrictEqual(['foo', 'bar', 'baz']);
+    expect(asTableRef('foo.bar')?.table).toStrictEqual(['foo.bar']);
+    expect(asTableRef('foo.bar.baz')?.table).toStrictEqual(['foo.bar.baz']);
+  });
+
+  it('are created by parseTableRef', () => {
+    expect(parseTableRef('foo')?.table).toStrictEqual(['foo']);
+    expect(parseTableRef('foo.bar')?.table).toStrictEqual(['foo', 'bar']);
+    expect(parseTableRef('foo.bar.baz')?.table).toStrictEqual(['foo', 'bar', 'baz']);
   });
 
   it('clone successfully', () => {


### PR DESCRIPTION
- Update `asNode` to treat column name string as-is, do not delimit on `.` characters.
- Update `asTableRef` to treat table name string as-is, do not delimit on `.` characters.
- Expose `parseColumnRef` and `parseTableRef` methods to provide methods that _do_ delimit on `.` characters.
- Update tests.

Note: this PR induces a **breaking change** in how column and table identifier strings are handled. Previously they would be parsed and delimited based on `.` characters. However, this is auto-magical and breaks when encountering names that include `.` characters. This PR removes this magic from the standard helper methods, but also exposes new methods to perform parsing if desired.

Fix #1026.