### PR TITLE
fix: Avoid recursing into scalar subqueries where unwanted.

### DIFF
--- a/packages/mosaic/sql/src/transforms/filter-query.ts
+++ b/packages/mosaic/sql/src/transforms/filter-query.ts
@@ -1,3 +1,4 @@
+import { SCALAR_SUBQUERY } from '../constants.js';
 import type { FilterExpr } from '../types.js';
 import { FromClauseNode } from '../ast/from.js';
 import { isSelectQuery, type Query } from '../ast/query.js';
@@ -8,7 +9,8 @@ import { walk } from '../visit/walk.js';
 
 /**
  * Perform filter pushdown on a query: clones the given query and adds a
- * WHERE clause for the specified base table.
+ * WHERE clause for the specified base table. Ignores scalar subqueries,
+ * but will recurse into CTEs, joins, and other subqueries.
  * @param query The query to clone and extend.
  * @param table The base table as a table name or table reference node.
  * @param filter The filter predicate expression to add.
@@ -21,7 +23,9 @@ export function filterPushdown(
   const clone = deepClone(query);
   const tableRef = asTableRef(table)!;
   walk(clone, (node) => {
-    if (
+    if (node.type === SCALAR_SUBQUERY) {
+      return 1; // don't recurse
+    } else if (
       isSelectQuery(node) &&
       node._from.length === 1 &&
       node._from[0] instanceof FromClauseNode &&

--- a/packages/mosaic/sql/src/visit/visitors.ts
+++ b/packages/mosaic/sql/src/visit/visitors.ts
@@ -2,8 +2,8 @@ import { type AggregateNode, aggregateNames } from '../ast/aggregate.js';
 import type { ColumnRefNode } from '../ast/column-ref.js';
 import type { SQLNode } from '../ast/node.js';
 import type { ParamNode } from '../ast/param.js';
+import { AGGREGATE, COLUMN_PARAM, COLUMN_REF, FRAGMENT, PARAM, SCALAR_SUBQUERY, VERBATIM, WINDOW } from '../constants.js';
 import type { ParamLike } from '../types.js';
-import { AGGREGATE, COLUMN_PARAM, COLUMN_REF, FRAGMENT, PARAM, VERBATIM, WINDOW } from '../constants.js';
 import { walk } from './walk.js';
 
 // regexp to match valid aggregate function names
@@ -53,6 +53,8 @@ export function isAggregateExpression(root: SQLNode) {
         }
         return 1; // don't recurse
       }
+      case SCALAR_SUBQUERY:
+        return 1; // don't recurse
     }
   });
   return agg;
@@ -67,6 +69,8 @@ export function collectAggregates(root: SQLNode) {
   walk(root, (node, parent) => {
     if (node.type === AGGREGATE && parent?.type !== WINDOW) {
       aggs.add(node as AggregateNode);
+    } else if (node.type === SCALAR_SUBQUERY) {
+      return 1; // don't recurse
     }
   });
   return Array.from(aggs);

--- a/packages/mosaic/sql/test/filter-pushdown.test.ts
+++ b/packages/mosaic/sql/test/filter-pushdown.test.ts
@@ -1,0 +1,31 @@
+import { expect, describe, it } from 'vitest';
+import { count, div, filterPushdown, gt, Query, ScalarSubqueryNode } from '../src/index.js';
+
+describe('filterPushdown', () => {
+  it('updates queries', () => {
+    const q = Query.select('v').from('table');
+    const f = filterPushdown(q, 'table', gt('x', 2));
+    expect(String(f)).toBe('SELECT "v" FROM "table" WHERE ("x" > 2)');
+  });
+
+  it('updates subqueries', () => {
+    const q = Query.select('v').from(Query.select({ v: 'x' }).from('table'));
+    const f = filterPushdown(q, 'table', gt('x', 2));
+    expect(String(f)).toBe('SELECT "v" FROM (SELECT "x" AS "v" FROM "table" WHERE ("x" > 2))');
+  });
+
+  it('updates CTEs', () => {
+    const q = Query
+      .with({ c: Query.select({ v: 'x' }).from('table') })
+      .select('v').from('c');
+    const f = filterPushdown(q, 'table', gt('x', 2));
+    expect(String(f)).toBe('WITH "c" AS (SELECT "x" AS "v" FROM "table" WHERE ("x" > 2)) SELECT "v" FROM "c"');
+  });
+
+  it('skips scalar subqueries', () => {
+    const sub = new ScalarSubqueryNode(Query.select({ count: count() }).from('table'))
+    const q = Query.select({ norm: div('v', sub) }).from('table');
+    const f = filterPushdown(q, 'table', gt('x', 2));
+    expect(String(f)).toBe('SELECT ("v" / (SELECT count(*) AS "count" FROM "table")) AS "norm" FROM "table" WHERE ("x" > 2)');
+  });
+});

--- a/packages/mosaic/sql/test/visitors.test.ts
+++ b/packages/mosaic/sql/test/visitors.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { abs, add, asVerbatim, collectColumns, collectParams, column, count, isAggregateExpression, sql, sum } from '../src/index.js';
+import { abs, add, asVerbatim, collectAggregates, collectColumns, collectParams, column, count, div, isAggregateExpression, Query, ScalarSubqueryNode, sql, sum } from '../src/index.js';
 import { stubParam } from './util/stub-param.js';
 
 describe('Visitor functions', () => {
@@ -25,12 +25,25 @@ describe('Visitor functions', () => {
     expect(collectParams(expr2)).toStrictEqual([]);
   });
 
+  it('include aggregate collection', () => {
+    expect(collectAggregates(Query.select({
+      count: count(),
+      sum: sum('foo'),
+      mix: add(sum('foo'), sum('bar'))
+    }).from('table'))).toHaveLength(4);
+    expect(collectAggregates(Query.select({
+      norm: div(1, new ScalarSubqueryNode(Query.select({ count: count() }).from('table')))
+    }).from('table'))).toHaveLength(0);
+  });
+
   it('include aggregate function detection', () => {
     expect(isAggregateExpression(column('a'))).toBe(0);
     expect(isAggregateExpression(add(1, 2))).toBe(0);
     expect(isAggregateExpression(abs(-1))).toBe(0);
 
     expect(isAggregateExpression(count())).toBe(1);
+    expect(isAggregateExpression(sum(sum('foo')).orderby('a'))).toBe(1);
+
     expect(isAggregateExpression(asVerbatim('count(*)'))).toBe(2);
     expect(isAggregateExpression(sql`count(*)`)).toBe(2);
     expect(isAggregateExpression(sql`count(${column('a')})`)).toBe(2);
@@ -38,8 +51,6 @@ describe('Visitor functions', () => {
     expect(isAggregateExpression(count().orderby('a'))).toBe(0);
     expect(isAggregateExpression(asVerbatim('count(*) OVER (ORDER BY a)'))).toBe(0);
     expect(isAggregateExpression(sql`count(*) OVER (ORDER BY a)`)).toBe(0);
-    expect(isAggregateExpression(sql`count(${column('a')}) OVER (ORDER BY a)`)).toBe(0);
-
-    expect(isAggregateExpression(sum(sum('foo')).orderby('a'))).toBe(1);
+    expect(isAggregateExpression(sql`count(${column('a')}) OVER (ORDER BY a)`)).toBe(0);    
   });
 });


### PR DESCRIPTION
- Avoid recursing into scalar subqueries when collecting aggregates or performing filter pushdown.
- Add corresponding test cases.

Fix #1034