### PR TITLE
fix: Support filter pushdown in multi-table from clauses.

### DIFF
--- a/packages/mosaic/core/test/preaggregator.test.ts
+++ b/packages/mosaic/core/test/preaggregator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { CreateQuery, ExprNode, FilterExpr } from "@uwdata/mosaic-sql";
-import { Query, add, argmax, argmin, avg, corr, count, covarPop, covariance, desc, geomean, gt, isNotDistinct, literal, loadObjects, max, min, mul, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, stddev, stddevPop, sum, varPop, variance } from '@uwdata/mosaic-sql';
+import { Query, add, argmax, argmin, avg, corr, count, covarPop, covariance, desc, filterPushdown, geomean, gt, isNotDistinct, literal, loadObjects, max, min, mul, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, stddev, stddevPop, sum, varPop, variance } from '@uwdata/mosaic-sql';
 import { Coordinator, Selection, SelectionClause } from '../src/index.js';
 import { NodeConnector } from './util/node-connector.js';
 import { TestClient } from './util/test-client.js';
@@ -215,5 +215,15 @@ describe('PreAggregator', () => {
         .qualify(gt('measure', 7));
     };
     expect(await run(query)).toStrictEqual([13, true]);
+  });
+
+  it('supports queries with filter pushdown applied', async () => {
+    const query = (predicate: FilterExpr = []) => {
+      const q = Query.from('testData')
+        .select({ measure: avg("x"), dim: "dim" })
+        .groupby("dim");
+      return predicate ? filterPushdown(q, 'testData', predicate) : q;
+    };
+    expect(await run(query)).toStrictEqual([3.5, true]);
   });
 });

--- a/packages/mosaic/core/test/preaggregator.test.ts
+++ b/packages/mosaic/core/test/preaggregator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { CreateQuery, ExprNode, FilterExpr } from "@uwdata/mosaic-sql";
-import { Query, add, argmax, argmin, avg, corr, count, covarPop, covariance, desc, filterPushdown, geomean, gt, isNotDistinct, literal, loadObjects, max, min, mul, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, stddev, stddevPop, sum, varPop, variance } from '@uwdata/mosaic-sql';
+import { Query, add, argmax, argmin, avg, corr, count, covarPop, covariance, desc, filterPushdown, geomean, gt, isNotDistinct, literal, loadObjects, max, min, mul, neq, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, stddev, stddevPop, sum, varPop, variance } from '@uwdata/mosaic-sql';
 import { Coordinator, Selection, SelectionClause } from '../src/index.js';
 import { NodeConnector } from './util/node-connector.js';
 import { TestClient } from './util/test-client.js';
@@ -198,7 +198,7 @@ describe('PreAggregator', () => {
   it('supports queries with column index references', async () => {
     const query = (predicate: FilterExpr = []) => {
       return Query.from('testData')
-        .select({ measure: avg("x"), dim: "dim" })
+        .select({ measure: avg('x'), dim: 'dim' })
         .groupby(literal(2))
         .where(predicate)
         .orderby(desc(literal(1)))
@@ -219,10 +219,13 @@ describe('PreAggregator', () => {
 
   it('supports queries with filter pushdown applied', async () => {
     const query = (predicate: FilterExpr = []) => {
+      // include a non-selective clause to ensure that we always have
+      // a "pushed-down" query input to preaggregation.
+      const filter = [neq('dim', literal('c')), predicate].flat();
       const q = Query.from('testData')
-        .select({ measure: avg("x"), dim: "dim" })
-        .groupby("dim");
-      return predicate ? filterPushdown(q, 'testData', predicate) : q;
+        .select({ measure: avg('x'), dim: 'dim' })
+        .groupby('dim');
+      return filterPushdown(q, 'testData', filter);
     };
     expect(await run(query)).toStrictEqual([3.5, true]);
   });

--- a/packages/mosaic/sql/src/transforms/filter-query.ts
+++ b/packages/mosaic/sql/src/transforms/filter-query.ts
@@ -21,20 +21,23 @@ export function filterPushdown(
   filter: FilterExpr
 ) {
   const clone = deepClone(query);
-  const tableRef = asTableRef(table)!;
-  walk(clone, (node) => {
-    if (node.type === SCALAR_SUBQUERY) {
-      return 1; // don't recurse
-    } else if (
-      isSelectQuery(node) &&
-      node._from.length === 1 &&
-      node._from[0] instanceof FromClauseNode &&
-      isTableRef(node._from[0].expr) &&
-      arrayEquals(node._from[0].expr.table, tableRef.table)
-    ) {
-      node.where(filter);
-    }
-  });
+  const tableRef = asTableRef(table);
+  if (tableRef) {
+    walk(clone, (node) => {
+      if (node.type === SCALAR_SUBQUERY) {
+        return 1; // don't recurse
+      } else if (isSelectQuery(node)) {
+        for (const source of node._from) {
+          if (source instanceof FromClauseNode &&
+            isTableRef(source.expr) &&
+            arrayEquals(source.expr.table, tableRef.table)
+          ) {
+            node.where(filter);
+          }
+        }
+      }
+    });
+  }
   return clone;
 }
 

--- a/packages/mosaic/sql/src/transforms/filter-query.ts
+++ b/packages/mosaic/sql/src/transforms/filter-query.ts
@@ -38,7 +38,7 @@ export function filterPushdown(
     // filtered table not present in query, nothing to do
     return clone;
   }
-  let filteredName = `_${tableRef?.name}`;
+  let filteredName = `_${tableRef.name}`;
   while (names.has(filteredName)) {
     filteredName = `_${filteredName}`;
   }

--- a/packages/mosaic/sql/src/transforms/filter-query.ts
+++ b/packages/mosaic/sql/src/transforms/filter-query.ts
@@ -1,7 +1,6 @@
 import { SCALAR_SUBQUERY } from '../constants.js';
 import type { FilterExpr } from '../types.js';
-import { FromClauseNode } from '../ast/from.js';
-import { isSelectQuery, type Query } from '../ast/query.js';
+import { Query } from '../ast/query.js';
 import { isTableRef, type TableRefNode } from '../ast/table-ref.js';
 import { asTableRef } from '../util/ast.js';
 import { deepClone } from '../visit/clone.js';
@@ -10,7 +9,7 @@ import { walk } from '../visit/walk.js';
 /**
  * Perform filter pushdown on a query: clones the given query and adds a
  * WHERE clause for the specified base table. Ignores scalar subqueries,
- * but will recurse into CTEs, joins, and other subqueries.
+ * but will recurse into CTEs, joins, and FROM subqueries.
  * @param query The query to clone and extend.
  * @param table The base table as a table name or table reference node.
  * @param filter The filter predicate expression to add.
@@ -22,23 +21,41 @@ export function filterPushdown(
 ) {
   const clone = deepClone(query);
   const tableRef = asTableRef(table);
-  if (tableRef) {
-    walk(clone, (node) => {
-      if (node.type === SCALAR_SUBQUERY) {
-        return 1; // don't recurse
-      } else if (isSelectQuery(node)) {
-        for (const source of node._from) {
-          if (source instanceof FromClauseNode &&
-            isTableRef(source.expr) &&
-            arrayEquals(source.expr.table, tableRef.table)
-          ) {
-            node.where(filter);
-          }
-        }
-      }
-    });
+
+  // early exit if no filter or no table to apply it to
+  if (!tableRef || (Array.isArray(filter) && filter.length === 0)) {
+    return clone;
   }
-  return clone;
+
+  // determine unique name for filtered CTE
+  const names = new Set<string>();
+  walk(clone, (node) => {
+    if (isTableRef(node)) {
+      names.add(node.name);
+    }
+  });
+  if (!names.has(tableRef.name)) {
+    // filtered table not present in query, nothing to do
+    return clone;
+  }
+  let filteredName = `_${tableRef?.name}`;
+  while (names.has(filteredName)) {
+    filteredName = `_${filteredName}`;
+  }
+
+  // rewrite table references to use filtered data
+  walk(clone, (node) => {
+    if (node.type === SCALAR_SUBQUERY) {
+      return 1; // don't recurse
+    } else if (isTableRef(node) && arrayEquals(node.table, tableRef.table)) {
+      // @ts-expect-error set read-only property
+      node.table = [filteredName];
+    }
+  });
+
+  return clone.with({
+    [filteredName]: Query.select("*").from(tableRef).where(filter)
+  });
 }
 
 /**

--- a/packages/mosaic/sql/src/transforms/filter-query.ts
+++ b/packages/mosaic/sql/src/transforms/filter-query.ts
@@ -5,14 +5,16 @@ import { isTableRef, type TableRefNode } from '../ast/table-ref.js';
 import { asTableRef } from '../util/ast.js';
 import { deepClone } from '../visit/clone.js';
 import { walk } from '../visit/walk.js';
+import { WithClauseNode } from '../ast/with.js';
 
 /**
- * Perform filter pushdown on a query: clones the given query and adds a
- * WHERE clause for the specified base table. Ignores scalar subqueries,
- * but will recurse into CTEs, joins, and FROM subqueries.
+ * Perform filter pushdown on a query: clone a query and push a filter into
+ * the given base table via a CTE, so every reference to the table sees the
+ * filtered rows. Skips scalar subqueries.
  * @param query The query to clone and extend.
  * @param table The base table as a table name or table reference node.
- * @param filter The filter predicate expression to add.
+ * @param filter The filter predicate expression to add. May only reference
+ *  columns of the table, not aliases assigned elsewhere in the query.
  */
 export function filterPushdown(
   query: Query,
@@ -53,9 +55,13 @@ export function filterPushdown(
     }
   });
 
-  return clone.with({
-    [filteredName]: Query.select("*").from(tableRef).where(filter)
-  });
+  // add filtered table as CTE node
+  const cte = new WithClauseNode(
+    filteredName,
+    Query.select("*").from(tableRef).where(filter)
+  );
+  clone._with = [cte, ...clone._with];
+  return clone;
 }
 
 /**

--- a/packages/mosaic/sql/test/filter-pushdown.test.ts
+++ b/packages/mosaic/sql/test/filter-pushdown.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { count, div, filterPushdown, gt, Query, ScalarSubqueryNode } from '../src/index.js';
+import { column, count, div, eq, filterPushdown, FromClauseNode, gt, Query, ScalarSubqueryNode, TableRefNode } from '../src/index.js';
 
 describe('filterPushdown', () => {
   it('updates queries', () => {
@@ -20,6 +20,18 @@ describe('filterPushdown', () => {
       .select('v').from('c');
     const f = filterPushdown(q, 'table', gt('x', 2));
     expect(String(f)).toBe('WITH "c" AS (SELECT "x" AS "v" FROM "table" WHERE ("x" > 2)) SELECT "v" FROM "c"');
+  });
+
+  it('updates implicit joins', () => {
+    const q = Query
+      .select('a', 'b', column('v', 'O'))
+      .from(
+        new FromClauseNode(new TableRefNode('table'), 'T'),
+        new FromClauseNode(new TableRefNode('other'), 'O'),
+      )
+      .where(eq(column('id', 'T'), column('id', 'O')));
+    const f = filterPushdown(q, 'table', gt('x', 2));
+    expect(String(f)).toBe('SELECT "a", "b", "O"."v" AS "v" FROM "table" AS "T", "other" AS "O" WHERE ("T"."id" = "O"."id") AND ("x" > 2)');
   });
 
   it('skips scalar subqueries', () => {

--- a/packages/mosaic/sql/test/filter-pushdown.test.ts
+++ b/packages/mosaic/sql/test/filter-pushdown.test.ts
@@ -37,17 +37,20 @@ describe('filterPushdown', () => {
       .with({ c: Query.select({ v: 'x' }).from('table') })
       .select('v').from('c');
     const f = filterPushdown(q, 'table', gt('x', 2));
-    expect(String(f)).toMatchInlineSnapshot(`"WITH "c" AS (SELECT "x" AS "v" FROM "_table" AS "table"), "_table" AS (SELECT * FROM "table" WHERE ("x" > 2)) SELECT "v" FROM "c""`);
+    expect(String(f)).toMatchInlineSnapshot(`"WITH "_table" AS (SELECT * FROM "table" WHERE ("x" > 2)), "c" AS (SELECT "x" AS "v" FROM "_table" AS "table") SELECT "v" FROM "c""`);
   });
 
   it('updates self joins', () => {
     const q = Query
       .select('*')
       .from(
-        cross_join('table', 'table')
+        cross_join(
+          new FromClauseNode(new TableRefNode('table'), 'T1'),
+          new FromClauseNode(new TableRefNode('table'), 'T2')
+        )
       );
     const f = filterPushdown(q, 'table', gt('x', 2));
-    expect(String(f)).toMatchInlineSnapshot(`"WITH "_table" AS (SELECT * FROM "table" WHERE ("x" > 2)) SELECT * FROM "_table" CROSS JOIN "_table""`);
+    expect(String(f)).toMatchInlineSnapshot(`"WITH "_table" AS (SELECT * FROM "table" WHERE ("x" > 2)) SELECT * FROM "_table" AS "T1" CROSS JOIN "_table" AS "T2""`);
   });
 
   it('updates explicit joins', () => {

--- a/packages/mosaic/sql/test/filter-pushdown.test.ts
+++ b/packages/mosaic/sql/test/filter-pushdown.test.ts
@@ -1,17 +1,29 @@
 import { expect, describe, it } from 'vitest';
-import { column, count, div, eq, filterPushdown, FromClauseNode, gt, Query, ScalarSubqueryNode, TableRefNode } from '../src/index.js';
+import { column, count, cross_join, div, eq, filterPushdown, FromClauseNode, gt, join, Query, ScalarSubqueryNode, TableRefNode } from '../src/index.js';
 
 describe('filterPushdown', () => {
+  it('does nothing given empty filter', () => {
+    const q = Query.select('v').from('table');
+    const f = filterPushdown(q, 'table', []);
+    expect(String(f)).toMatchInlineSnapshot(`"SELECT "v" FROM "table""`);
+  });
+
+  it('does nothing given unreferenced table', () => {
+    const q = Query.select('v').from('table');
+    const f = filterPushdown(q, 'dont_exist', gt('x', 2));
+    expect(String(f)).toMatchInlineSnapshot(`"SELECT "v" FROM "table""`);
+  });
+
   it('updates queries', () => {
     const q = Query.select('v').from('table');
     const f = filterPushdown(q, 'table', gt('x', 2));
-    expect(String(f)).toBe('SELECT "v" FROM "table" WHERE ("x" > 2)');
+    expect(String(f)).toMatchInlineSnapshot(`"WITH "_table" AS (SELECT * FROM "table" WHERE ("x" > 2)) SELECT "v" FROM "_table" AS "table""`);
   });
 
-  it('updates subqueries', () => {
+  it('updates FROM subqueries', () => {
     const q = Query.select('v').from(Query.select({ v: 'x' }).from('table'));
     const f = filterPushdown(q, 'table', gt('x', 2));
-    expect(String(f)).toBe('SELECT "v" FROM (SELECT "x" AS "v" FROM "table" WHERE ("x" > 2))');
+    expect(String(f)).toMatchInlineSnapshot(`"WITH "_table" AS (SELECT * FROM "table" WHERE ("x" > 2)) SELECT "v" FROM (SELECT "x" AS "v" FROM "_table" AS "table")"`);
   });
 
   it('updates CTEs', () => {
@@ -19,7 +31,27 @@ describe('filterPushdown', () => {
       .with({ c: Query.select({ v: 'x' }).from('table') })
       .select('v').from('c');
     const f = filterPushdown(q, 'table', gt('x', 2));
-    expect(String(f)).toBe('WITH "c" AS (SELECT "x" AS "v" FROM "table" WHERE ("x" > 2)) SELECT "v" FROM "c"');
+    expect(String(f)).toMatchInlineSnapshot(`"WITH "c" AS (SELECT "x" AS "v" FROM "_table" AS "table"), "_table" AS (SELECT * FROM "table" WHERE ("x" > 2)) SELECT "v" FROM "c""`);
+  });
+
+  it('updates self joins', () => {
+    const q = Query
+      .select('*')
+      .from(
+        cross_join('table', 'table')
+      );
+    const f = filterPushdown(q, 'table', gt('x', 2));
+    expect(String(f)).toMatchInlineSnapshot(`"WITH "_table" AS (SELECT * FROM "table" WHERE ("x" > 2)) SELECT * FROM "_table" CROSS JOIN "_table""`);
+  });
+
+  it('updates explicit joins', () => {
+    const q = Query
+      .select('*')
+      .from(
+        join('table', 'other', { using: ['id'] })
+      );
+    const f = filterPushdown(q, 'table', gt('x', 2));
+    expect(String(f)).toMatchInlineSnapshot(`"WITH "_table" AS (SELECT * FROM "table" WHERE ("x" > 2)) SELECT * FROM "_table" JOIN "other" USING ("id")"`);
   });
 
   it('updates implicit joins', () => {
@@ -31,13 +63,13 @@ describe('filterPushdown', () => {
       )
       .where(eq(column('id', 'T'), column('id', 'O')));
     const f = filterPushdown(q, 'table', gt('x', 2));
-    expect(String(f)).toBe('SELECT "a", "b", "O"."v" AS "v" FROM "table" AS "T", "other" AS "O" WHERE ("T"."id" = "O"."id") AND ("x" > 2)');
+    expect(String(f)).toMatchInlineSnapshot(`"WITH "_table" AS (SELECT * FROM "table" WHERE ("x" > 2)) SELECT "a", "b", "O"."v" AS "v" FROM "_table" AS "T", "other" AS "O" WHERE ("T"."id" = "O"."id")"`);
   });
 
   it('skips scalar subqueries', () => {
     const sub = new ScalarSubqueryNode(Query.select({ count: count() }).from('table'))
     const q = Query.select({ norm: div('v', sub) }).from('table');
     const f = filterPushdown(q, 'table', gt('x', 2));
-    expect(String(f)).toBe('SELECT ("v" / (SELECT count(*) AS "count" FROM "table")) AS "norm" FROM "table" WHERE ("x" > 2)');
+    expect(String(f)).toMatchInlineSnapshot(`"WITH "_table" AS (SELECT * FROM "table" WHERE ("x" > 2)) SELECT ("v" / (SELECT count(*) AS "count" FROM "table")) AS "norm" FROM "_table" AS "table""`);
   });
 });

--- a/packages/mosaic/sql/test/filter-pushdown.test.ts
+++ b/packages/mosaic/sql/test/filter-pushdown.test.ts
@@ -20,6 +20,12 @@ describe('filterPushdown', () => {
     expect(String(f)).toMatchInlineSnapshot(`"WITH "_table" AS (SELECT * FROM "table" WHERE ("x" > 2)) SELECT "v" FROM "_table" AS "table""`);
   });
 
+  it('avoids namespace collisions', () => {
+    const q = Query.select('v').from('table', '_table');
+    const f = filterPushdown(q, 'table', gt('x', 2));
+    expect(String(f)).toMatchInlineSnapshot(`"WITH "__table" AS (SELECT * FROM "table" WHERE ("x" > 2)) SELECT "v" FROM "__table" AS "table", "_table""`);
+  });
+
   it('updates FROM subqueries', () => {
     const q = Query.select('v').from(Query.select({ v: 'x' }).from('table'));
     const f = filterPushdown(q, 'table', gt('x', 2));


### PR DESCRIPTION
- Support filter pushdown in multi-table `FROM` clauses.

This improves pushdown, for example to support implicit joins.