### PR TITLE
feat: Preaggregation of having and qualify clauses.

### DIFF
--- a/packages/mosaic/core/src/preagg/PreAggregator.ts
+++ b/packages/mosaic/core/src/preagg/PreAggregator.ts
@@ -332,7 +332,7 @@ function preaggregateInfo(
   preaggCols: PreAggColumnsResult,
   schema: string
 ): PreAggregateInfo {
-  const { dims, groupby, output, preagg } = preaggCols;
+  const { dims, groupby, having, output, preagg, qualify } = preaggCols;
   const { columns = {} } = active;
 
   // build materialized view construction query
@@ -362,6 +362,8 @@ function preaggregateInfo(
     .setSelect(dims, output)
     .setFrom(table)
     .setGroupby(dims)
+    .setHaving(having)
+    .setQualify(qualify)
     .setOrderby(replaceIndices(query._orderby, query._select))
     .sample(null);
   select._with = [];

--- a/packages/mosaic/core/src/preagg/preagg-columns.ts
+++ b/packages/mosaic/core/src/preagg/preagg-columns.ts
@@ -8,6 +8,8 @@ export interface PreAggColumnsResult {
   groupby: Record<string, ExprNode>;
   preagg: Record<string, ExprNode>;
   output: Record<string, ExprNode>;
+  having: ExprNode[];
+  qualify: ExprNode[];
 }
 
 /**
@@ -57,43 +59,80 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
     return sql`(SELECT avg(${expr ?? ref}) FROM "${from}")`;
   };
 
-  // iterate over select clauses and analyze expressions
-  for (const { alias, expr } of q._select) {
-    // bail if there is an aggregate we can't analyze
-    // a value > 1 indicates an aggregate in verbatim text
-    if (isAggregateExpression(expr!) > 1) return null;
-
-    const nodes = collectAggregates(expr!);
-    if (nodes.length === 0) {
-      // if no aggregates, expr is a groupby dimension
-      dims.add(alias);
-      preagg[alias] = expr;
-    } else {
-      for (const node of nodes) {
-        // bail if distinct aggregate
-        if (node.isDistinct) return null;
-
-        // bail if aggregate function is unsupported
-        // otherwise add output aggregate to rewrite map
-        const agg = sufficientStatistics(node, preagg, avg);
-        if (!agg) return null;
-        aggrs.set(node, agg);
+  try {
+    // iterate over select clauses and analyze expressions
+    for (const { alias, expr } of q._select) {
+      const result = analyzeExpression(expr, aggrs, preagg, avg);
+      if (result) {
+        // rewrite original select clause to use preaggregates
+        output[alias] = result;
+      } else {
+        // if no aggregates, expr is a groupby dimension
+        dims.add(alias);
+        preagg[alias] = expr;
       }
-
-      // rewrite original select clause to use preaggregates
-      output[alias] = rewrite(expr!, aggrs)!;
     }
+
+    // bail if select clause has no aggregates
+    if (!aggrs.size) return null;
+
+    // analyze any having expressions
+    const having = q._having
+      .map(expr => analyzeExpression(expr, aggrs, preagg, avg) ?? expr);
+
+    // analyze any qualify expressions
+    const qualify = q._qualify
+      .map(expr => analyzeExpression(expr, aggrs, preagg, avg) ?? expr);
+
+    // bail if the query has no aggregates
+    if (!aggrs.size) return null;
+
+    return {
+      dims: Array.from(dims),
+      groupby,
+      preagg,
+      output,
+      having,
+      qualify
+    };
+  } catch {
+    // bail if unsupported aggregate was encountered
+    return null;
   }
+}
 
-  // bail if the query has no aggregates
-  if (!aggrs.size) return null;
+/**
+ * Analyzes an expression and returns a rewritten expression if preaggregation
+ * optimization is supported. Returns undefined if the expressions does not
+ * contain any aggregates. Throws if the expression contains an unsupported
+ * or non-optimizable aggregate.
+ */
+function analyzeExpression(
+  expr: ExprNode,
+  aggrs: Map<AggregateNode, ExprNode>,
+  preagg: Record<string, ExprNode>,
+  avg: (ref: ColumnRefNode) => ExprNode
+) {
+  // bail if there is an aggregate we can't analyze
+  // a value > 1 indicates an aggregate in verbatim text
+  if (isAggregateExpression(expr!) > 1) throw new Error();
 
-  return {
-    dims: Array.from(dims),
-    groupby,
-    preagg,
-    output
-  };
+  const nodes = collectAggregates(expr!);
+  if (nodes.length) {
+    for (const node of nodes) {
+      // bail if distinct aggregate
+      if (node.isDistinct) throw new Error();
+
+      // bail if aggregate function is unsupported
+      // otherwise add output aggregate to rewrite map
+      const agg = sufficientStatistics(node, preagg, avg);
+      if (!agg) throw new Error();
+      aggrs.set(node, agg);
+    }
+
+    // rewrite original expression to use preaggregates
+    return rewrite(expr!, aggrs)!;
+  }
 }
 
 /**

--- a/packages/mosaic/core/test/preaggregator.test.ts
+++ b/packages/mosaic/core/test/preaggregator.test.ts
@@ -217,6 +217,28 @@ describe('PreAggregator', () => {
     expect(await run(query)).toStrictEqual([13, true]);
   });
 
+  it('supports queries with having clause', async () => {
+    const query = (predicate: FilterExpr = []) => {
+      return Query.from('testData')
+        .select({ measure: sum('y') })
+        .groupby('dim')
+        .where(predicate)
+        .having(gt(avg('x'), 2));
+    };
+    expect(await run(query)).toStrictEqual([13, true]);
+  });
+
+  it('supports queries with qualify clause containing an aggregate', async () => {
+    const query = (predicate: FilterExpr = []) => {
+      return Query.from('testData')
+        .select({ measure: sum(sum('y')).orderby('order') })
+        .groupby('dim', 'order')
+        .where(predicate)
+        .qualify(gt('measure', 7), gt(avg('x'), 0));
+    };
+    expect(await run(query)).toStrictEqual([13, true]);
+  });
+
   it('supports queries with filter pushdown applied', async () => {
     const query = (predicate: FilterExpr = []) => {
       // include a non-selective clause to ensure that we always have

--- a/packages/mosaic/sql/src/ast/query.ts
+++ b/packages/mosaic/sql/src/ast/query.ts
@@ -467,6 +467,15 @@ export class SelectQuery extends Query {
   }
 
   /**
+   * Set HAVING expressions, replacing any prior expressions.
+   * @param expr Expressions to add.
+   */
+  setHaving(...expr: FilterExpr[]): this {
+    this._having = [];
+    return this.having(...expr);
+  }
+
+  /**
    * Add WINDOW definitions.
    * @param expr Window definitions to add.
    */
@@ -494,6 +503,15 @@ export class SelectQuery extends Query {
   qualify(...expr: FilterExpr[]): this {
     this._qualify = this._qualify.concat(exprList(expr, asVerbatim));
     return this;
+  }
+
+  /**
+   * Set QUALIFY expressions, replacing any prior expressions.
+   * @param expr Expressions to add.
+   */
+  setQualify(...expr: FilterExpr[]): this {
+    this._qualify = [];
+    return this.qualify(...expr);
   }
 }
 


### PR DESCRIPTION
- Add preaggregation optimization of aggregates in `HAVING` and `QUALIFY` clauses.
- Add `setHaving` and `setQualify` methods to the `SelectQuery` class.
- Add new preaggregator tests.

Close #1047.