### PR TITLE
Security: SQL Injection via Template Literal in parse.html

### DIFF
--- a/dev/parse.html
+++ b/dev/parse.html
@@ -15,7 +15,8 @@
     const t0 = Date.now();
     const result = await db.query({
       type: 'json',
-      sql: `SELECT json_serialize_sql($$${query}$$, skip_empty:=true, skip_null:=true) AS ast`
+      sql: 'SELECT json_serialize_sql($1, skip_empty:=true, skip_null:=true) AS ast',
+      params: [query]
     });
     const ast = JSON.parse(result[0].ast);
     ast._time = Date.now() - t0;


### PR DESCRIPTION
## Summary

Security: SQL Injection via Template Literal in parse.html

## Problem

**Severity**: `Critical` | **File**: `dev/parse.html:L12`

The `parse` function in `dev/parse.html` directly interpolates user-provided `query` input into a SQL string using template literals (`$$${query}$$`). This creates a SQL injection vulnerability where an attacker can inject arbitrary SQL code. The function is exposed on `self.parse`, making it accessible globally. While this appears to be a development tool, if this pattern is used in production or the file is served, it could allow complete database compromise.

## Solution

Use parameterized queries or proper escaping of the query input before interpolation. If this is a debug tool, ensure it is not accessible in production builds. Consider using the database's built-in SQL serialization functions with proper parameter binding.

## Changes

- `dev/parse.html` (modified)