### PR TITLE
ci: don't build pages in forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.repository == 'uwdata/mosaic'
     runs-on: ubuntu-latest
 
     environment:


### PR DESCRIPTION
Prevents build failures like https://github.com/cmudig/mosaic/actions/runs/28101915371/job/83205873059