### PR TITLE
fix(sql): correct symlog scale invert to be the inverse of apply

### DIFF
--- a/packages/mosaic/sql/src/transforms/scales.ts
+++ b/packages/mosaic/sql/src/transforms/scales.ts
@@ -88,7 +88,7 @@ function scaleSymlog({ constant = 1 } = {}): ScaleTransform<number> {
   const _ = +constant;
   return {
     apply: x => Math.sign(x) * Math.log1p(Math.abs(x)),
-    invert: x => Math.sign(x) * Math.exp(Math.abs(x) - _),
+    invert: x => Math.sign(x) * (Math.exp(Math.abs(x)) - _),
     sqlApply: c => (c = asNode(c), mul(sign(c), ln(add(_, abs(c))))),
     sqlInvert: c => mul(sign(c), sub(exp(abs(c)), _))
   };

--- a/packages/mosaic/sql/test/scales.test.ts
+++ b/packages/mosaic/sql/test/scales.test.ts
@@ -1,0 +1,11 @@
+import { expect, describe, it } from 'vitest';
+import { scaleTransform } from '../src/index.js';
+
+describe('scaleTransform', () => {
+  it('symlog invert is the inverse of apply', () => {
+    const s = scaleTransform<number>({ type: 'symlog' });
+    for (const x of [5, 10, 100, -7, 1, 0.5]) {
+      expect(s.invert(s.apply(x))).toBeCloseTo(x, 9);
+    }
+  });
+});


### PR DESCRIPTION
## What's broken
The symlog scale's JS `invert` is not the inverse of its `apply`. With `apply(x) = sign(x)·log1p(|x|)`, the correct inverse is `sign(x)·(exp(|x|) − C)`, but the code computed `sign(x)·exp(|x| − C)` — subtracting the constant inside the exponent. So `invert(apply(5))` returns ≈2.207 instead of 5. This corrupts data coordinates wherever `scale.invert` is used on a symlog scale, e.g. mapping pixel positions back to data values during brushing/zoom (`vgplot .../interactors/util/invert.js`).

## Why it happens
Operator placement error: the constant is subtracted within the exponent (`exp(|x|−C)`) instead of after exponentiation (`exp(|x|)−C`). The sibling `sqlInvert` already used the correct form, so the JS and SQL paths disagreed.

## Fix
`invert: x => Math.sign(x) * (Math.exp(Math.abs(x)) - constant)`, matching `sqlInvert`.

## Test
Added a `symlog invert is the inverse of apply` test asserting `invert(apply(x)) ≈ x` across several values. Fails before (≈2.207 vs 5), passes after; full sql suite green (254).
