### PR TITLE
fix: Avoid typing issues in non-generated modules

### DIFF
--- a/packages/vgplot/vgplot-python/pyproject.toml
+++ b/packages/vgplot/vgplot-python/pyproject.toml
@@ -31,3 +31,7 @@ pattern = "\"version\": \"(?P<version>.+?)\""
 
 [tool.hatch.build.targets.wheel]
 packages = ["vgplot"]
+
+[tool.pyright]
+ignore = ["../**/.venv/"]  # Do not display diagnostics in external source code
+typeCheckingMode = "standard"

--- a/packages/vgplot/vgplot-python/test/test_python_api.py
+++ b/packages/vgplot/vgplot-python/test/test_python_api.py
@@ -35,7 +35,7 @@ class TestGeneratedMarks:
         assert vg.line_y("t", x="a", z=None).to_dict()["z"] is None
         assert "z" not in vg.line_y("t", x="a").to_dict()
 
-    def test_unknown_name_raises(self):
+    def test_unknown_name_raises(self) -> None:
         # No __getattr__ fallback: a missing or mis-typed API name is an error.
         with pytest.raises(AttributeError):
             vg.some_custom_mark  # pyright: ignore[reportAttributeAccessIssue] # ty: ignore[unresolved-attribute]

--- a/packages/vgplot/vgplot-python/test/test_python_api.py
+++ b/packages/vgplot/vgplot-python/test/test_python_api.py
@@ -35,7 +35,7 @@ class TestGeneratedMarks:
         assert vg.line_y("t", x="a", z=None).to_dict()["z"] is None
         assert "z" not in vg.line_y("t", x="a").to_dict()
 
-    def test_unknown_name_raises(self) -> None:
+    def test_unknown_name_raises(self):
         # No __getattr__ fallback: a missing or mis-typed API name is an error.
         with pytest.raises(AttributeError):
             vg.some_custom_mark  # pyright: ignore[reportAttributeAccessIssue] # ty: ignore[unresolved-attribute]

--- a/packages/vgplot/vgplot-python/test/test_python_api.py
+++ b/packages/vgplot/vgplot-python/test/test_python_api.py
@@ -38,9 +38,9 @@ class TestGeneratedMarks:
     def test_unknown_name_raises(self):
         # No __getattr__ fallback: a missing or mis-typed API name is an error.
         with pytest.raises(AttributeError):
-            vg.some_custom_mark  # ty: ignore[unresolved-attribute]
+            vg.some_custom_mark  # pyright: ignore[reportAttributeAccessIssue] # ty: ignore[unresolved-attribute]
         with pytest.raises(AttributeError):
-            vg.definitely_not_a_real_directive  # ty: ignore[unresolved-attribute]
+            vg.definitely_not_a_real_directive  # pyright: ignore[reportAttributeAccessIssue] # ty: ignore[unresolved-attribute]
 
 
 class TestDataHelpers:

--- a/packages/vgplot/vgplot-python/vgplot/__init__.py
+++ b/packages/vgplot/vgplot-python/vgplot/__init__.py
@@ -134,4 +134,4 @@ __all__ = [
     "toggle_y",
     "vconcat",
     "vspace",
-] + list(_generated_all)
+] + list(_generated_all)  # pyright: ignore[reportUnsupportedDunderAll]

--- a/packages/vgplot/vgplot-python/vgplot/params.py
+++ b/packages/vgplot/vgplot-python/vgplot/params.py
@@ -20,7 +20,7 @@ def _resolve(v: Any, param_names: dict[int, str] | None) -> Any:
 class _ParamBase:
     """Base for Param and Selection instances used as param ref tokens."""
 
-    def param_def(self, param_names: dict[int, str] | None = None) -> Any:
+    def param_def(self, *, param_names: dict[int, str] | None = None) -> Any:
         raise NotImplementedError
 
 
@@ -28,7 +28,7 @@ class ParamValue(_ParamBase):
     def __init__(self, value: Any = None) -> None:
         self._value = value
 
-    def param_def(self, **_: Any) -> Any:
+    def param_def(self, *, param_names: dict[int, str] | None = None) -> Any:
         return self._value
 
     def __repr__(self) -> str:
@@ -39,7 +39,7 @@ class ParamArray(_ParamBase):
     def __init__(self, values: list) -> None:
         self._values = list(values)
 
-    def param_def(self, param_names: dict[int, str] | None = None) -> Any:
+    def param_def(self, *, param_names: dict[int, str] | None = None) -> Any:
         return [_resolve(v, param_names) for v in self._values]
 
     def __repr__(self) -> str:
@@ -51,7 +51,7 @@ class SelectionDef(_ParamBase):
         self._select = select
         self._opts = {k: v for k, v in opts.items() if v is not None}
 
-    def param_def(self, param_names: dict[int, str] | None = None) -> Any:
+    def param_def(self, *, param_names: dict[int, str] | None = None) -> Any:
         d: dict = {"select": self._select}
         d.update(_resolve(self._opts, param_names))
         return d

--- a/packages/vgplot/vgplot-python/vgplot/params.py
+++ b/packages/vgplot/vgplot-python/vgplot/params.py
@@ -20,6 +20,9 @@ def _resolve(v: Any, param_names: dict[int, str] | None) -> Any:
 class _ParamBase:
     """Base for Param and Selection instances used as param ref tokens."""
 
+    def param_def(self, param_names: dict[int, str] | None = None) -> Any:
+        raise NotImplementedError
+
 
 class ParamValue(_ParamBase):
     def __init__(self, value: Any = None) -> None:

--- a/packages/vgplot/vgplot-python/vgplot/plot.py
+++ b/packages/vgplot/vgplot-python/vgplot/plot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -87,7 +88,7 @@ def encode_value(
 
 
 def plot(
-    *items: Mark | Directive,
+    *items: Mark | Directive | Mapping[str, Any],
     param_names: dict[int, str] | None = None,
     **kwargs: Any,
 ) -> Any:
@@ -101,8 +102,8 @@ def plot(
         elif isinstance(item, Directive):
             k, v = item.to_kv()
             directives[k] = encode_value(v, param_names)
-        elif isinstance(item, dict):
-            marks.append({k: encode_value(v, param_names) for k, v in item.items()})  # pyright: ignore[reportGeneralTypeIssues]
+        elif isinstance(item, (dict, Mapping)):
+            marks.append({k: encode_value(v, param_names) for k, v in item.items()})
         else:
             raise TypeError(f"Unsupported plot item: {item}")
     root: dict[str, Any] = {"plot": marks}

--- a/packages/vgplot/vgplot-python/vgplot/plot.py
+++ b/packages/vgplot/vgplot-python/vgplot/plot.py
@@ -102,7 +102,7 @@ def plot(
             k, v = item.to_kv()
             directives[k] = encode_value(v, param_names)
         elif isinstance(item, dict):
-            marks.append({k: encode_value(v, param_names) for k, v in item.items()})
+            marks.append({k: encode_value(v, param_names) for k, v in item.items()})  # pyright: ignore[reportGeneralTypeIssues]
         else:
             raise TypeError(f"Unsupported plot item: {item}")
     root: dict[str, Any] = {"plot": marks}
@@ -426,7 +426,7 @@ def input(kind: str, **opts: Any) -> Any:
             and any(isinstance(i, dict) for i in v)
         ):
             v = [{"label": i, "value": i} if not isinstance(i, dict) else i for i in v]
-        payload[key] = v
+        payload[key] = v  # pyright: ignore[reportArgumentType]
     return View(payload)
 
 

--- a/packages/vgplot/vgplot-python/vgplot/plot.py
+++ b/packages/vgplot/vgplot-python/vgplot/plot.py
@@ -416,7 +416,7 @@ _INPUT_ALIASES = {"bind": "as", "source": "from"}
 def input(kind: str, **opts: Any) -> Any:
     from .spec import View
 
-    payload = {"input": kind}
+    payload: dict[str, Any] = {"input": kind}
     for k, v in opts.items():
         if v is None:
             continue
@@ -427,7 +427,7 @@ def input(kind: str, **opts: Any) -> Any:
             and any(isinstance(i, dict) for i in v)
         ):
             v = [{"label": i, "value": i} if not isinstance(i, dict) else i for i in v]
-        payload[key] = v  # pyright: ignore[reportArgumentType]
+        payload[key] = v
     return View(payload)
 
 

--- a/packages/vgplot/vgplot-python/vgplot/spec.py
+++ b/packages/vgplot/vgplot-python/vgplot/spec.py
@@ -119,7 +119,7 @@ class Spec:
                 all_params[name] = view_params[obj_id]
         for name, p in all_params.items():
             if isinstance(p, _ParamBase):
-                serialized_params[name] = p.param_def(param_names=param_names)  # pyright: ignore[reportAttributeAccessIssue]
+                serialized_params[name] = p.param_def(param_names=param_names)
             else:
                 serialized_params[name] = p
 

--- a/packages/vgplot/vgplot-python/vgplot/spec.py
+++ b/packages/vgplot/vgplot-python/vgplot/spec.py
@@ -119,7 +119,7 @@ class Spec:
                 all_params[name] = view_params[obj_id]
         for name, p in all_params.items():
             if isinstance(p, _ParamBase):
-                serialized_params[name] = p.param_def(param_names=param_names)
+                serialized_params[name] = p.param_def(param_names=param_names)  # pyright: ignore[reportAttributeAccessIssue]
             else:
                 serialized_params[name] = p
 


### PR DESCRIPTION
Mainly trying to get less red squiggles in VS code with `pyright`.

But it also reduces the `ty` errors mentioned in (https://github.com/uwdata/mosaic/pull/1067#discussion_r3540122687):

```diff
- Found 103 diagnostics
+ Found 7 diagnostics
``` 

If any changes look surprising, try reading the commits in order for explanation 😄 