### PR TITLE
fix: Handle case-insensitive column collisions in preagg dims.

### DIFF
--- a/packages/mosaic/core/src/preagg/PreAggregator.ts
+++ b/packages/mosaic/core/src/preagg/PreAggregator.ts
@@ -4,6 +4,7 @@ import type { MosaicClient } from '../MosaicClient.js';
 import type { Selection } from '../Selection.js';
 import type { BinMethod, ClauseSource, IntervalMetadata, SelectionClause } from '../SelectionClause.js';
 import { fnv_hash } from '../util/hash.js';
+import { resolvePositional } from '../util/positional.js';
 import { preaggColumns, PreAggColumnsResult } from './preagg-columns.js';
 
 const Skip = { skip: true, result: null };
@@ -332,7 +333,7 @@ function preaggregateInfo(
   preaggCols: PreAggColumnsResult,
   schema: string
 ): PreAggregateInfo {
-  const { dims, groupby, having, output, preagg, qualify } = preaggCols;
+  const { groupby, having, output, preagg, qualify } = preaggCols;
   const { columns = {} } = active;
 
   // build materialized view construction query
@@ -341,8 +342,8 @@ function preaggregateInfo(
     .with(query._with)
     .sample(query._sample)
     .where(query._where)
-    .select({ ...groupby, ...preagg, ...columns })
-    .groupby(dims, Object.keys(columns));
+    .select({ ...preagg, ...columns })
+    .groupby(groupby, Object.keys(columns));
 
   // ensure active clause columns are selected by subqueries
   const [subq] = create.subqueries;
@@ -359,9 +360,9 @@ function preaggregateInfo(
   // generate preaggregate select query from original query
   // replace select, from, groupby; sanitize orderby; remove CTEs, where
   const select = query.clone()
-    .setSelect(dims, output)
+    .setSelect(output)
     .setFrom(table)
-    .setGroupby(dims)
+    .setGroupby(groupby)
     .setHaving(having)
     .setQualify(qualify)
     .setOrderby(replaceIndices(query._orderby, query._select))
@@ -381,20 +382,16 @@ function replaceIndices(exprs: ExprNode[], select: SelectClauseNode[]) {
   return exprs.flatMap(expr => {
     if (expr.type === "ORDER_BY") {
       const e = (expr as OrderByNode).expr;
-      if (e.type === "LITERAL") {
-        const ref = select[(e as LiteralNode).value as number - 1];
-        if (ref) {
-          const cloned = expr.clone();
-          // @ts-expect-error assign to cloned order by node
-          cloned.expr = asNode(ref.alias);
-          return cloned
-        } else {
-          return [];
-        }
+      const ref = resolvePositional(e, select);
+      if (ref) {
+        const cloned = expr.clone();
+        // @ts-expect-error assign to cloned order by node
+        cloned.expr = asNode(ref.alias);
+        return cloned;
       }
-    } else if (expr.type === "LITERAL") {
-      const ref = select[(expr as LiteralNode).value as number - 1];
-      return ref ? asNode(ref.alias) : [];
+    } else {
+      const ref = resolvePositional(expr, select);
+      if (ref) return asNode(ref.alias);
     }
     return expr;
   });

--- a/packages/mosaic/core/src/preagg/preagg-columns.ts
+++ b/packages/mosaic/core/src/preagg/preagg-columns.ts
@@ -1,14 +1,20 @@
+import { asNode, collectAggregates, FromClauseNode, isAggregateExpression, isColumnRef, isSelectQuery, isTableRef, rewrite, sql } from '@uwdata/mosaic-sql';
 import type { AggregateNode, ColumnRefNode, ExprNode, Query, SelectQuery } from '@uwdata/mosaic-sql';
 import type { MosaicClient } from '../MosaicClient.js';
-import { collectAggregates, FromClauseNode, isAggregateExpression, isColumnRef, isSelectQuery, isTableRef, rewrite, sql } from '@uwdata/mosaic-sql';
+import { resolvePositional } from '../util/positional.js';
 import { sufficientStatistics } from './sufficient-statistics.js';
 
+// result of determining columns for preaggregation optimization
 export interface PreAggColumnsResult {
-  dims: string[];
-  groupby: Record<string, ExprNode>;
+  // Columns to include in a created preaggregate table
   preagg: Record<string, ExprNode>;
+  // Output columns for selection update queries
   output: Record<string, ExprNode>;
+  // Group by dimension aliases
+  groupby: string[]
+  // HAVING clause expressions, potentially rewritten for preaggregation
   having: ExprNode[];
+  // QUALIFY clause expressions, potentially rewritten for preaggregation
   qualify: ExprNode[];
 }
 
@@ -34,33 +40,33 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
   });
   if (typeof from !== 'string') return null;
 
-  const aggrs = new Map<AggregateNode, ExprNode>();
-  const preagg: Record<string, ExprNode> = {};
-  const output: Record<string, ExprNode> = {};
-
-  // all group by dimensions, including selected ones.
-  const dims: string[] = [];
-  const dimsLower = new Set<string>(); // case-insensitive
-
   // generate a scalar subquery for a global average
+  // this may be used to mean-center data in preaggregate calculations
   const avg = (ref: ColumnRefNode) => {
     const name = ref.column;
     const expr = getBase(q, q => q._select.find(c => c.alias === name)?.expr);
     return sql`(SELECT avg(${expr ?? ref}) FROM "${from}")`;
   };
 
+  const aggrs = new Map<AggregateNode, ExprNode>();
+  const preagg: Record<string, ExprNode> = {}; // alias -> expr
+  const output: Record<string, ExprNode> = {}; // alias -> expr
+  const groupby: Record<string, string> = {}; // lower case alias -> alias
+
   try {
+    const select = q._select;
+
     // iterate over select clauses and analyze expressions
-    for (const { alias, expr } of q._select) {
+    for (const { alias, expr } of select) {
       const result = analyzeExpression(expr, aggrs, preagg, avg);
       if (result) {
         // rewrite original select clause to use preaggregates
         output[alias] = result;
       } else {
-        // if no aggregates, expr is a groupby dimension
-        dimsLower.add(alias.toLowerCase());
-        dims.push(alias);
+        // include non-aggregates in preagg table and update results
         preagg[alias] = expr;
+        output[alias] = asNode(alias);
+        groupby[alias.toLowerCase()] = alias;
       }
     }
 
@@ -75,26 +81,21 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
     const qualify = q._qualify
       .map(expr => analyzeExpression(expr, aggrs, preagg, avg) ?? expr);
 
-    // add groupby entries, which may or may not be selected
-    const groupby: Record<string, ExprNode> = {};
-    for (const expr of q._groupby) {
-      // ignore integer index, as expr was in select clause
-      // so we harvested that expr as a dimension above
-      if (expr.type !== "LITERAL") {
-        // skip duplicates, as column names are case-insensitive in DuckDB
-        const alias = isColumnRef(expr) ? expr.column : `${expr}`;
-        const key = alias.toLowerCase();
-        if (!dimsLower.has(key)) {
-          dimsLower.add(key);
-          groupby[alias] = expr;
-          dims.push(alias);
-        }
+    // add groupby entries; these may or may not be selected
+    let id = 0;
+    for (let expr of q._groupby) {
+      expr = resolvePositional(expr, select)?.expr ?? expr;
+      const alias = isColumnRef(expr) ? expr.column : `__groupby_${++id}`;
+      const key = alias.toLowerCase();
+      if (!groupby[key]) {
+        // add non-selected groupby term
+        preagg[alias] = expr;
+        groupby[key] = alias;
       }
     }
 
     return {
-      dims,
-      groupby,
+      groupby: Object.values(groupby),
       preagg,
       output,
       having,

--- a/packages/mosaic/core/src/preagg/preagg-columns.ts
+++ b/packages/mosaic/core/src/preagg/preagg-columns.ts
@@ -75,9 +75,6 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
     const qualify = q._qualify
       .map(expr => analyzeExpression(expr, aggrs, preagg, avg) ?? expr);
 
-    // bail if the query has no aggregates
-    if (!aggrs.size) return null;
-
     // add groupby entries, which may or may not be selected
     const groupby: Record<string, ExprNode> = {};
     for (const expr of q._groupby) {

--- a/packages/mosaic/core/src/preagg/preagg-columns.ts
+++ b/packages/mosaic/core/src/preagg/preagg-columns.ts
@@ -84,11 +84,11 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
       // ignore integer index, as expr was in select clause
       // so we harvested that expr as a dimension above
       if (expr.type !== "LITERAL") {
-        // if column ref, do not duplicate given case-insensitive match
-        const alias = !isColumnRef(expr) ? `${expr}`
-          : dimsLower.has(expr.column.toLowerCase()) ? undefined
-          : expr.column;
-        if (alias) {
+        // skip duplicates, as column names are case-insensitive in DuckDB
+        const alias = isColumnRef(expr) ? expr.column : `${expr}`;
+        const key = alias.toLowerCase();
+        if (!dimsLower.has(key)) {
+          dimsLower.add(key);
           groupby[alias] = expr;
           dims.push(alias);
         }

--- a/packages/mosaic/core/src/preagg/preagg-columns.ts
+++ b/packages/mosaic/core/src/preagg/preagg-columns.ts
@@ -38,19 +38,9 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
   const preagg: Record<string, ExprNode> = {};
   const output: Record<string, ExprNode> = {};
 
-  // groupby entries, these may or may not be selected
-  const groupby: Record<string, ExprNode> = {};
-  for (const expr of q._groupby) {
-    // ignore integer index, as expr will be in select clause
-    // we will harvest that expr as a dimension below
-    if (expr.type !== "LITERAL") {
-      const alias = isColumnRef(expr) ? expr.column : `${expr}`;
-      groupby[alias] = expr;
-    }
-  }
-
   // all group by dimensions, including selected ones.
-  const dims: Set<string> = new Set(Object.keys(groupby));
+  const dims: string[] = [];
+  const dimsLower = new Set<string>(); // case-insensitive
 
   // generate a scalar subquery for a global average
   const avg = (ref: ColumnRefNode) => {
@@ -68,7 +58,8 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
         output[alias] = result;
       } else {
         // if no aggregates, expr is a groupby dimension
-        dims.add(alias);
+        dimsLower.add(alias.toLowerCase());
+        dims.push(alias);
         preagg[alias] = expr;
       }
     }
@@ -87,8 +78,25 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
     // bail if the query has no aggregates
     if (!aggrs.size) return null;
 
+    // add groupby entries, which may or may not be selected
+    const groupby: Record<string, ExprNode> = {};
+    for (const expr of q._groupby) {
+      // ignore integer index, as expr was in select clause
+      // so we harvested that expr as a dimension above
+      if (expr.type !== "LITERAL") {
+        // if column ref, do not duplicate given case-insensitive match
+        const alias = !isColumnRef(expr) ? `${expr}`
+          : dimsLower.has(expr.column.toLowerCase()) ? undefined
+          : expr.column;
+        if (alias) {
+          groupby[alias] = expr;
+          dims.push(alias);
+        }
+      }
+    }
+
     return {
-      dims: Array.from(dims),
+      dims,
       groupby,
       preagg,
       output,
@@ -103,7 +111,7 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
 
 /**
  * Analyzes an expression and returns a rewritten expression if preaggregation
- * optimization is supported. Returns undefined if the expressions does not
+ * optimization is supported. Returns undefined if the expression does not
  * contain any aggregates. Throws if the expression contains an unsupported
  * or non-optimizable aggregate.
  */

--- a/packages/mosaic/core/src/util/positional.ts
+++ b/packages/mosaic/core/src/util/positional.ts
@@ -1,0 +1,10 @@
+import type { ExprNode, LiteralNode, SelectClauseNode } from '@uwdata/mosaic-sql';
+
+export function resolvePositional(expr: ExprNode, select: SelectClauseNode[]) {
+  if (expr.type === 'LITERAL') {
+    const { value } = (expr as LiteralNode);
+    if (typeof value === 'number') {
+      return select[value - 1];
+    }
+  }
+}

--- a/packages/mosaic/core/test/preaggregator.test.ts
+++ b/packages/mosaic/core/test/preaggregator.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { CreateQuery, ExprNode, FilterExpr } from "@uwdata/mosaic-sql";
 import { Query, add, argmax, argmin, avg, corr, count, covarPop, covariance, desc, filterPushdown, geomean, gt, isNotDistinct, literal, loadObjects, max, min, mul, neq, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, stddev, stddevPop, sum, upper, varPop, variance } from '@uwdata/mosaic-sql';
 import { Coordinator, Selection, SelectionClause } from '../src/index.js';
+import { preaggColumns } from '../src/preagg/preagg-columns.js';
 import { NodeConnector } from './util/node-connector.js';
 import { TestClient } from './util/test-client.js';
 
@@ -273,5 +274,44 @@ describe('PreAggregator', () => {
         .orderby(desc("measure"))
     };
     expect(await run(query)).toStrictEqual([3.5, true]);
+  });
+
+  it('supports case-insensitive collisions among groupby dimensions', async () => {
+    const query = (predicate: FilterExpr = []) => {
+      return Query.from('testData')
+        .select({ measure: avg('x') })
+        .groupby("cat", "CAT")
+        .where(predicate)
+        .orderby(desc("measure"))
+    };
+    expect(await run(query)).toStrictEqual([3.5, true]);
+  });
+
+  it('supports duplicate groupby dimensions', async () => {
+    const query = (predicate: FilterExpr = []) => {
+      return Query.from('testData')
+        .select({ measure: avg('x') })
+        .groupby("cat", "cat")
+        .where(predicate)
+        .orderby(desc("measure"))
+    };
+    expect(await run(query)).toStrictEqual([3.5, true]);
+  });
+
+  it('dedupes case-insensitive collisions among groupby dimensions', () => {
+    const query = Query.from('testData')
+      .select({ measure: avg('x') })
+      .groupby('cat', 'CAT');
+    const cols = preaggColumns(new TestClient(query));
+    expect(cols?.dims).toStrictEqual(['cat']);
+    expect(Object.keys(cols?.groupby ?? {})).toStrictEqual(['cat']);
+  });
+
+  it('dedupes duplicate groupby dimensions', () => {
+    const query = Query.from('testData')
+      .select({ measure: avg('x') })
+      .groupby('cat', 'cat');
+    const cols = preaggColumns(new TestClient(query));
+    expect(cols?.dims).toStrictEqual(['cat']);
   });
 });

--- a/packages/mosaic/core/test/preaggregator.test.ts
+++ b/packages/mosaic/core/test/preaggregator.test.ts
@@ -303,8 +303,7 @@ describe('PreAggregator', () => {
       .select({ measure: avg('x') })
       .groupby('cat', 'CAT');
     const cols = preaggColumns(new TestClient(query));
-    expect(cols?.dims).toStrictEqual(['cat']);
-    expect(Object.keys(cols?.groupby ?? {})).toStrictEqual(['cat']);
+    expect(cols?.groupby).toStrictEqual(['cat']);
   });
 
   it('dedupes duplicate groupby dimensions', () => {
@@ -312,6 +311,6 @@ describe('PreAggregator', () => {
       .select({ measure: avg('x') })
       .groupby('cat', 'cat');
     const cols = preaggColumns(new TestClient(query));
-    expect(cols?.dims).toStrictEqual(['cat']);
+    expect(cols?.groupby).toStrictEqual(['cat']);
   });
 });

--- a/packages/mosaic/core/test/preaggregator.test.ts
+++ b/packages/mosaic/core/test/preaggregator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { CreateQuery, ExprNode, FilterExpr } from "@uwdata/mosaic-sql";
-import { Query, add, argmax, argmin, avg, corr, count, covarPop, covariance, desc, filterPushdown, geomean, gt, isNotDistinct, literal, loadObjects, max, min, mul, neq, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, stddev, stddevPop, sum, varPop, variance } from '@uwdata/mosaic-sql';
+import { Query, add, argmax, argmin, avg, corr, count, covarPop, covariance, desc, filterPushdown, geomean, gt, isNotDistinct, literal, loadObjects, max, min, mul, neq, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, stddev, stddevPop, sum, upper, varPop, variance } from '@uwdata/mosaic-sql';
 import { Coordinator, Selection, SelectionClause } from '../src/index.js';
 import { NodeConnector } from './util/node-connector.js';
 import { TestClient } from './util/test-client.js';
@@ -20,11 +20,11 @@ type RunMeasure = ExprNode | ((predicate?: FilterExpr) => Query);
 
 async function run(measure: RunMeasure): Promise<[number, boolean]> {
   const loadQuery = loadObjects('testData', [
-    { dim: 'a', order: 1, x: 1, y: 9 },
-    { dim: 'a', order: 2, x: 2, y: 8 },
-    { dim: 'b', order: 1, x: 3, y: 7 },
-    { dim: 'b', order: 2, x: 4, y: 6 },
-    { dim: 'b', order: 3, x: null, y: null }
+    { dim: 'a', cat: "c", order: 1, x: 1, y: 9 },
+    { dim: 'a', cat: "c", order: 2, x: 2, y: 8 },
+    { dim: 'b', cat: "d", order: 1, x: 3, y: 7 },
+    { dim: 'b', cat: "d", order: 2, x: 4, y: 6 },
+    { dim: 'b', cat: "d", order: 3, x: null, y: null }
   ]);
   const mc = await setup(loadQuery);
   const sel = Selection.single({ cross: true });
@@ -45,6 +45,7 @@ async function run(measure: RunMeasure): Promise<[number, boolean]> {
           ]);
         }
         ++iter;
+        return this;
       },
       queryError(err: Error) {
         console.error("QUERY ERROR", err);
@@ -248,6 +249,28 @@ describe('PreAggregator', () => {
         .select({ measure: avg('x'), dim: 'dim' })
         .groupby('dim');
       return filterPushdown(q, 'testData', filter);
+    };
+    expect(await run(query)).toStrictEqual([3.5, true]);
+  });
+
+  it('supports queries with renamed groupby dimensions', async () => {
+    const query = (predicate: FilterExpr = []) => {
+      return Query.from('testData')
+        .select({ measure: avg('x'), Cat: 'cat' })
+        .groupby("cat")
+        .where(predicate)
+        .orderby(desc("measure"))
+    };
+    expect(await run(query)).toStrictEqual([3.5, true]);
+  });
+
+  it('supports queries with expression-valued groupby dimensions', async () => {
+    const query = (predicate: FilterExpr = []) => {
+      return Query.from('testData')
+        .select({ measure: avg('x'), Cat: 'cat' })
+        .groupby("Cat", upper("cat"))
+        .where(predicate)
+        .orderby(desc("measure"))
     };
     expect(await run(query)).toStrictEqual([3.5, true]);
   });


### PR DESCRIPTION
- Update preaggregator to handle case-insensitive column name collisions. This prevents preaggregation select queries from requesting column names that do not exist because they got re-written with suffixes (`_1`) by DuckDB to avoid case-insensitive name collisions.
- Refactor preaggregate column identification for cleaner, more straightforward handling.
- Add internal utility to resolve positional references to select clauses.
- Add more preaggregator tests.