### PR TITLE
fix: Avoid `UnicodeDecodeError` on windows

### DIFF
--- a/packages/vgplot/vgplot-python/test/test_schema_coverage.py
+++ b/packages/vgplot/vgplot-python/test/test_schema_coverage.py
@@ -48,7 +48,7 @@ def _consts(defs: dict, key: str) -> set[str]:
 
 
 def test_schema_surface_is_exported():
-    defs = json.loads(SCHEMA.read_text())["definitions"]
+    defs = json.loads(SCHEMA.read_text("utf-8"))["definitions"]
     names = (
         _consts(defs, "mark")
         | _consts(defs, "select")


### PR DESCRIPTION
62/63 tests worked on windows, not too bad!

<details><summary>Show pytest yelling</summary>
<p>

```py
============================================================================================================================= FAILURES ==============================================================================================================================
__________________________________________________________________________________________________________________ test_schema_surface_is_exported __________________________________________________________________________________________________________________
[gw8] win32 -- Python 3.14.5 C:\Users\danie\AppData\Local\uv\cache\archive-v0\NNBXUR5lJgtWMAsa\Scripts\python.exe

    def test_schema_surface_is_exported():
>       defs = json.loads(SCHEMA.read_text())["definitions"]
                          ^^^^^^^^^^^^^^^^^^

test\test_schema_coverage.py:51: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
C:\Users\danie\AppData\Roaming\uv\python\cpython-3.14-windows-x86_64-none\Lib\pathlib\__init__.py:788: in read_text
    return f.read()
           ^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <encodings.cp1252.IncrementalDecoder object at 0x0000020EB84B79D0>
input = b'{\n  "$ref": "#/definitions/Spec",\n  "$schema": "http://json-schema.org/draft-07/schema#",\n  "definitions": {\n   ...umber"\n        }\n      },\n      "required": [\n        "years"\n      ],\n      "type": "object"\n    }\n  }\n}\n\n', final = True
    def decode(self, input, final=False):
>       return codecs.charmap_decode(input,self.errors,decoding_table)[0]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 18562: character maps to <undefined>

C:\Users\danie\AppData\Roaming\uv\python\cpython-3.14-windows-x86_64-none\Lib\encodings\cp1252.py:23: UnicodeDecodeError
====================================================================================================================== short test summary info ======================================================================================================================
FAILED test/test_schema_coverage.py::test_schema_surface_is_exported - UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 18562: character maps to <undefined>
=================================================================================================================== 1 failed, 62 passed in 3.43s ====================================================================================================================
```

</p>
</details> 