### PR TITLE
chore: fix schema url in `.vscode` settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,6 @@
       "specs/json/*",
       "docs/public/specs/json/*"
     ],
-    "url": "./packages/spec/dist/mosaic-schema.json"
+    "url": "./packages/vgplot/spec/dist/mosaic-schema.json"
   }]
 }


### PR DESCRIPTION
This stops the yelling when opening anything in `specs/json`

<details><summary>Show error</summary>
<p>


<img width="1131" height="288" alt="image" src="https://github.com/user-attachments/assets/711f2cba-2fed-4871-8ae1-51dc9398b7c6" />

</p>
</details> 
