### PR TITLE
fix: Pre-aggregate ORDER BY aggregates.

### DIFF
--- a/packages/mosaic/core/src/preagg/PreAggregator.ts
+++ b/packages/mosaic/core/src/preagg/PreAggregator.ts
@@ -334,7 +334,7 @@ function preaggregateInfo(
   preaggCols: PreAggColumnsResult,
   schema: string
 ): PreAggregateInfo {
-  const { groupby, having, output, preagg, qualify } = preaggCols;
+  const { groupby, having, orderby, output, preagg, qualify } = preaggCols;
   const { columns = {} } = active;
 
   // build materialized view construction query
@@ -366,7 +366,7 @@ function preaggregateInfo(
     .setGroupby(groupby)
     .setHaving(having)
     .setQualify(qualify)
-    .setOrderby(replaceIndices(query._orderby, query._select))
+    .setOrderby(replaceIndices(orderby, query._select))
     .sample(null);
   select._with = [];
   select.setWhere();

--- a/packages/mosaic/core/src/preagg/preagg-columns.ts
+++ b/packages/mosaic/core/src/preagg/preagg-columns.ts
@@ -12,6 +12,8 @@ export interface PreAggColumnsResult {
   output: Record<string, ExprNode>;
   // Group by dimension aliases
   groupby: string[]
+  // ORDER BY clause expressions, potentially rewritten for preaggregation
+  orderby: ExprNode[];
   // HAVING clause expressions, potentially rewritten for preaggregation
   having: ExprNode[];
   // QUALIFY clause expressions, potentially rewritten for preaggregation
@@ -73,6 +75,10 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
     // bail if select clause has no aggregates
     if (!aggrs.size) return null;
 
+    // analyze any orderby expressions
+    const orderby = q._orderby
+      .map(expr => analyzeExpression(expr, aggrs, preagg, avg) ?? expr);
+
     // analyze any having expressions
     const having = q._having
       .map(expr => analyzeExpression(expr, aggrs, preagg, avg) ?? expr);
@@ -96,6 +102,7 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
 
     return {
       groupby: Object.values(groupby),
+      orderby,
       preagg,
       output,
       having,

--- a/packages/mosaic/core/src/preagg/preagg-columns.ts
+++ b/packages/mosaic/core/src/preagg/preagg-columns.ts
@@ -72,9 +72,6 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
       }
     }
 
-    // bail if select clause has no aggregates
-    if (!aggrs.size) return null;
-
     // analyze any orderby expressions
     const orderby = q._orderby
       .map(expr => analyzeExpression(expr, aggrs, preagg, avg) ?? expr);
@@ -86,6 +83,9 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
     // analyze any qualify expressions
     const qualify = q._qualify
       .map(expr => analyzeExpression(expr, aggrs, preagg, avg) ?? expr);
+
+    // bail if query has no aggregates
+    if (!aggrs.size) return null;
 
     // add groupby entries; these may or may not be selected
     let id = 0;

--- a/packages/mosaic/core/test/preaggregator.test.ts
+++ b/packages/mosaic/core/test/preaggregator.test.ts
@@ -223,6 +223,17 @@ describe('PreAggregator', () => {
     expect(await run(query)).toStrictEqual([3.5, true]);
   });
 
+  it('supports queries with aggregate order by expressions', async () => {
+    const query = (predicate: FilterExpr = []) => {
+      return Query.from('testData')
+        .select({ measure: avg('x'), dim: 'dim' })
+        .groupby('dim')
+        .where(predicate)
+        .orderby(sum('y'))
+    };
+    expect(await run(query)).toStrictEqual([3.5, true]);
+  });
+
   it('supports queries with window functions with aggregate inputs', async () => {
     const query = (predicate: FilterExpr = []) => {
       return Query.from('testData')


### PR DESCRIPTION
- Apply pre-aggregate analysis to ORDER BY expressions.
- Update test cases to include ORDER BY aggregate.

Fix #1083 