### PR TITLE
ci: use client-id instead of deprecated app-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7


### PR DESCRIPTION
Addresses

<img width="773" height="293" alt="Screenshot 2026-07-17 at 13 32 19" src="https://github.com/user-attachments/assets/10ebdc98-a2fe-4822-909e-cf70ec6a97b9" />
