### PR TITLE
fix: preserve visible table name in filter pushdown

### DIFF
--- a/packages/mosaic/sql/src/transforms/filter-query.ts
+++ b/packages/mosaic/sql/src/transforms/filter-query.ts
@@ -1,5 +1,7 @@
-import { SCALAR_SUBQUERY } from '../constants.js';
+import { COLUMN_PARAM, COLUMN_REF, SCALAR_SUBQUERY } from '../constants.js';
 import type { FilterExpr } from '../types.js';
+import { FromClauseNode } from '../ast/from.js';
+import { JoinNode } from '../ast/join.js';
 import { Query } from '../ast/query.js';
 import { isTableRef, type TableRefNode } from '../ast/table-ref.js';
 import { asTableRef } from '../util/ast.js';
@@ -45,13 +47,37 @@ export function filterPushdown(
     filteredName = `_${filteredName}`;
   }
 
-  // rewrite table references to use filtered data
-  walk(clone, (node) => {
+  // rewrite table references to use filtered data, keeping the visible name
+  const visibleName = tableRef.name;
+  walk(clone, (node, parent) => {
     if (node.type === SCALAR_SUBQUERY) {
       return 1; // don't recurse
-    } else if (isTableRef(node) && arrayEquals(node.table, tableRef.table)) {
-      // @ts-expect-error set read-only property
-      node.table = [filteredName];
+    }
+    if (!isTableRef(node) || !arrayEquals(node.table, tableRef.table)) {
+      return;
+    }
+    if (parent?.type === COLUMN_REF || parent?.type === COLUMN_PARAM) {
+      return; // qualifiers bind to the visible name, so leave them as-is
+    }
+
+    // @ts-expect-error set read-only property
+    node.table = [filteredName];
+
+    if (parent instanceof FromClauseNode) {
+      if (!parent.alias) {
+        // @ts-expect-error set read-only property
+        parent.alias = visibleName;
+      }
+    } else if (parent instanceof JoinNode) {
+      // bare join operands have no alias, so wrap to preserve the name
+      const wrapped = new FromClauseNode(node, visibleName);
+      if (parent.left === node) {
+        // @ts-expect-error set read-only property
+        parent.left = wrapped;
+      } else if (parent.right === node) {
+        // @ts-expect-error set read-only property
+        parent.right = wrapped;
+      }
     }
   });
 

--- a/packages/mosaic/sql/test/filter-pushdown.test.ts
+++ b/packages/mosaic/sql/test/filter-pushdown.test.ts
@@ -74,7 +74,7 @@ describe('filterPushdown', () => {
       );
     const f = filterPushdown(q, 't1', gt('num2', 2));
     await expect(f).toBeValidQuery(
-      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT * FROM "_t1" JOIN "t2" USING ("num3")'
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT * FROM "_t1" AS "t1" JOIN "t2" USING ("num3")'
     );
   });
 
@@ -89,6 +89,45 @@ describe('filterPushdown', () => {
     const f = filterPushdown(q, 't1', gt('num2', 2));
     await expect(f).toBeValidQuery(
       'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "T"."num1" AS "num1", "T"."num2" AS "num2", "O"."num3" AS "num3" FROM "_t1" AS "T", "t2" AS "O" WHERE ("T"."num3" = "O"."num3")'
+    );
+  });
+
+  it('preserves columns qualified by the base table name', async () => {
+    const q = Query.select(column('num1', 't1')).from('t1');
+    const f = filterPushdown(q, 't1', gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1"'
+    );
+  });
+
+  it('preserves qualified columns over joined tables', async () => {
+    const q = Query
+      .select(column('num1', 't1'))
+      .from(join('t1', 't2'));
+    const f = filterPushdown(q, 't1', gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1" NATURAL JOIN "t2"'
+    );
+  });
+
+  it('preserves qualified columns over unaliased from clauses', async () => {
+    const q = Query
+      .select(column('num1', 't1'))
+      .from(new FromClauseNode(new TableRefNode('t1')));
+    const f = filterPushdown(q, 't1', gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1"'
+    );
+  });
+
+  it('preserves qualified columns in filter criteria', async () => {
+    const q = Query
+      .select('*')
+      .from('t1')
+      .where(eq(column('num1', 't1'), 1));
+    const f = filterPushdown(q, 't1', gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT * FROM "_t1" AS "t1" WHERE ("t1"."num1" = 1)'
     );
   });
 


### PR DESCRIPTION
# Description

Went with the fix suggested in #1074: keep every rewritten source under its original visible name, so column qualifiers never need rewriting at all.

## Summary of changes:

- **`filter-query.ts`**: uses the `parent` argument of `walk`, which wasn't used before. Skips refs under `COLUMN_REF`/`COLUMN_PARAM`, aliases an unaliased `FromClauseNode` back to the original name, and wraps bare join operands in `FromClauseNode(ref, name)`. The filtered source is then visible as `t1` everywhere, so `t1` qualifiers bind.

- **`filter-pushdown.test.ts`**: four new cases, plus an updated expectation in `updates explicit joins`.

## What this actually fixes

Two of the four cases produced SQL that DuckDB rejects. Those are the bug:

```diff
# column qualified by the base table name (the case in the issue)
- SELECT "_t1"."num1" AS "num1" FROM "_t1" AS "t1"     Binder Error: Referenced table "_t1" not found!
+ SELECT "t1"."num1"  AS "num1" FROM "_t1" AS "t1"

# same thing in a WHERE clause, not in the original report
- SELECT * FROM "_t1" AS "t1" WHERE ("_t1"."num1" = 1)  Binder Error: Referenced table "_t1" not found!
+ SELECT * FROM "_t1" AS "t1" WHERE ("t1"."num1"  = 1)
```

The other two cases were already valid before this change and are still valid after. They are here as regression guards, because the naive fix (just skipping qualifier rewrites) would break them. Their generated SQL does change shape, since the source now carries an alias:

```diff
# bare join operand
- SELECT "_t1"."num1" AS "num1" FROM "_t1" NATURAL JOIN "t2"
+ SELECT "t1"."num1"  AS "num1" FROM "_t1" AS "t1" NATURAL JOIN "t2"

# unaliased FromClauseNode
- SELECT "_t1"."num1" AS "num1" FROM "_t1"
+ SELECT "t1"."num1"  AS "num1" FROM "_t1" AS "t1"
```

The existing `updates explicit joins` case changes for the same reason, which is why its expected SQL is updated here. It was valid before and is valid after:

```diff
- FROM "_t1" JOIN "t2" USING ("num3")
+ FROM "_t1" AS "t1" JOIN "t2" USING ("num3")
```

So in short 2 invalid queries fixed, 3 valid queries reshaped. 

## Testing

`mosaic-sql` suite passes (263 tests), plus `tsc --build` and lint.

I checked the bug is still present on current main by reverting only `filter-query.ts` and re-running. The tests fail on the serialized SQL before the binder is reached, so what we get to see is a string mismatch, but the SQL they report receiving is the invalid SQL: running the two `"_t1"."num1"` queries through DuckDB directly gives `Binder Error: Referenced table "_t1" not found!`.

Closes #1074.