### PR TITLE
feat: Add QueryError, preagg update fallback.

### DIFF
--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -251,7 +251,6 @@ export class Coordinator {
         data => client.queryResult(data).update(),
         err => {
           const e = new QueryError(err, query);
-          console.warn(`${e}`);
           this._logger?.error(e);
           client.queryError(e);
           return e;

--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -402,13 +402,13 @@ function updateSelection(
 
     if (info) {
       // skip due to cross-filtering
-      if (info?.skip) return;
+      if (info.skip) return;
       // generate and issue preaggregate update query
-      const query = (info as PreAggregateInfo)?.query(active);
+      const query = (info as PreAggregateInfo).query(active);
       const result = await mc.updateClient(client, query);
-      // if preaggregation fails, fall through to standard query
-      // this safeguards against any preagg bugs
       if (!(result instanceof QueryError)) return;
+      // if preaggregate update fails, fall through to standard query
+      // this safeguards against potential preagg bugs
     }
 
     // generate and issue standard query

--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -11,6 +11,7 @@ import { type MosaicClient } from './MosaicClient.js';
 import { type SelectionClause } from './SelectionClause.js';
 import { MaybeArray } from '@uwdata/mosaic-sql';
 import { Table } from '@uwdata/flechette';
+import { QueryError } from './util/query-error.js';
 
 interface FilterGroupEntry {
   selection: Selection;
@@ -248,7 +249,13 @@ export class Coordinator {
     return client._pending = this.query(query, { priority })
       .then(
         data => client.queryResult(data).update(),
-        err => { this._logger?.error(err); client.queryError(err); }
+        err => {
+          const e = new QueryError(err, query);
+          console.warn(`${e}`);
+          this._logger?.error(e);
+          client.queryError(e);
+          return e;
+        }
       )
       .catch(err => this._logger?.error(err));
   }
@@ -383,20 +390,32 @@ function updateSelection(
   const { active } = selection;
   return Promise.allSettled(Array.from(clients, async (client: MosaicClient) => {
     // if client is not enabled, register a request for later
-    if (!client.enabled) return client.requestQuery();
+    if (!client.enabled) {
+      await client.requestQuery();
+      return;
+    }
 
     // if client is initializing, wait for it to complete
     if (!client.initialized) await client.pending;
 
     // check if we can handle selection update via preaggregation
     const info = preaggregator.request(client, selection, active);
-    const filter = info ? null : selection.predicate(client);
 
+    if (info) {
+      // skip due to cross-filtering
+      if (info?.skip) return;
+      // generate and issue preaggregate update query
+      const query = (info as PreAggregateInfo)?.query(active);
+      const result = await mc.updateClient(client, query);
+      // if preaggregation fails, fall through to standard query
+      // this safeguards against any preagg bugs
+      if (!(result instanceof QueryError)) return;
+    }
+
+    // generate and issue standard query
+    const filter = selection.predicate(client);
     // skip due to cross-filtering
-    if (info?.skip || (!info && !filter)) return;
-
-    // generate and issue update query    
-    const query = (info as PreAggregateInfo)?.query(active) ?? client.query(filter);
-    return mc.updateClient(client, query);
+    if (!filter) return; 
+    await mc.updateClient(client, client.query(filter)!);
   }));
 }

--- a/packages/mosaic/core/src/MosaicClient.ts
+++ b/packages/mosaic/core/src/MosaicClient.ts
@@ -2,6 +2,7 @@ import { FilterExpr, type Query } from '@uwdata/mosaic-sql';
 import { type Coordinator } from './Coordinator.js';
 import { type Selection } from './Selection.js';
 import { throttle } from './util/throttle.js';
+import { QueryError } from './util/query-error.js';
 
 export type ClientQuery = Query | string | null;
 
@@ -166,7 +167,7 @@ export class MosaicClient {
    * @param error
    * @returns this
    */
-  queryError(error: Error): this { // eslint-disable-line @typescript-eslint/no-unused-vars
+  queryError(error: QueryError): this { // eslint-disable-line @typescript-eslint/no-unused-vars
     // do nothing, the coordinator logs the error
     return this;
   }

--- a/packages/mosaic/core/src/index.ts
+++ b/packages/mosaic/core/src/index.ts
@@ -35,6 +35,7 @@ export type { Arrayish, DataColumns } from './util/to-data-columns.js';
 export { queryFieldInfo } from './util/field-info.js';
 export { jsType } from './util/js-type.js';
 export { isActivatable } from './util/is-activatable.js';
+export { QueryError } from './util/query-error.js';
 export type { QueryResult } from './util/query-result.js';
 
 export * from './types.js';

--- a/packages/mosaic/core/src/make-client.ts
+++ b/packages/mosaic/core/src/make-client.ts
@@ -1,8 +1,9 @@
-import type { Coordinator } from './Coordinator.js';
-import type { Selection } from './Selection.js';
 import type { FilterExpr } from '@uwdata/mosaic-sql';
-import { type ClientQuery, MosaicClient } from './MosaicClient.js';
+import type { Coordinator } from './Coordinator.js';
 import { coordinator as defaultCoordinator } from './Coordinator.js';
+import { type ClientQuery, MosaicClient } from './MosaicClient.js';
+import type { Selection } from './Selection.js';
+import type { QueryError } from './util/query-error.js';
 
 export interface MakeClientOptions {
   /** Mosaic coordinator. Defaults to the global coordinator. */
@@ -86,7 +87,7 @@ class ProxyClient extends MosaicClient {
     return this;
   }
 
-  queryError(error: Error): this {
+  queryError(error: QueryError): this {
     this._methods.queryError?.(error);
     return this;
   }

--- a/packages/mosaic/core/src/make-client.ts
+++ b/packages/mosaic/core/src/make-client.ts
@@ -24,7 +24,7 @@ export interface MakeClientOptions {
   /** Called by the coordinator to inform the client that a query is pending. */
   queryPending?: () => void;
   /** Called by the coordinator to report a query execution error. */
-  queryError?: (error: Error) => void;
+  queryError?: (error: QueryError) => void;
 }
 
 /**

--- a/packages/mosaic/core/src/util/query-error.ts
+++ b/packages/mosaic/core/src/util/query-error.ts
@@ -1,0 +1,23 @@
+import { QueryType } from "../types.js";
+
+function asError(value: unknown) {
+  return value instanceof Error
+    ? value
+    : new Error(`${value}`);
+}
+
+export class QueryError extends Error {
+  #sql: string;
+
+  get sql() {
+    return this.#sql;
+  }
+
+  constructor(err: unknown, query: QueryType) {
+    const cause = asError(err)
+    const sql = `${query}`;
+    const msg = `${cause.message}\n\nSQL Query: ${sql}`;
+    super(msg, { cause });
+    this.#sql = sql;
+  }
+}


### PR DESCRIPTION
- Add `QueryError` class, which provides access to query SQL and more complete error reporting.
- Use `QueryError` as typed input to client `queryError` method.
- Update selection updates to fallback to standard queries if preaggregate updates fail with a query error.