### PR TITLE
test(python): Enable strict `xfail` for `pytest`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ extend-select = [
 extend-safe-fixes = ["FA", "TC", "UP"]
 ignore = ["G004", "TRY301", "EM102", "EM101", "TRY003", "FBT002", "S608", "TRY002", "ARG001"]
 
+[tool.pytest]
+strict_xfail = true
+
 [dependency-groups]
 dev = [
     "marimo>=0.23.9",


### PR DESCRIPTION
## Description

Related #1088

There aren't any uses of [`@pytest.mark.xfail`](https://docs.pytest.org/en/stable/how-to/skipping.html#xfail-strict-tutorial) yet - so this is an easy one.
The other `pytest` config will be building on the new repo-wide `[tool.pytest]`, but they need some tweaks to the tests too [^1]

[^1]: Follow-up PRs coming soon