### PR TITLE
test(python): Avoid using relative paths

### DIFF
--- a/packages/vgplot/widget/mosaic_widget/tests/test_frame_interop.py
+++ b/packages/vgplot/widget/mosaic_widget/tests/test_frame_interop.py
@@ -1,11 +1,13 @@
 import logging
+from pathlib import Path
 
 import pytest
 from narwhals.typing import IntoFrame
 
 from mosaic_widget.frame_interop import frame_to_duckdb_registrable
 
-CSV_PATH = "../../../data/seattle-weather.csv"
+ROOT = Path(__file__).parent.parent.parent.parent.parent.parent
+CSV_PATH = (ROOT / "data/seattle-weather.csv").as_posix()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Repro
In the repo root try:

```cmd
uv run pytest
```

<details><summary>Show output</summary>
<p>

```py
ERROR packages/vgplot/widget/mosaic_widget/tests/test_frame_interop.py::test_frame_to_duckdb_registrable_lazy[duckdb_frame] - _duckdb.IOException: IO Error: No files found that match the pattern "../../../data/seattle-weather.csv"
ERROR packages/vgplot/widget/mosaic_widget/tests/test_frame_interop.py::test_frame_to_duckdb_registrable_native[pandas_frame] - FileNotFoundError: [Errno 2] No such file or directory: '../../../data/seattle-weather.csv'
ERROR packages/vgplot/widget/mosaic_widget/tests/test_frame_interop.py::test_frame_to_duckdb_registrable_native[pyarrow_frame] - FileNotFoundError: [Errno 2] No such file or directory: '../../../data/seattle-weather.csv'
ERROR packages/vgplot/widget/mosaic_widget/tests/test_frame_interop.py::test_frame_to_duckdb_registrable_native[polars_frame] - FileNotFoundError: The system cannot find the path specified. (os error 3): ../../../data/seattle-weather.csv
ERROR packages/vgplot/widget/mosaic_widget/tests/test_frame_interop.py::test_frame_to_duckdb_registrable_eager[modin_frame] - FileNotFoundError: [Errno 2] No such file or directory: '../../../data/seattle-weather.csv'
ERROR packages/vgplot/widget/mosaic_widget/tests/test_frame_interop.py::test_frame_to_duckdb_registrable_lazy[ibis_frame] - _duckdb.IOException: IO Error: No files found that match the pattern "C:\Users\danie\data\seattle-weather.csv"
ERROR packages/vgplot/widget/mosaic_widget/tests/test_frame_interop.py::test_frame_to_duckdb_registrable_lazy[dask_frame] - FileNotFoundError: An error occurred while calling the read_csv method registered to the pandas backend.
```

</p>
</details> 

## Related
- #1088
- (d9cd8a837165da84443e2556b409c48fe3165785)