### PR TITLE
chore(typing): Add `pyright` and fix errors

### DIFF
--- a/bin/generate-python-api.js
+++ b/bin/generate-python-api.js
@@ -229,7 +229,7 @@ function writeInit() {
     'from .attributes import __all__ as _attr_all\n' +
     'from .encodings import __all__ as _enc_all\n' +
     'from .marks import __all__ as _mark_all\n\n' +
-    '__all__ = [*_mark_all, *_attr_all, *_enc_all]\n');
+    '__all__ = [*_mark_all, *_attr_all, *_enc_all]  # pyright: ignore[reportUnsupportedDunderAll]\n');
 }
 
 const schema = JSON.parse(readFileSync(SCHEMA, 'utf8'));

--- a/packages/server/duckdb-server/pkg/server.py
+++ b/packages/server/duckdb-server/pkg/server.py
@@ -1,31 +1,29 @@
+from __future__ import annotations
+
 import logging
 import sys
 import time
 from functools import partial
+from typing import TYPE_CHECKING, Any, Protocol
 
 import ujson
 from socketify import App, CompressOptions, OpCode
-import duckdb
 
 from pkg.query import get_arrow_bytes, get_json, retrieve
+
+if TYPE_CHECKING:
+    import duckdb
 
 logger = logging.getLogger(__name__)
 
 SLOW_QUERY_THRESHOLD = 5000
 
 
-class Handler:
-    def done(self):
-        raise Exception("NotImplementedException")
-
-    def arrow(self, buffer):
-        raise Exception("NotImplementedException")
-
-    def json(self, data):
-        raise Exception("NotImplementedException")
-
-    def error(self, error):
-        raise Exception("NotImplementedException")
+class Handler(Protocol):
+    def done(self) -> None: ...
+    def arrow(self, buffer: Any) -> None: ...
+    def json(self, data: Any) -> None: ...
+    def error(self, error: Any) -> None: ...
 
 
 class SocketHandler(Handler):
@@ -36,19 +34,19 @@ class SocketHandler(Handler):
         if not ok:
             logger.warning(f"WebSocket backpressure: {self.ws.get_buffered_amount()}")
 
-    def done(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def done(self):
         ok = self.ws.send({}, OpCode.TEXT)
         self.check(ok)
 
-    def arrow(self, buffer):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def arrow(self, buffer):
         ok = self.ws.send(buffer, OpCode.BINARY)
         self.check(ok)
 
-    def json(self, data):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def json(self, data):
         ok = self.ws.send(data, OpCode.TEXT)
         self.check(ok)
 
-    def error(self, error):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def error(self, error):
         ok = self.ws.send({"error": str(error)}, OpCode.TEXT)
         self.check(ok)
 
@@ -57,18 +55,18 @@ class HTTPHandler(Handler):
     def __init__(self, res):
         self.res = res
 
-    def done(self):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def done(self):
         self.res.end("")
 
-    def arrow(self, buffer):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def arrow(self, buffer):
         self.res.write_header("Content-Type", "application/octet-stream")
         self.res.end(buffer)
 
-    def json(self, data):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def json(self, data):
         self.res.write_header("Content-Type", "application/json")
         self.res.end(data)
 
-    def error(self, error):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def error(self, error):
         self.res.write_status(500)
         self.res.end(str(error))
 

--- a/packages/server/duckdb-server/pkg/server.py
+++ b/packages/server/duckdb-server/pkg/server.py
@@ -36,19 +36,19 @@ class SocketHandler(Handler):
         if not ok:
             logger.warning(f"WebSocket backpressure: {self.ws.get_buffered_amount()}")
 
-    def done(self):
+    def done(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         ok = self.ws.send({}, OpCode.TEXT)
         self.check(ok)
 
-    def arrow(self, buffer):
+    def arrow(self, buffer):  # pyright: ignore[reportIncompatibleMethodOverride]
         ok = self.ws.send(buffer, OpCode.BINARY)
         self.check(ok)
 
-    def json(self, data):
+    def json(self, data):  # pyright: ignore[reportIncompatibleMethodOverride]
         ok = self.ws.send(data, OpCode.TEXT)
         self.check(ok)
 
-    def error(self, error):
+    def error(self, error):  # pyright: ignore[reportIncompatibleMethodOverride]
         ok = self.ws.send({"error": str(error)}, OpCode.TEXT)
         self.check(ok)
 
@@ -57,18 +57,18 @@ class HTTPHandler(Handler):
     def __init__(self, res):
         self.res = res
 
-    def done(self):
+    def done(self):  # pyright: ignore[reportIncompatibleMethodOverride]
         self.res.end("")
 
-    def arrow(self, buffer):
+    def arrow(self, buffer):  # pyright: ignore[reportIncompatibleMethodOverride]
         self.res.write_header("Content-Type", "application/octet-stream")
         self.res.end(buffer)
 
-    def json(self, data):
+    def json(self, data):  # pyright: ignore[reportIncompatibleMethodOverride]
         self.res.write_header("Content-Type", "application/json")
         self.res.end(data)
 
-    def error(self, error):
+    def error(self, error):  # pyright: ignore[reportIncompatibleMethodOverride]
         self.res.write_status(500)
         self.res.end(str(error))
 

--- a/packages/vgplot/vgplot-python/pyproject.toml
+++ b/packages/vgplot/vgplot-python/pyproject.toml
@@ -31,7 +31,3 @@ pattern = "\"version\": \"(?P<version>.+?)\""
 
 [tool.hatch.build.targets.wheel]
 packages = ["vgplot"]
-
-[tool.pyright]
-ignore = ["../**/.venv/"]  # Do not display diagnostics in external source code
-typeCheckingMode = "standard"

--- a/packages/vgplot/vgplot-python/tests/test_python_api.py
+++ b/packages/vgplot/vgplot-python/tests/test_python_api.py
@@ -101,7 +101,6 @@ class TestDataFrames:
         assert d["plot"][1]["data"] == {"from": "athletes"}
         assert d["data"]["weather"] is weather
         assert d["data"]["athletes"] == {"type": "csv", "file": "athletes.csv"}
-        vg.params
 
 
 if TYPE_CHECKING:

--- a/packages/vgplot/vgplot-python/tests/test_python_api.py
+++ b/packages/vgplot/vgplot-python/tests/test_python_api.py
@@ -1,5 +1,7 @@
 # Unit tests for the vgplot Python API, covering behaviors that the
 # generated-spec round-trip suite does not exercise directly.
+from typing import TYPE_CHECKING
+
 import pytest
 
 import vgplot as vg
@@ -99,3 +101,18 @@ class TestDataFrames:
         assert d["plot"][1]["data"] == {"from": "athletes"}
         assert d["data"]["weather"] is weather
         assert d["data"]["athletes"] == {"type": "csv", "file": "athletes.csv"}
+        vg.params
+
+
+if TYPE_CHECKING:
+
+    def typing_dunder_all() -> None:
+        # Ok
+        vg.arrow
+        vg.errorbar_x
+        vg.mark
+
+        # TODO @dangotbanned: Get pyright to error on these
+        # Error (`_generated` modules)
+        vg.attributes  # ty: ignore[unresolved-attribute]
+        vg.marks  # ty: ignore[unresolved-attribute]

--- a/packages/vgplot/vgplot-python/vgplot/_generated/__init__.py
+++ b/packages/vgplot/vgplot-python/vgplot/_generated/__init__.py
@@ -7,4 +7,4 @@ from .attributes import __all__ as _attr_all
 from .encodings import __all__ as _enc_all
 from .marks import __all__ as _mark_all
 
-__all__ = [*_mark_all, *_attr_all, *_enc_all]
+__all__ = [*_mark_all, *_attr_all, *_enc_all]  # pyright: ignore[reportUnsupportedDunderAll]

--- a/packages/vgplot/widget/mosaic_widget/__init__.py
+++ b/packages/vgplot/widget/mosaic_widget/__init__.py
@@ -103,10 +103,10 @@ class MosaicWidget(anywidget.AnyWidget):
                     f"spec must be a dict or have a to_dict() method, got {type(spec)}"
                 )
             try:
-                spec = to_dict(_context=caller_locals)
+                spec = to_dict(_context=caller_locals)  # pyright: ignore[reportAssignmentType]
             except TypeError:
-                spec = to_dict()
-        spec = _register_frame_data(spec, data)
+                spec = to_dict()  # pyright: ignore[reportAssignmentType]
+        spec = _register_frame_data(spec, data)  # pyright: ignore[reportArgumentType]
         if con is None:
             con = duckdb.connect()
 

--- a/packages/vgplot/widget/mosaic_widget/__init__.py
+++ b/packages/vgplot/widget/mosaic_widget/__init__.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 import time
 import warnings
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import anywidget
 import duckdb
@@ -19,7 +19,7 @@ from mosaic_widget.frame_interop import (
 
 if TYPE_CHECKING:
     from narwhals.typing import IntoFrame
-
+    from typing_extensions import TypeIs
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -28,7 +28,12 @@ SLOW_QUERY_THRESHOLD = 5000
 
 
 class SupportsToDict(Protocol):
-    def to_dict(self) -> dict: ...
+    def to_dict(self, *, _context: dict[str, Any] | None = None) -> dict[str, Any]: ...
+
+
+def _has_to_dict(obj: Any) -> TypeIs[SupportsToDict]:
+    _sentinel = object()
+    return inspect.getattr_static(obj, "to_dict", _sentinel) is not _sentinel
 
 
 def _register_frame_data(spec: dict, data: dict) -> dict:
@@ -72,12 +77,12 @@ class MosaicWidget(anywidget.AnyWidget):
 
     def __init__(
         self,
-        spec: dict | SupportsToDict | None = None,
+        spec: dict[str, Any] | SupportsToDict | None = None,
         con: duckdb.DuckDBPyConnection | None = None,
         data: dict[str, IntoFrame] | None = None,
         *args,
         **kwargs,
-    ):
+    ) -> None:
         """Create a Mosaic widget.
 
         Args:
@@ -97,15 +102,15 @@ class MosaicWidget(anywidget.AnyWidget):
         if spec is None:
             spec = {}
         elif not isinstance(spec, dict):
-            to_dict = getattr(spec, "to_dict", None)
-            if not callable(to_dict):
-                raise TypeError(
+            if not _has_to_dict(spec):
+                msg = (
                     f"spec must be a dict or have a to_dict() method, got {type(spec)}"
                 )
+                raise TypeError(msg)
             try:
-                spec = to_dict(_context=caller_locals)  # pyright: ignore[reportAssignmentType]
+                spec = spec.to_dict(_context=caller_locals)
             except TypeError:
-                spec = to_dict()  # pyright: ignore[reportAssignmentType]
+                spec = spec.to_dict()
         spec = _register_frame_data(spec, data)  # pyright: ignore[reportArgumentType]
         if con is None:
             con = duckdb.connect()

--- a/packages/vgplot/widget/mosaic_widget/__init__.py
+++ b/packages/vgplot/widget/mosaic_widget/__init__.py
@@ -100,23 +100,23 @@ class MosaicWidget(anywidget.AnyWidget):
         frame = inspect.currentframe()
         caller_locals = frame.f_back.f_locals if frame and frame.f_back else {}
         if spec is None:
-            spec = {}
-        elif not isinstance(spec, dict):
-            if not _has_to_dict(spec):
-                msg = (
-                    f"spec must be a dict or have a to_dict() method, got {type(spec)}"
-                )
-                raise TypeError(msg)
+            spec_: dict[str, Any] = {}
+        elif _has_to_dict(spec):
             try:
-                spec = spec.to_dict(_context=caller_locals)
+                spec_ = spec.to_dict(_context=caller_locals)
             except TypeError:
-                spec = spec.to_dict()
-        spec = _register_frame_data(spec, data)
+                spec_ = spec.to_dict()
+        elif isinstance(spec, dict):
+            spec_ = spec
+        else:
+            msg = f"spec must be a dict or have a to_dict() method, got {type(spec)}"
+            raise TypeError(msg)
+        spec_ = _register_frame_data(spec_, data)
         if con is None:
             con = duckdb.connect()
 
         super().__init__(*args, **kwargs)
-        self.spec = spec
+        self.spec = spec_
         self.con = con
         self._registered_tables: set[str] = set()
         for name, df in data.items():

--- a/packages/vgplot/widget/mosaic_widget/__init__.py
+++ b/packages/vgplot/widget/mosaic_widget/__init__.py
@@ -36,7 +36,7 @@ def _has_to_dict(obj: Any) -> TypeIs[SupportsToDict]:
     return inspect.getattr_static(obj, "to_dict", _sentinel) is not _sentinel
 
 
-def _register_frame_data(spec: dict, data: dict) -> dict:
+def _register_frame_data(spec: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
     """Move in-memory DataFrames out of the spec's data section into `data`.
 
     The spec is synced to the frontend as JSON and cannot carry live frames, so
@@ -111,7 +111,7 @@ class MosaicWidget(anywidget.AnyWidget):
                 spec = spec.to_dict(_context=caller_locals)
             except TypeError:
                 spec = spec.to_dict()
-        spec = _register_frame_data(spec, data)  # pyright: ignore[reportArgumentType]
+        spec = _register_frame_data(spec, data)
         if con is None:
             con = duckdb.connect()
 

--- a/packages/vgplot/widget/mosaic_widget/frame_interop.py
+++ b/packages/vgplot/widget/mosaic_widget/frame_interop.py
@@ -13,7 +13,7 @@ def is_registrable_frame(obj: object) -> bool:
     ):
         return False
     try:
-        nw.from_native(obj)  # ty: ignore[no-matching-overload]
+        nw.from_native(obj)  # pyright: ignore[reportArgumentType, reportCallIssue] # ty: ignore[no-matching-overload]
     except TypeError:
         return False
     return True

--- a/packages/vgplot/widget/mosaic_widget/frame_interop.py
+++ b/packages/vgplot/widget/mosaic_widget/frame_interop.py
@@ -1,24 +1,32 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING, Any, TypeAlias
+
 import narwhals as nw
-from narwhals.typing import IntoFrame
+from narwhals.dependencies import is_into_dataframe, is_into_lazyframe
+
+if TYPE_CHECKING:
+    from narwhals.typing import IntoDataFrame, IntoLazyFrame
+    from typing_extensions import TypeIs
+
+    IntoFrame: TypeAlias = IntoDataFrame | IntoLazyFrame
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def is_registrable_frame(obj: object) -> bool:
+_NON_FRAME_TYPES = (str, bytes, int, float, bool, dict, list, tuple, type(None))
+
+
+def is_registrable_frame(obj: Any) -> TypeIs[IntoFrame]:
     """Return True if `obj` is a dataframe-like object that DuckDB can register."""
-    if obj is None or isinstance(
-        obj, (str, bytes, int, float, bool, dict, list, tuple)
-    ):
-        return False
-    try:
-        nw.from_native(obj)  # pyright: ignore[reportArgumentType, reportCallIssue] # ty: ignore[no-matching-overload]
-    except TypeError:
-        return False
-    return True
+    return not isinstance(obj, _NON_FRAME_TYPES) and (
+        is_into_dataframe(obj) or is_into_lazyframe(obj)
+    )
 
 
+# TODO @dangotbanned: Replace with Narwhals
 def _is_frame_native_to_duckdb(frame: IntoFrame) -> bool:
     """Check if a frame is natively supported by DuckDB to be registered as a virtual table with zero-copy guarantees."""
 
@@ -29,6 +37,7 @@ def _is_frame_native_to_duckdb(frame: IntoFrame) -> bool:
     return frame_backend in backends_with_native_virtual_table_support
 
 
+# TODO @dangotbanned: Avoid materializing `DuckDBPyRelation`
 def frame_to_duckdb_registrable(frame: IntoFrame) -> object:
     """Converts a native dataframe(-like) object to a DuckDB-registrable object.
 

--- a/packages/vgplot/widget/mosaic_widget/tests/test_spec_input.py
+++ b/packages/vgplot/widget/mosaic_widget/tests/test_spec_input.py
@@ -44,7 +44,7 @@ def test_spec_object_with_context_receives_caller_locals():
 
 # NOTE: Reporting a diagnostic is correct, because the implementation accepts this object by catching a `TypeError`
 def test_spec_object_without_context_falls_back() -> None:
-    widget = MosaicWidget(SpecWithoutContext())  # pyright: ignore[reportArgumentType]
+    widget = MosaicWidget(SpecWithoutContext())  # pyright: ignore[reportArgumentType]  # ty:ignore[invalid-argument-type]
     assert widget.spec == {"plot": [], "seen": "plain"}
 
 

--- a/packages/vgplot/widget/mosaic_widget/tests/test_spec_input.py
+++ b/packages/vgplot/widget/mosaic_widget/tests/test_spec_input.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 
 from mosaic_widget import MosaicWidget
@@ -56,10 +60,10 @@ class FrameDataSpec:
     marks reference them by name. The widget's job is to register the frames.
     """
 
-    def __init__(self, data):
+    def __init__(self, data: dict[str, Any]):
         self._data = data
 
-    def to_dict(self, _context=None):
+    def to_dict(self, *, _context=None):
         marks = [{"mark": "dot", "data": {"from": name}} for name in self._data]
         return {"plot": marks, "data": dict(self._data)}
 

--- a/packages/vgplot/widget/mosaic_widget/tests/test_spec_input.py
+++ b/packages/vgplot/widget/mosaic_widget/tests/test_spec_input.py
@@ -42,8 +42,9 @@ def test_spec_object_with_context_receives_caller_locals():
     assert any(v is marker for v in spec_obj.received_context.values())
 
 
-def test_spec_object_without_context_falls_back():
-    widget = MosaicWidget(SpecWithoutContext())
+# NOTE: Reporting a diagnostic is correct, because the implementation accepts this object by catching a `TypeError`
+def test_spec_object_without_context_falls_back() -> None:
+    widget = MosaicWidget(SpecWithoutContext())  # pyright: ignore[reportArgumentType]
     assert widget.spec == {"plot": [], "seen": "plain"}
 
 

--- a/packages/vgplot/widget/mosaic_widget/tests/test_spec_input.py
+++ b/packages/vgplot/widget/mosaic_widget/tests/test_spec_input.py
@@ -46,7 +46,7 @@ def test_spec_object_without_context_falls_back():
 def test_object_without_to_dict_raises():
     with pytest.raises(TypeError, match="to_dict"):
         # An object without to_dict() is intentionally invalid input.
-        MosaicWidget(object())  # ty: ignore[invalid-argument-type]
+        MosaicWidget(object())  # pyright: ignore[reportArgumentType] # ty: ignore[invalid-argument-type]
 
 
 class FrameDataSpec:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,19 @@ ignore = ["G004", "TRY301", "EM102", "EM101", "TRY003", "FBT002", "S608", "TRY00
 [tool.pytest]
 strict_xfail = true
 
+[tool.pyright]
+include = [
+    "packages/server/duckdb-server/**/*.py",
+    "packages/vgplot/widget/**/*.py",
+    "packages/vgplot/vgplot-python/**/*.py",
+    "dev/notebooks/weather.py",
+    "specs/python/*.py",
+]
+ignore = ["**/.venv/", "../../../**/*typeshed*"]  # Do not display diagnostics in external source code
+typeCheckingMode = "standard"
+reportUnnecessaryTypeIgnoreComment = "error"
+reportUnusedExpression = "none" # covered by ruff
+
 [dependency-groups]
 dev = [
     "marimo>=0.23.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ strict_xfail = true
 [tool.pyright]
 include = [
     "packages/server/duckdb-server/**/*.py",
-    "packages/vgplot/widget/**/*.py",
+    "packages/vgplot/widget/mosaic_widget/**/*.py",
     "packages/vgplot/vgplot-python/**/*.py",
     "dev/notebooks/weather.py",
     "specs/python/*.py",


### PR DESCRIPTION
## Description
Main goal is to avoid red squiggles if a contributor opens a `.py` file in the workspace [^1].

**Where were the issues?**
See (a09f82b8e210afd1ef614a67f84395fd74e25c2f)

**How do we fix them?**
*I'm working on it*

[^1]: While using VSCode and [Pylance](https://github.com/microsoft/pylance-release)

## Possible `__all__` follow-up
I can fix this here, *but* the diff will be 98% related to it.
Did mention before (https://github.com/uwdata/mosaic/pull/1068#discussion_r3543675753) that fixing it is important:

<details><summary>Show <code>[reportUnsupportedDunderAll]</code></summary>
<p>

```py
mosaic/packages/vgplot/vgplot-python/vgplot/_generated/__init__.py:10:1
warning: Operation on "__all__" is not supported, so exported symbol list may be incorrect (reportUnsupportedDunderAll)
0 errors, 1 warning, 0 informations
```

</p>
</details>

There are many forms which are specified in [Typing spec - Library interface (public and private symbols)](https://typing.python.org/en/latest/spec/distributing.html#library-interface-public-and-private-symbols).
Which forms are supported by each type checker[^2] **vary** and so a major issue in downstream projects is incomplete/invalid export definitions.

[^2]: aaaaaaand now there are [7 type checkers](https://htmlpreview.github.io/?https://github.com/python/typing/blob/main/conformance/results/results.html) 🫠 



### Example

This code will fail at runtime:
```py
def check_exports_bad() -> None:
    import vgplot

    _not_really_there = vgplot.attributes.align

check_exports_bad()
```
```py
AttributeError: module 'vgplot' has no attribute 'attributes'
```

#### Pyright
Because it doesn't understand the `__all__` definition *fully*, it is inferring that `_generated.attributes.py` is available at the top level.
So it thinks that was valid and here you can see "Go to definition":

<img width="1085" height="390" alt="image" src="https://github.com/user-attachments/assets/b515055f-86cc-4799-ae35-aa0d53b2aa9e" />


#### ty
However, with `ty` this is correctly reported as an error:

```rust
error[unresolved-attribute]: Module `vgplot` has no member `attributes`
   --> packages/vgplot/vgplot-python/tests/test_python_api.py:480:25
    |
480 |     _not_really_there = vgplot.attributes.align
    |                         ^^^^^^^^^^^^^^^^^
    |

Found 1 diagnostic
```

#### Others
- (https://github.com/facebook/pyrefly) matches `ty`
- (https://github.com/python/mypy) doesn't recognise anything in `__all__`
    - It reports `attributes` as an error, but also **316 others** that are in the runtime definition

## Related
- #1088
- https://github.com/microsoft/pyright
- https://github.com/vega/altair/pull/3482