### PR TITLE
docs: Mention python in examples overview

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,7 +1,7 @@
 # Examples
 
 Mosaic-powered visualizations created with [vgplot](/vgplot/).
-These visualizations can be specified using a JavaScript API, or in a standalone YAML or JSON file. Each example includes code for all three specification formats.
+These visualizations can be specified using a JavaScript or Python API, or in a standalone YAML or JSON file. Each example includes code for all four specification formats.
 
 For example, here is a line chart of historical Apple stock prices:
 


### PR DESCRIPTION
The examples are there, why not shout about it?