### PR TITLE
fix: preserve visible table name in filter pushdown

### DIFF
--- a/packages/mosaic/sql/src/transforms/filter-query.ts
+++ b/packages/mosaic/sql/src/transforms/filter-query.ts
@@ -1,5 +1,7 @@
-import { SCALAR_SUBQUERY } from '../constants.js';
+import { COLUMN_PARAM, COLUMN_REF, SCALAR_SUBQUERY } from '../constants.js';
 import type { FilterExpr } from '../types.js';
+import { FromClauseNode } from '../ast/from.js';
+import { JoinNode } from '../ast/join.js';
 import { Query } from '../ast/query.js';
 import { isTableRef, type TableRefNode } from '../ast/table-ref.js';
 import { asTableRef } from '../util/ast.js';
@@ -45,13 +47,37 @@ export function filterPushdown(
     filteredName = `_${filteredName}`;
   }
 
-  // rewrite table references to use filtered data
-  walk(clone, (node) => {
+  // rewrite table references to use filtered data, keeping the visible name
+  const visibleName = tableRef.name;
+  walk(clone, (node, parent) => {
     if (node.type === SCALAR_SUBQUERY) {
       return 1; // don't recurse
-    } else if (isTableRef(node) && arrayEquals(node.table, tableRef.table)) {
-      // @ts-expect-error set read-only property
-      node.table = [filteredName];
+    }
+    if (!isTableRef(node) || !arrayEquals(node.table, tableRef.table)) {
+      return;
+    }
+    if (parent?.type === COLUMN_REF || parent?.type === COLUMN_PARAM) {
+      return; // qualifiers bind to the visible name, so leave them as-is
+    }
+
+    // @ts-expect-error set read-only property
+    node.table = [filteredName];
+
+    if (parent instanceof FromClauseNode) {
+      if (!parent.alias) {
+        // @ts-expect-error set read-only property
+        parent.alias = visibleName;
+      }
+    } else if (parent instanceof JoinNode) {
+      // bare join operands have no alias, so wrap to preserve the name
+      const wrapped = new FromClauseNode(node, visibleName);
+      if (parent.left === node) {
+        // @ts-expect-error set read-only property
+        parent.left = wrapped;
+      } else if (parent.right === node) {
+        // @ts-expect-error set read-only property
+        parent.right = wrapped;
+      }
     }
   });
 

--- a/packages/mosaic/sql/src/transforms/filter-query.ts
+++ b/packages/mosaic/sql/src/transforms/filter-query.ts
@@ -1,5 +1,6 @@
-import { COLUMN_PARAM, COLUMN_REF, SCALAR_SUBQUERY } from '../constants.js';
+import { SCALAR_SUBQUERY } from '../constants.js';
 import type { FilterExpr } from '../types.js';
+import { ColumnRefNode } from '../ast/column-ref.js';
 import { FromClauseNode } from '../ast/from.js';
 import { JoinNode } from '../ast/join.js';
 import { Query } from '../ast/query.js';
@@ -47,37 +48,31 @@ export function filterPushdown(
     filteredName = `_${filteredName}`;
   }
 
-  // rewrite table references to use filtered data, keeping the visible name
+  // rename table refs to the filtered CTE, keeping each source visible
+  // under its original name so that column qualifiers still bind
   const visibleName = tableRef.name;
   walk(clone, (node, parent) => {
     if (node.type === SCALAR_SUBQUERY) {
       return 1; // don't recurse
     }
     if (!isTableRef(node) || !arrayEquals(node.table, tableRef.table)) {
-      return;
+      return; // not a reference to the filtered table
     }
-    if (parent?.type === COLUMN_REF || parent?.type === COLUMN_PARAM) {
-      return; // qualifiers bind to the visible name, so leave them as-is
+    if (parent instanceof ColumnRefNode) {
+      return; // column qualifiers keep binding to the visible name
     }
-
     // @ts-expect-error set read-only property
     node.table = [filteredName];
-
     if (parent instanceof FromClauseNode) {
       if (!parent.alias) {
         // @ts-expect-error set read-only property
         parent.alias = visibleName;
       }
     } else if (parent instanceof JoinNode) {
-      // bare join operands have no alias, so wrap to preserve the name
-      const wrapped = new FromClauseNode(node, visibleName);
-      if (parent.left === node) {
-        // @ts-expect-error set read-only property
-        parent.left = wrapped;
-      } else if (parent.right === node) {
-        // @ts-expect-error set read-only property
-        parent.right = wrapped;
-      }
+      // a bare join operand can not carry an alias, so wrap it in one
+      const side = parent.left === node ? 'left' : 'right';
+      // @ts-expect-error set read-only property
+      parent[side] = new FromClauseNode(node, visibleName);
     }
   });
 

--- a/packages/mosaic/sql/test/filter-pushdown.test.ts
+++ b/packages/mosaic/sql/test/filter-pushdown.test.ts
@@ -74,7 +74,7 @@ describe('filterPushdown', () => {
       );
     const f = filterPushdown(q, 't1', gt('num2', 2));
     await expect(f).toBeValidQuery(
-      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT * FROM "_t1" JOIN "t2" USING ("num3")'
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT * FROM "_t1" AS "t1" JOIN "t2" USING ("num3")'
     );
   });
 
@@ -89,6 +89,45 @@ describe('filterPushdown', () => {
     const f = filterPushdown(q, 't1', gt('num2', 2));
     await expect(f).toBeValidQuery(
       'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "T"."num1" AS "num1", "T"."num2" AS "num2", "O"."num3" AS "num3" FROM "_t1" AS "T", "t2" AS "O" WHERE ("T"."num3" = "O"."num3")'
+    );
+  });
+
+  it('preserves columns qualified by the base table name', async () => {
+    const q = Query.select(column('num1', 't1')).from('t1');
+    const f = filterPushdown(q, 't1', gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1"'
+    );
+  });
+
+  it('preserves qualified columns over joined tables', async () => {
+    const q = Query
+      .select(column('num1', 't1'))
+      .from(join('t1', 't2'));
+    const f = filterPushdown(q, 't1', gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1" NATURAL JOIN "t2"'
+    );
+  });
+
+  it('preserves qualified columns over unaliased from clauses', async () => {
+    const q = Query
+      .select(column('num1', 't1'))
+      .from(new FromClauseNode(new TableRefNode('t1')));
+    const f = filterPushdown(q, 't1', gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1"'
+    );
+  });
+
+  it('preserves qualified columns in filter criteria', async () => {
+    const q = Query
+      .select('*')
+      .from('t1')
+      .where(eq(column('num1', 't1'), 1));
+    const f = filterPushdown(q, 't1', gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT * FROM "_t1" AS "t1" WHERE ("t1"."num1" = 1)'
     );
   });
 

--- a/packages/mosaic/sql/test/filter-pushdown.test.ts
+++ b/packages/mosaic/sql/test/filter-pushdown.test.ts
@@ -120,6 +120,18 @@ describe('filterPushdown', () => {
     );
   });
 
+  it('preserves qualified columns in join conditions', async () => {
+    const q = Query
+      .select(column('num1', 't1'))
+      .from(join('t1', 't2', {
+        on: eq(column('num3', 't1'), column('num3', 't2'))
+      }));
+    const f = filterPushdown(q, 't1', gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1" JOIN "t2" ON ("t1"."num3" = "t2"."num3")'
+    );
+  });
+
   it('preserves qualified columns in filter criteria', async () => {
     const q = Query
       .select('*')

--- a/packages/mosaic/sql/test/filter-pushdown.test.ts
+++ b/packages/mosaic/sql/test/filter-pushdown.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { column, count, cross_join, div, eq, filterPushdown, FromClauseNode, gt, join, Query, ScalarSubqueryNode, TableRefNode } from '../src/index.js';
+import { column, count, cross_join, div, eq, filterPushdown, FromClauseNode, gt, join, Query, ScalarSubqueryNode, sum, TableRefNode } from '../src/index.js';
 
 describe('filterPushdown', () => {
   it('does nothing given empty filter', async () => {
@@ -92,21 +92,22 @@ describe('filterPushdown', () => {
     );
   });
 
-  it('preserves columns qualified by the base table name', async () => {
-    const q = Query.select(column('num1', 't1')).from('t1');
+  it('updates pivot queries', async () => {
+    const q = Query.pivot('t1').on('num1').using(sum('num2'));
     const f = filterPushdown(q, 't1', gt('num2', 2));
     await expect(f).toBeValidQuery(
-      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1"'
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) PIVOT "_t1" ON "num1" USING sum("num2")'
     );
   });
 
-  it('preserves qualified columns over joined tables', async () => {
+  it('preserves columns qualified by the base table name', async () => {
     const q = Query
       .select(column('num1', 't1'))
-      .from(join('t1', 't2'));
+      .from('t1')
+      .where(eq(column('num1', 't1'), 1));
     const f = filterPushdown(q, 't1', gt('num2', 2));
     await expect(f).toBeValidQuery(
-      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1" NATURAL JOIN "t2"'
+      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1" WHERE ("t1"."num1" = 1)'
     );
   });
 
@@ -129,17 +130,6 @@ describe('filterPushdown', () => {
     const f = filterPushdown(q, 't1', gt('num2', 2));
     await expect(f).toBeValidQuery(
       'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1" JOIN "t2" ON ("t1"."num3" = "t2"."num3")'
-    );
-  });
-
-  it('preserves qualified columns in filter criteria', async () => {
-    const q = Query
-      .select('*')
-      .from('t1')
-      .where(eq(column('num1', 't1'), 1));
-    const f = filterPushdown(q, 't1', gt('num2', 2));
-    await expect(f).toBeValidQuery(
-      'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT * FROM "_t1" AS "t1" WHERE ("t1"."num1" = 1)'
     );
   });
 


### PR DESCRIPTION
Closes https://github.com/uwdata/mosaic/pull/1089. Fixes #1074