### PR TITLE
fix(sql): AST walk skips join conditions

### DIFF
--- a/packages/mosaic/sql/src/visit/recurse.ts
+++ b/packages/mosaic/sql/src/visit/recurse.ts
@@ -57,7 +57,7 @@ export const recurse: Record<string, string[]> = {
   [FROM_CLAUSE]: ['expr'],
   [FUNCTION]: ['args'],
   [IN_OPERATOR]: ['expr', 'values'],
-  [JOIN_CLAUSE]: ['left', 'right', 'on', 'using', 'sample'],
+  [JOIN_CLAUSE]: ['left', 'right', 'condition', 'using', 'sample'],
   [LIST]: ['values'],
   [LOGICAL_OPERATOR]: ['clauses'],
   [NOT_BETWEEN_OPERATOR]: ['expr', 'extent'],

--- a/packages/mosaic/sql/test/visitors.test.ts
+++ b/packages/mosaic/sql/test/visitors.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { abs, add, asVerbatim, collectAggregates, collectColumns, collectParams, column, count, div, isAggregateExpression, Query, ScalarSubqueryNode, sql, sum } from '../src/index.js';
+import { abs, add, asVerbatim, collectAggregates, collectColumns, collectParams, column, count, div, eq, isAggregateExpression, join, Query, ScalarSubqueryNode, sql, sum } from '../src/index.js';
 import { stubParam } from './util/stub-param.js';
 import { validateQuery } from './util/validate.js';
 
@@ -24,6 +24,23 @@ describe('Visitor functions', () => {
 
     const expr2 = sql`(${'a'} + ${'b'}) ${'a'}`;
     expect(collectParams(expr2)).toStrictEqual([]);
+  });
+
+  it('include columns inside a join condition', () => {
+    const q = Query.select('*').from(
+      join('t1', 't2', { on: eq(column('a', 't1'), column('b', 't2')) })
+    );
+    const cols = collectColumns(q).map(c => c.column);
+    expect(cols).toContain('a');
+    expect(cols).toContain('b');
+  });
+
+  it('include params inside a join condition', () => {
+    const p = stubParam(1);
+    const q = Query.select('*').from(
+      join('t1', 't2', { on: eq(column('a', 't1'), p) })
+    );
+    expect(collectParams(q)).toStrictEqual([p]);
   });
 
   it('include aggregate collection', async () => {


### PR DESCRIPTION
## Description

I was poking around in mosaic-sql and noticed that when a query has a JOIN, anything inside the ON condition was being silently skipped. So if a column or a parameter lived inside the join condition, the query analysis just didn't see it. It shows no error, it was quietly dropped.

I reproduced it on the published npm package: I built a query with columns in the join condition, asked for the query's columns back, and the ones from the join condition simply weren't there.


### **Before (published @uwdata/mosaic-sql):** 
The join condition columns "a" and "b" are missing, only "id" from the SELECT shows up.

<img width="670" height="393" alt="image" src="https://github.com/user-attachments/assets/2882fc9a-952f-4eaa-880b-1038c7f54326" />

---

### **After (with the fix):** 
"a" and "b" now show up alongside "id".

<img width="670" height="393" alt="image" src="https://github.com/user-attachments/assets/88a88ba4-d94a-434d-a45d-dc7ed8cda288" />

---
I also added tests so it doesn't slip back.