### PR TITLE
fix(go-server): enforce query policies

### DIFF
--- a/packages/server/duckdb-server-go/internal/query/options.go
+++ b/packages/server/duckdb-server-go/internal/query/options.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"log/slog"
+	"strings"
 	"time"
 )
 
@@ -65,8 +66,12 @@ func WithLogger(logger *slog.Logger) OptionFunc {
 
 func WithFunctionBlocklist(blockedFunctions []string) OptionFunc {
 	return func(opts *Options) error {
-		if len(blockedFunctions) > 0 {
-			opts.FunctionBlocklist = blockedFunctions
+		opts.FunctionBlocklist = make([]string, 0, len(blockedFunctions))
+		for _, function := range blockedFunctions {
+			function = strings.ToLower(strings.TrimSpace(function))
+			if function != "" {
+				opts.FunctionBlocklist = append(opts.FunctionBlocklist, function)
+			}
 		}
 		return nil
 	}

--- a/packages/server/duckdb-server-go/internal/query/query.go
+++ b/packages/server/duckdb-server-go/internal/query/query.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/maphash"
 	"io"
@@ -19,6 +20,8 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+var ErrExecWithValidation = errors.New("query: exec command is disabled when schema or function validation is active")
+
 type DB struct {
 	db *sql.DB
 
@@ -30,7 +33,8 @@ type DB struct {
 	cache     *otter.Cache[uint64, []byte]
 	cacheSeed maphash.Seed
 
-	logger *slog.Logger
+	functionBlocklist []string
+	logger            *slog.Logger
 }
 
 // New creates a new DB instance using the provided DuckDB connector, opening a sql.DB and arrow connection.
@@ -86,7 +90,8 @@ func New(ctx context.Context, connector *duckdb.Connector, opts ...OptionFunc) (
 		cache:     cache,
 		cacheSeed: maphash.MakeSeed(), // Initialize the cache seed for consistent hashing
 
-		logger: o.Logger,
+		functionBlocklist: append([]string(nil), o.FunctionBlocklist...),
+		logger:            o.Logger,
 	}, nil
 }
 
@@ -184,9 +189,33 @@ func (db *DB) Close() {
 }
 
 func (db *DB) Exec(ctx context.Context, query string) error {
+	if len(db.functionBlocklist) > 0 {
+		return ErrExecWithValidation
+	}
+
 	_, err := db.db.ExecContext(ctx, query)
 	if err != nil {
 		return fmt.Errorf("query: failed to execute query: %w", err)
+	}
+
+	return nil
+}
+
+func (db *DB) validateQuery(ctx context.Context, query string, allowedSchemas []string) error {
+	validators := make([]Validator, 0, 2)
+	if len(allowedSchemas) > 0 {
+		validators = append(validators, newBaseTableValidator(allowedSchemas))
+	}
+	if len(db.functionBlocklist) > 0 {
+		validators = append(validators, newFunctionBlocklistValidator(db.functionBlocklist))
+	}
+	if len(validators) == 0 {
+		return nil
+	}
+
+	err := db.ValidateSQL(ctx, query, validators...)
+	if err != nil {
+		return fmt.Errorf("query: validation failed for query: %w", err)
 	}
 
 	return nil
@@ -218,12 +247,9 @@ func (db *DB) QueryJSON(ctx context.Context, query string, allowedSchemas []stri
 }
 
 func (db *DB) WriteJSON(ctx context.Context, query string, allowedSchemas []string, w io.Writer) error {
-	if len(allowedSchemas) > 0 {
-		btValidator := newBaseTableValidator(allowedSchemas)
-		err := db.ValidateSQL(ctx, query, btValidator)
-		if err != nil {
-			return fmt.Errorf("query: validation failed for query: %w", err)
-		}
+	err := db.validateQuery(ctx, query, allowedSchemas)
+	if err != nil {
+		return err
 	}
 
 	arrow, err := db.getArrowConn(ctx)
@@ -299,12 +325,9 @@ func (db *DB) QueryArrow(ctx context.Context, query string, allowedSchemas []str
 }
 
 func (db *DB) WriteArrow(ctx context.Context, query string, allowedSchemas []string, w io.Writer) error {
-	if len(allowedSchemas) > 0 {
-		btValidator := newBaseTableValidator(allowedSchemas)
-		err := db.ValidateSQL(ctx, query, btValidator)
-		if err != nil {
-			return fmt.Errorf("query: validation failed for query: %w", err)
-		}
+	err := db.validateQuery(ctx, query, allowedSchemas)
+	if err != nil {
+		return err
 	}
 
 	arrow, err := db.getArrowConn(ctx)

--- a/packages/server/duckdb-server-go/internal/query/query_test.go
+++ b/packages/server/duckdb-server-go/internal/query/query_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // setupTestDB creates a new in-memory DuckDB instance for testing
-func setupTestDB(t *testing.T) *DB {
+func setupTestDB(t *testing.T, opts ...OptionFunc) *DB {
 	t.Helper()
 
 	ctx := context.Background()
@@ -27,7 +27,8 @@ func setupTestDB(t *testing.T) *DB {
 		Level: slog.LevelError, // Only show errors during tests
 	}))
 
-	db, err := New(ctx, connector, WithLogger(logger))
+	opts = append([]OptionFunc{WithLogger(logger)}, opts...)
+	db, err := New(ctx, connector, opts...)
 	require.NoError(t, err)
 
 	// Clean up when test completes
@@ -40,6 +41,62 @@ func setupTestDB(t *testing.T) *DB {
 	})
 
 	return db
+}
+
+func TestDB_FunctionBlocklist(t *testing.T) {
+	db := setupTestDB(t, WithFunctionBlocklist([]string{" RANGE ", "MD5", "SUM", "ROW_NUMBER"}))
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		function string
+		query    string
+		format   string
+	}{
+		{
+			name:     "JSON table function",
+			function: "range",
+			query:    "SELECT * FROM range(3)",
+			format:   "json",
+		},
+		{
+			name:     "JSON scalar function",
+			function: "md5",
+			query:    "SELECT md5('mosaic')",
+			format:   "json",
+		},
+		{
+			name:     "JSON window aggregate",
+			function: "sum",
+			query:    "SELECT sum(i) OVER () FROM (VALUES (1), (2), (3)) t(i)",
+			format:   "json",
+		},
+		{
+			name:     "JSON window function",
+			function: "row_number",
+			query:    "SELECT row_number() OVER ()",
+			format:   "json",
+		},
+		{
+			name:     "Arrow table function",
+			function: "range",
+			query:    "SELECT * FROM range(3)",
+			format:   "arrow",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			if tt.format == "arrow" {
+				_, _, err = db.QueryArrow(ctx, tt.query, nil, false)
+			} else {
+				_, _, err = db.QueryJSON(ctx, tt.query, nil, false)
+			}
+
+			require.ErrorContains(t, err, "use of function '"+tt.function+"' is not allowed")
+		})
+	}
 }
 
 func TestDB_Exec(t *testing.T) {
@@ -63,6 +120,14 @@ func TestDB_Exec(t *testing.T) {
 		err := db.Exec(ctx, "INVALID SQL STATEMENT")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "query: failed to execute query")
+	})
+
+	t.Run("function validation rejects exec", func(t *testing.T) {
+		db := setupTestDB(t, WithFunctionBlocklist([]string{"range"}))
+
+		err := db.Exec(ctx, "SELECT 1")
+		require.ErrorIs(t, err, ErrExecWithValidation)
+		assert.EqualError(t, err, "query: exec command is disabled when schema or function validation is active")
 	})
 }
 

--- a/packages/server/duckdb-server-go/internal/query/validator.go
+++ b/packages/server/duckdb-server-go/internal/query/validator.go
@@ -205,7 +205,7 @@ func (v *baseTableValidator) Validate() []error {
 	return errs
 }
 
-// functionBlocklistValidator validates that the SQL query only accesses schemas that match request headers
+// functionBlocklistValidator validates that the SQL query does not use blocked functions.
 type functionBlocklistValidator struct {
 	blockedFunctions []string
 	errs             []error
@@ -217,24 +217,12 @@ func newFunctionBlocklistValidator(blockedFunctions []string) Validator {
 	}
 }
 
-func (v *functionBlocklistValidator) CheckNode(node map[string]any, keyStack []string) {
-	if len(keyStack) > 0 && keyStack[len(keyStack)-1] != "function" {
-		return
-	}
-
+func (v *functionBlocklistValidator) CheckNode(node map[string]any, _ []string) {
 	class, exists := node["class"]
 	if !exists {
 		return
 	}
-	if class != "FUNCTION" {
-		return
-	}
-
-	typeVal, exists := node["type"]
-	if !exists {
-		return
-	}
-	if typeVal != "FUNCTION" {
+	if class != "FUNCTION" && class != "WINDOW" {
 		return
 	}
 

--- a/packages/server/duckdb-server-go/internal/server/server.go
+++ b/packages/server/duckdb-server-go/internal/server/server.go
@@ -259,6 +259,9 @@ func (s *Server) execCommand(ctx context.Context, params QueryParams, allowedSch
 
 	switch *params.Type {
 	case CommandExec:
+		if len(s.schemaMatchHeaders) > 0 {
+			return nil, false, query.ErrExecWithValidation
+		}
 		return nil, false, s.db.Exec(ctx, *params.SQL) // No data to return for exec command
 
 	case CommandArrow:

--- a/packages/server/duckdb-server-go/internal/server/server_test.go
+++ b/packages/server/duckdb-server-go/internal/server/server_test.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/duckdb/duckdb-go/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uwdata/mosaic/packages/server/duckdb-server-go/internal/query"
+)
+
+func TestExecCommandHonorsSchemaPolicy(t *testing.T) {
+	connector, err := duckdb.NewConnector(":memory:", nil)
+	require.NoError(t, err)
+
+	db, err := query.New(t.Context(), connector)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		db.Close()
+		require.NoError(t, connector.Close())
+	})
+
+	command := CommandExec
+	sql := "SELECT 1"
+	params := QueryParams{Type: &command, SQL: &sql}
+
+	s := New(db, []string{"X-Tenant"}, nil)
+	_, _, err = s.execCommand(t.Context(), params, nil)
+	require.ErrorIs(t, err, query.ErrExecWithValidation)
+
+	s = New(db, nil, nil)
+	_, _, err = s.execCommand(t.Context(), params, nil)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Stack

**1. #1106 — fix(go-server): enforce query policies**
2. #1117 — fix(go-server): make cached responses policy- and format-safe
3. #1118 — fix(go-server): classify query and request failures
4. #1119 — fix(go-server): harden schema and function authorization
5. #1120 — fix(go-server): harden SQL serializer validation
6. #1121 — docs(go-server): document query policy boundaries

This is **1 of 6**. Merge bottom-up.

## What

- retain and normalize the configured function blocklist
- validate JSON and Arrow queries against schema and function policies
- reject `exec` when schema or function validation is active

## Why

The function blocklist was parsed but not retained for query execution, and `exec` could bypass request-scoped schema policy. DuckDB’s serializer cannot currently authorize arbitrary DDL/DML, so restricted-mode `exec` now fails closed.

## Impact

Policy-enabled deployments enforce their configured controls. Unrestricted `exec` behavior is unchanged. Full restricted DDL/DML support remains follow-up work under #947.

## Verification

- `go test -tags=duckdb_arrow ./... -count=1`
- `go test -race -tags=duckdb_arrow ./... -count=1`
- `golangci-lint run`

Part of #958