### PR TITLE
fix(go-server): make cached responses policy- and format-safe

### DIFF
--- a/packages/server/duckdb-server-go/internal/query/query.go
+++ b/packages/server/duckdb-server-go/internal/query/query.go
@@ -222,6 +222,11 @@ func (db *DB) validateQuery(ctx context.Context, query string, allowedSchemas []
 }
 
 func (db *DB) QueryJSON(ctx context.Context, query string, allowedSchemas []string, useCache bool) (json.RawMessage, bool, error) {
+	err := db.validateQuery(ctx, query, allowedSchemas)
+	if err != nil {
+		return nil, false, err
+	}
+
 	var key uint64
 	var data []byte
 
@@ -234,7 +239,7 @@ func (db *DB) QueryJSON(ctx context.Context, query string, allowedSchemas []stri
 
 	var buf bytes.Buffer
 
-	err := db.WriteJSON(ctx, query, allowedSchemas, &buf)
+	err = db.writeJSON(ctx, query, &buf)
 	if err != nil {
 		return nil, false, err
 	}
@@ -252,6 +257,12 @@ func (db *DB) WriteJSON(ctx context.Context, query string, allowedSchemas []stri
 		return err
 	}
 
+	return db.writeJSON(ctx, query, w)
+}
+
+// SECURITY: writeJSON executes without policy validation. Call it only after validateQuery succeeds for the same query
+// and request-scoped allowed schemas.
+func (db *DB) writeJSON(ctx context.Context, query string, w io.Writer) error {
 	arrow, err := db.getArrowConn(ctx)
 	if err != nil {
 		return err
@@ -300,11 +311,16 @@ func (db *DB) WriteJSON(ctx context.Context, query string, allowedSchemas []stri
 }
 
 func (db *DB) QueryArrow(ctx context.Context, query string, allowedSchemas []string, useCache bool) ([]byte, bool, error) {
+	err := db.validateQuery(ctx, query, allowedSchemas)
+	if err != nil {
+		return nil, false, err
+	}
+
 	var key uint64
 	var data []byte
 
 	if useCache && db.cache != nil {
-		key, data = db.cacheGet("j", query)
+		key, data = db.cacheGet("a", query)
 		if data != nil {
 			return data, true, nil
 		}
@@ -312,7 +328,7 @@ func (db *DB) QueryArrow(ctx context.Context, query string, allowedSchemas []str
 
 	var buf bytes.Buffer
 
-	err := db.WriteArrow(ctx, query, allowedSchemas, &buf)
+	err = db.writeArrow(ctx, query, &buf)
 	if err != nil {
 		return nil, false, err
 	}
@@ -330,6 +346,12 @@ func (db *DB) WriteArrow(ctx context.Context, query string, allowedSchemas []str
 		return err
 	}
 
+	return db.writeArrow(ctx, query, w)
+}
+
+// SECURITY: writeArrow executes without policy validation. Call it only after validateQuery succeeds for the same query
+// and request-scoped allowed schemas.
+func (db *DB) writeArrow(ctx context.Context, query string, w io.Writer) error {
 	arrow, err := db.getArrowConn(ctx)
 	if err != nil {
 		return err

--- a/packages/server/duckdb-server-go/internal/query/query_test.go
+++ b/packages/server/duckdb-server-go/internal/query/query_test.go
@@ -99,6 +99,83 @@ func TestDB_FunctionBlocklist(t *testing.T) {
 	}
 }
 
+func TestDB_CacheValidatesSchemas(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+	}{
+		{name: "JSON", format: "json"},
+		{name: "Arrow", format: "arrow"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupTestDB(t)
+			ctx := context.Background()
+
+			err := db.Exec(ctx, `
+				CREATE SCHEMA tenant_a;
+				CREATE TABLE tenant_a.secret (value VARCHAR);
+				INSERT INTO tenant_a.secret VALUES ('tenant-a-only')
+			`)
+			require.NoError(t, err)
+
+			const query = "SELECT * FROM tenant_a.secret"
+			if tt.format == "arrow" {
+				_, fromCache, err := db.QueryArrow(ctx, query, []string{"tenant_a"}, true)
+				require.NoError(t, err)
+				assert.False(t, fromCache)
+
+				_, fromCache, err = db.QueryArrow(ctx, query, []string{"tenant_b"}, true)
+				require.ErrorContains(t, err, "unauthorized access to schema")
+				assert.False(t, fromCache)
+
+				_, fromCache, err = db.QueryArrow(ctx, query, []string{"tenant_a"}, true)
+				require.NoError(t, err)
+				assert.True(t, fromCache)
+			} else {
+				_, fromCache, err := db.QueryJSON(ctx, query, []string{"tenant_a"}, true)
+				require.NoError(t, err)
+				assert.False(t, fromCache)
+
+				_, fromCache, err = db.QueryJSON(ctx, query, []string{"tenant_b"}, true)
+				require.ErrorContains(t, err, "unauthorized access to schema")
+				assert.False(t, fromCache)
+
+				_, fromCache, err = db.QueryJSON(ctx, query, []string{"tenant_a"}, true)
+				require.NoError(t, err)
+				assert.True(t, fromCache)
+			}
+		})
+	}
+}
+
+func TestDB_CacheSeparatesFormats(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	const query = "SELECT 42 AS answer"
+
+	jsonData, fromCache, err := db.QueryJSON(ctx, query, nil, true)
+	require.NoError(t, err)
+	assert.False(t, fromCache)
+	assert.True(t, json.Valid(jsonData))
+
+	arrowData, fromCache, err := db.QueryArrow(ctx, query, nil, true)
+	require.NoError(t, err)
+	assert.False(t, fromCache)
+	assert.False(t, json.Valid(arrowData))
+
+	cachedJSON, fromCache, err := db.QueryJSON(ctx, query, nil, true)
+	require.NoError(t, err)
+	assert.True(t, fromCache)
+	assert.Equal(t, jsonData, cachedJSON)
+
+	cachedArrow, fromCache, err := db.QueryArrow(ctx, query, nil, true)
+	require.NoError(t, err)
+	assert.True(t, fromCache)
+	assert.Equal(t, arrowData, cachedArrow)
+}
+
 func TestDB_Exec(t *testing.T) {
 	db := setupTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Stack

1. #1106 — fix(go-server): enforce query policies
**2. #1117 — fix(go-server): make cached responses policy- and format-safe**
3. #1118 — fix(go-server): classify query and request failures
4. #1119 — fix(go-server): harden schema and function authorization
5. #1120 — fix(go-server): harden SQL serializer validation
6. #1121 — docs(go-server): document query policy boundaries

This is **2 of 6**. Merge bottom-up.

## What

- validate each request before consulting the result cache
- use distinct cache keys for JSON and Arrow responses
- avoid repeating validation on cache misses

## Why

A cached result could be returned without applying the current request’s allowed-schema policy. JSON and Arrow also shared a cache-key prefix, allowing one response format to collide with the other.

## Impact

Cache hits are reusable only after the requesting caller passes authorization, and JSON and Arrow payloads can no longer collide.

## Verification

- `go test -tags=duckdb_arrow ./... -count=1`
- `go test -race -tags=duckdb_arrow ./... -count=1`
- `golangci-lint run`

Part of #958