### PR TITLE
fix(go-server): classify query and request failures

### DIFF
--- a/packages/server/duckdb-server-go/internal/query/query.go
+++ b/packages/server/duckdb-server-go/internal/query/query.go
@@ -215,7 +215,7 @@ func (db *DB) validateQuery(ctx context.Context, query string, allowedSchemas []
 
 	err := db.ValidateSQL(ctx, query, validators...)
 	if err != nil {
-		return fmt.Errorf("query: validation failed for query: %w", err)
+		return fmt.Errorf("query: validation failed: %w", err)
 	}
 
 	return nil

--- a/packages/server/duckdb-server-go/internal/query/query_test.go
+++ b/packages/server/duckdb-server-go/internal/query/query_test.go
@@ -99,6 +99,27 @@ func TestDB_FunctionBlocklist(t *testing.T) {
 	}
 }
 
+func TestDB_FunctionBlocklistHandlesUnsupportedStatements(t *testing.T) {
+	db := setupTestDB(t, WithFunctionBlocklist([]string{"range"}))
+	ctx := context.Background()
+
+	t.Run("JSON", func(t *testing.T) {
+		_, _, err := db.QueryJSON(ctx, "PRAGMA version", nil, false)
+		require.ErrorIs(t, err, ErrUnsupportedStatement)
+		require.ErrorContains(t, err, "query: validation failed: query: not implemented: Only SELECT statements can be serialized to json")
+		require.NotContains(t, err.Error(), "()")
+		require.NotContains(t, err.Error(), " at :")
+	})
+
+	t.Run("Arrow", func(t *testing.T) {
+		_, _, err := db.QueryArrow(ctx, "PRAGMA version", nil, false)
+		require.ErrorIs(t, err, ErrUnsupportedStatement)
+		require.ErrorContains(t, err, "query: validation failed: query: not implemented: Only SELECT statements can be serialized to json")
+		require.NotContains(t, err.Error(), "()")
+		require.NotContains(t, err.Error(), " at :")
+	})
+}
+
 func TestDB_CacheValidatesSchemas(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/packages/server/duckdb-server-go/internal/query/validator.go
+++ b/packages/server/duckdb-server-go/internal/query/validator.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 )
 
+var (
+	ErrAccessDenied = errors.New("query: access denied")
+
+	ErrUnsupportedStatement = errors.New("query: unsupported statement")
+)
+
 type Validator interface {
 	// CheckNode is called once for each node in the AST
 	// - node: the current node being processed
@@ -36,7 +42,24 @@ type ErrorDetails struct {
 }
 
 func (e ErrorDetails) Error() string {
-	return fmt.Sprintf("query: %s (%s) at %s: %s", e.Type, e.Subtype, e.Position, e.Message)
+	details := "query"
+	if e.Type != "" {
+		details += ": " + e.Type
+	}
+	if e.Subtype != "" {
+		details += " (" + e.Subtype + ")"
+	}
+	if e.Position != "" {
+		details += " at " + e.Position
+	}
+	if e.Message != "" {
+		details += ": " + e.Message
+	}
+	return details
+}
+
+func (e ErrorDetails) Is(target error) bool {
+	return target == ErrUnsupportedStatement && strings.EqualFold(e.Type, "not implemented")
 }
 
 // ValidateSQL validates the given SQL query using the provided validators
@@ -52,12 +75,16 @@ func (db *DB) ValidateSQL(ctx context.Context, sql string, validators ...Validat
 		return fmt.Errorf("failed to parse SQL query: %w", err)
 	}
 
-	if m["error"].(bool) {
+	parseError, ok := m["error"].(bool)
+	if !ok {
+		return errors.New("invalid SQL parser response: missing error status")
+	}
+	if parseError {
 		return ErrorDetails{
-			Type:     m["error_type"].(string),
-			Subtype:  m["error_subtype"].(string),
-			Message:  m["error_message"].(string),
-			Position: m["position"].(string),
+			Type:     stringField(m, "error_type"),
+			Subtype:  stringField(m, "error_subtype"),
+			Message:  stringField(m, "error_message"),
+			Position: stringField(m, "position"),
 		}
 	}
 
@@ -83,6 +110,11 @@ func (db *DB) ValidateSQL(ctx context.Context, sql string, validators ...Validat
 	}
 
 	return errors.Join(combinedErrs...)
+}
+
+func stringField(m map[string]any, key string) string {
+	value, _ := m[key].(string)
+	return value
 }
 
 // quoteLiteral properly escapes a string for use as a SQL string literal
@@ -193,12 +225,12 @@ func (v *baseTableValidator) Validate() []error {
 			if ok {
 				continue // empty schemas are allowed if they are CTEs
 			} else {
-				errs = append(errs, fmt.Errorf("access denied: unauthorized access to table '%v' with empty schema", baseTable.TableName))
+				errs = append(errs, fmt.Errorf("%w: unauthorized access to table '%v' with empty schema", ErrAccessDenied, baseTable.TableName))
 			}
 		}
 
 		if !slices.Contains(v.allowedSchemas, baseTable.SchemaName) {
-			errs = append(errs, fmt.Errorf("access denied: unauthorized access to schema '%v'", baseTable))
+			errs = append(errs, fmt.Errorf("%w: unauthorized access to schema '%v'", ErrAccessDenied, baseTable))
 		}
 	}
 
@@ -238,7 +270,7 @@ func (v *functionBlocklistValidator) CheckNode(node map[string]any, _ []string) 
 	}
 
 	if slices.Contains(v.blockedFunctions, functionNameStr) {
-		v.errs = append(v.errs, fmt.Errorf("query: access denied: use of function '%s' is not allowed", functionNameStr))
+		v.errs = append(v.errs, fmt.Errorf("%w: use of function '%s' is not allowed", ErrAccessDenied, functionNameStr))
 	}
 }
 

--- a/packages/server/duckdb-server-go/internal/query/validator_test.go
+++ b/packages/server/duckdb-server-go/internal/query/validator_test.go
@@ -6,6 +6,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestErrorDetails(t *testing.T) {
+	t.Run("all fields", func(t *testing.T) {
+		err := ErrorDetails{Type: "parser", Subtype: "syntax", Position: "line 1", Message: "invalid SQL"}
+		assert.EqualError(t, err, "query: parser (syntax) at line 1: invalid SQL")
+		assert.NotErrorIs(t, err, ErrUnsupportedStatement)
+	})
+
+	t.Run("sparse unsupported statement", func(t *testing.T) {
+		err := ErrorDetails{Type: "not implemented", Message: "Only SELECT statements can be serialized to json!"}
+		assert.EqualError(t, err, "query: not implemented: Only SELECT statements can be serialized to json!")
+		assert.ErrorIs(t, err, ErrUnsupportedStatement)
+	})
+}
+
 func TestDB_ValidateSQL(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/packages/server/duckdb-server-go/internal/server/server.go
+++ b/packages/server/duckdb-server-go/internal/server/server.go
@@ -30,6 +30,12 @@ type QueryParams struct {
 	Name    *string  `json:"name"`
 }
 
+type queryParamsError string
+
+func (e queryParamsError) Error() string {
+	return string(e)
+}
+
 type Server struct {
 	*http.ServeMux
 
@@ -203,7 +209,21 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 
 	data, cacheHit, err := s.execCommand(r.Context(), params, allowedSchemas)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		status := http.StatusInternalServerError
+		var (
+			errorDetails query.ErrorDetails
+			paramsError  queryParamsError
+		)
+		switch {
+		case errors.Is(err, query.ErrExecWithValidation),
+			errors.Is(err, query.ErrUnsupportedStatement),
+			errors.As(err, &errorDetails),
+			errors.As(err, &paramsError):
+			status = http.StatusBadRequest
+		case errors.Is(err, query.ErrAccessDenied):
+			status = http.StatusForbidden
+		}
+		http.Error(w, err.Error(), status)
 		return
 	}
 
@@ -279,19 +299,19 @@ func (s *Server) execCommand(ctx context.Context, params QueryParams, allowedSch
 func (p QueryParams) Validate(logger *slog.Logger) error {
 	if p.Type == nil || *p.Type == "" {
 		logger.Error("server: missing required 'type' parameter")
-		return errors.New("missing required 'type' parameter")
+		return queryParamsError("missing required 'type' parameter")
 	}
 
 	switch *p.Type {
 	case CommandArrow, CommandExec, CommandJSON:
 	default:
 		logger.Error("server: invalid 'type' parameter", "type", *p.Type)
-		return errors.New("invalid 'type' parameter: " + string(*p.Type))
+		return queryParamsError("invalid 'type' parameter: " + string(*p.Type))
 	}
 
 	if p.SQL == nil || *p.SQL == "" {
 		logger.Error("server: missing required 'sql' parameter")
-		return errors.New("missing required 'sql' parameter")
+		return queryParamsError("missing required 'sql' parameter")
 	}
 
 	return nil

--- a/packages/server/duckdb-server-go/internal/server/server_test.go
+++ b/packages/server/duckdb-server-go/internal/server/server_test.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/duckdb/duckdb-go/v2"
@@ -9,26 +12,151 @@ import (
 	"github.com/uwdata/mosaic/packages/server/duckdb-server-go/internal/query"
 )
 
-func TestExecCommandHonorsSchemaPolicy(t *testing.T) {
+func setupTestDB(t *testing.T, opts ...query.OptionFunc) *query.DB {
+	t.Helper()
+
 	connector, err := duckdb.NewConnector(":memory:", nil)
 	require.NoError(t, err)
 
-	db, err := query.New(t.Context(), connector)
+	db, err := query.New(t.Context(), connector, opts...)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		db.Close()
 		require.NoError(t, connector.Close())
 	})
+	return db
+}
+
+func TestExecCommandHonorsSchemaPolicy(t *testing.T) {
+	db := setupTestDB(t)
 
 	command := CommandExec
 	sql := "SELECT 1"
 	params := QueryParams{Type: &command, SQL: &sql}
 
 	s := New(db, []string{"X-Tenant"}, nil)
-	_, _, err = s.execCommand(t.Context(), params, nil)
+	_, _, err := s.execCommand(t.Context(), params, nil)
 	require.ErrorIs(t, err, query.ErrExecWithValidation)
 
 	s = New(db, nil, nil)
 	_, _, err = s.execCommand(t.Context(), params, nil)
 	require.NoError(t, err)
+}
+
+func TestHandleHTTPPolicyErrors(t *testing.T) {
+	t.Run("blocked function is forbidden", func(t *testing.T) {
+		db := setupTestDB(t, query.WithFunctionBlocklist([]string{"md5"}))
+		s := New(db, nil, nil)
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"SELECT md5('mosaic')"}`))
+		res := httptest.NewRecorder()
+
+		s.ServeHTTP(res, req)
+
+		require.Equal(t, http.StatusForbidden, res.Code)
+		require.Contains(t, res.Body.String(), "use of function 'md5' is not allowed")
+	})
+
+	t.Run("unauthorized schema is forbidden", func(t *testing.T) {
+		db := setupTestDB(t)
+		require.NoError(t, db.Exec(t.Context(), "CREATE SCHEMA tenant_a; CREATE TABLE tenant_a.secret (value INTEGER)"))
+
+		s := New(db, []string{"X-Tenant"}, nil)
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"SELECT * FROM tenant_a.secret"}`))
+		req.Header.Set("X-Tenant", "tenant_b")
+		res := httptest.NewRecorder()
+
+		s.ServeHTTP(res, req)
+
+		require.Equal(t, http.StatusForbidden, res.Code)
+		require.Contains(t, res.Body.String(), "unauthorized access to schema")
+	})
+
+	t.Run("exec under schema policy is a bad request", func(t *testing.T) {
+		db := setupTestDB(t)
+		s := New(db, []string{"X-Tenant"}, nil)
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"exec","sql":"SELECT 1"}`))
+		req.Header.Set("X-Tenant", "tenant_a")
+		res := httptest.NewRecorder()
+
+		s.ServeHTTP(res, req)
+
+		require.Equal(t, http.StatusBadRequest, res.Code)
+		require.Equal(t, query.ErrExecWithValidation.Error()+"\n", res.Body.String())
+	})
+
+	t.Run("unsupported statement under policy is a bad request", func(t *testing.T) {
+		db := setupTestDB(t, query.WithFunctionBlocklist([]string{"md5"}))
+		s := New(db, nil, nil)
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"PRAGMA version"}`))
+		res := httptest.NewRecorder()
+
+		s.ServeHTTP(res, req)
+
+		require.Equal(t, http.StatusBadRequest, res.Code)
+		require.Contains(t, res.Body.String(), "query: validation failed: query: not implemented: Only SELECT statements can be serialized to json")
+		require.NotContains(t, res.Body.String(), "()")
+		require.NotContains(t, res.Body.String(), " at :")
+	})
+
+	t.Run("syntax error under policy is a bad request", func(t *testing.T) {
+		db := setupTestDB(t, query.WithFunctionBlocklist([]string{"md5"}))
+		s := New(db, nil, nil)
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"SELECT ("}`))
+		res := httptest.NewRecorder()
+
+		s.ServeHTTP(res, req)
+
+		require.Equal(t, http.StatusBadRequest, res.Code)
+		require.Contains(t, res.Body.String(), "query: parser")
+	})
+
+	t.Run("missing schema header is unauthorized", func(t *testing.T) {
+		db := setupTestDB(t)
+		s := New(db, []string{"X-Tenant"}, nil)
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"exec","sql":"SELECT 1"}`))
+		res := httptest.NewRecorder()
+
+		s.ServeHTTP(res, req)
+
+		require.Equal(t, http.StatusUnauthorized, res.Code)
+	})
+}
+
+func TestHandleHTTPQueryParamsErrors(t *testing.T) {
+	db := setupTestDB(t)
+	s := New(db, nil, nil)
+
+	tests := []struct {
+		name     string
+		body     string
+		wantBody string
+	}{
+		{
+			name:     "missing type",
+			body:     `{"sql":"SELECT 1"}`,
+			wantBody: "missing required 'type' parameter\n",
+		},
+		{
+			name:     "invalid type",
+			body:     `{"type":"csv","sql":"SELECT 1"}`,
+			wantBody: "invalid 'type' parameter: csv\n",
+		},
+		{
+			name:     "missing SQL",
+			body:     `{"type":"json"}`,
+			wantBody: "missing required 'sql' parameter\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tt.body))
+			res := httptest.NewRecorder()
+
+			s.ServeHTTP(res, req)
+
+			require.Equal(t, http.StatusBadRequest, res.Code)
+			require.Equal(t, tt.wantBody, res.Body.String())
+		})
+	}
 }


### PR DESCRIPTION
## Stack

1. #1106 — fix(go-server): enforce query policies
2. #1117 — fix(go-server): make cached responses policy- and format-safe
**3. #1118 — fix(go-server): classify query and request failures**
4. #1119 — fix(go-server): harden schema and function authorization
5. #1120 — fix(go-server): harden SQL serializer validation
6. #1121 — docs(go-server): document query policy boundaries

This is **3 of 6**. Merge bottom-up.

## What

- add typed errors for access denial and unsupported statements
- return 400 for invalid requests and unsupported policy-validated SQL
- return 403 for authorization failures
- safely decode sparse DuckDB serializer errors

## Why

Expected client and policy failures were reported as 500 responses, and sparse serializer error objects could produce malformed messages or unsafe type assertions.

## Impact

Clients receive actionable HTTP statuses while unexpected server failures remain 500s. Validation errors retain the `query:` package prefix.

## Verification

- `go test -tags=duckdb_arrow ./... -count=1`
- `go test -race -tags=duckdb_arrow ./... -count=1`
- `golangci-lint run`

Part of #958