### PR TITLE
fix(go-server): harden schema and function authorization

### DIFF
--- a/packages/server/duckdb-server-go/internal/query/validator.go
+++ b/packages/server/duckdb-server-go/internal/query/validator.go
@@ -173,9 +173,18 @@ func newBaseTableValidator(allowedSchemas []string) Validator {
 }
 
 func (v *baseTableValidator) CheckNode(node map[string]any, keyStack []string) {
+	if class, exists := node["class"]; exists && (class == "FUNCTION" || class == "WINDOW") {
+		v.rejectCatalogReference(node, "catalog")
+	}
+
 	val, exists := node["type"]
-	if exists && val == "BASE_TABLE" {
-		v.handleBaseTable(node)
+	if exists {
+		switch val {
+		case "BASE_TABLE":
+			v.handleBaseTable(node)
+		case "SHOW_REF":
+			v.handleShowRef(node)
+		}
 	}
 
 	if len(keyStack) >= 2 && keyStack[len(keyStack)-2] == "cte_map" && keyStack[len(keyStack)-1] == "map" {
@@ -189,7 +198,38 @@ func (v *baseTableValidator) CheckNode(node map[string]any, keyStack []string) {
 	}
 }
 
+func (v *baseTableValidator) handleShowRef(showRef map[string]any) {
+	if v.rejectCatalogReference(showRef, "catalog_name") {
+		return
+	}
+
+	// DESCRIBE statements contain a nested query whose base tables are validated separately.
+	if _, exists := showRef["query"]; exists {
+		return
+	}
+
+	schemaName, exists := showRef["schema_name"]
+	if !exists {
+		v.errs = append(v.errs, fmt.Errorf("%w: SHOW statement requires an explicit authorized schema", ErrAccessDenied))
+		return
+	}
+
+	schemaNameStr, ok := schemaName.(string)
+	if !ok {
+		v.errs = append(v.errs, fmt.Errorf("invalid 'schema_name' in show reference, expected string: %v", schemaName))
+		return
+	}
+	schemaNameStr = strings.TrimPrefix(schemaNameStr, "schema_name:")
+	if !slices.Contains(v.allowedSchemas, schemaNameStr) {
+		v.errs = append(v.errs, fmt.Errorf("%w: unauthorized access to schema '%s'", ErrAccessDenied, schemaNameStr))
+	}
+}
+
 func (v *baseTableValidator) handleBaseTable(baseTable map[string]any) {
+	if v.rejectCatalogReference(baseTable, "catalog_name") {
+		return
+	}
+
 	var schemaNameStr string
 	schemaName, exists := baseTable["schema_name"]
 	if exists {
@@ -215,8 +255,24 @@ func (v *baseTableValidator) handleBaseTable(baseTable map[string]any) {
 	}] = struct{}{}
 }
 
+func (v *baseTableValidator) rejectCatalogReference(ref map[string]any, field string) bool {
+	catalogName, exists := ref[field]
+	if !exists {
+		return false
+	}
+
+	catalogNameStr, ok := catalogName.(string)
+	if !ok {
+		v.errs = append(v.errs, fmt.Errorf("invalid '%s', expected string: %v", field, catalogName))
+		return true
+	}
+	catalogNameStr = strings.TrimPrefix(catalogNameStr, field+":")
+	v.errs = append(v.errs, fmt.Errorf("%w: access to catalog '%s' is not allowed", ErrAccessDenied, catalogNameStr))
+	return true
+}
+
 func (v *baseTableValidator) Validate() []error {
-	var errs []error
+	errs := append([]error(nil), v.errs...)
 
 	// Check if all referenced schemas are allowed
 	for baseTable := range v.baseTables {
@@ -224,13 +280,13 @@ func (v *baseTableValidator) Validate() []error {
 			_, ok := v.baseTables[tableRef{TableName: baseTable.TableName, IsCTE: true}]
 			if ok {
 				continue // empty schemas are allowed if they are CTEs
-			} else {
-				errs = append(errs, fmt.Errorf("%w: unauthorized access to table '%v' with empty schema", ErrAccessDenied, baseTable.TableName))
 			}
+			errs = append(errs, fmt.Errorf("%w: unauthorized access to table '%s' with empty schema", ErrAccessDenied, baseTable.TableName))
+			continue
 		}
 
 		if !slices.Contains(v.allowedSchemas, baseTable.SchemaName) {
-			errs = append(errs, fmt.Errorf("%w: unauthorized access to schema '%v'", ErrAccessDenied, baseTable))
+			errs = append(errs, fmt.Errorf("%w: unauthorized access to schema '%s'", ErrAccessDenied, baseTable.SchemaName))
 		}
 	}
 
@@ -268,6 +324,7 @@ func (v *functionBlocklistValidator) CheckNode(node map[string]any, _ []string) 
 		v.errs = append(v.errs, fmt.Errorf("query: invalid 'function_name' in function, expected string: %v", functionName))
 		return
 	}
+	functionNameStr = strings.ToLower(functionNameStr)
 
 	if slices.Contains(v.blockedFunctions, functionNameStr) {
 		v.errs = append(v.errs, fmt.Errorf("%w: use of function '%s' is not allowed", ErrAccessDenied, functionNameStr))

--- a/packages/server/duckdb-server-go/internal/query/validator_test.go
+++ b/packages/server/duckdb-server-go/internal/query/validator_test.go
@@ -237,3 +237,99 @@ func TestDB_ValidateSQL(t *testing.T) {
 		})
 	}
 }
+
+func TestBaseTableValidatorErrors(t *testing.T) {
+	db := setupTestDB(t)
+
+	t.Run("disallowed schema", func(t *testing.T) {
+		err := db.ValidateSQL(t.Context(), "SELECT * FROM tenant_b.secret", newBaseTableValidator([]string{"tenant_a"}))
+		assert.ErrorIs(t, err, ErrAccessDenied)
+		assert.EqualError(t, err, "query: access denied: unauthorized access to schema 'tenant_b'")
+	})
+
+	t.Run("unqualified table", func(t *testing.T) {
+		err := db.ValidateSQL(t.Context(), "SELECT * FROM secret", newBaseTableValidator([]string{"tenant_a"}))
+		assert.ErrorIs(t, err, ErrAccessDenied)
+		assert.EqualError(t, err, "query: access denied: unauthorized access to table 'secret' with empty schema")
+	})
+}
+
+func TestBaseTableValidatorShowStatements(t *testing.T) {
+	db := setupTestDB(t)
+
+	tests := []struct {
+		name    string
+		sql     string
+		wantErr string
+	}{
+		{
+			name:    "disallowed schema",
+			sql:     "SHOW TABLES FROM tenant_b",
+			wantErr: "query: access denied: unauthorized access to schema 'tenant_b'",
+		},
+		{
+			name: "allowed schema",
+			sql:  "SHOW TABLES FROM tenant_a",
+		},
+		{
+			name:    "all schemas",
+			sql:     "SHOW ALL TABLES",
+			wantErr: "query: access denied: SHOW statement requires an explicit authorized schema",
+		},
+		{
+			name:    "describe disallowed table",
+			sql:     "DESCRIBE tenant_b.secret",
+			wantErr: "query: access denied: unauthorized access to schema 'tenant_b'",
+		},
+		{
+			name: "describe expression",
+			sql:  "DESCRIBE SELECT 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := db.ValidateSQL(t.Context(), tt.sql, newBaseTableValidator([]string{"tenant_a"}))
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorIs(t, err, ErrAccessDenied)
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestBaseTableValidatorRejectsCatalogReferences(t *testing.T) {
+	db := setupTestDB(t)
+
+	tests := []string{
+		"SELECT * FROM otherdb.tenant_a.secret",
+		"SHOW TABLES FROM otherdb.tenant_a",
+		"DESCRIBE otherdb.tenant_a.secret",
+		"SELECT * FROM otherdb.tenant_a.fn()",
+		"SELECT otherdb.tenant_a.fn() OVER ()",
+	}
+
+	for _, sql := range tests {
+		t.Run(sql, func(t *testing.T) {
+			err := db.ValidateSQL(t.Context(), sql, newBaseTableValidator([]string{"tenant_a"}))
+			assert.ErrorIs(t, err, ErrAccessDenied)
+			assert.EqualError(t, err, "query: access denied: access to catalog 'otherdb' is not allowed")
+		})
+	}
+}
+
+func TestFunctionBlocklistValidatorNormalizesFunctionNames(t *testing.T) {
+	validator := newFunctionBlocklistValidator([]string{"md5"})
+	validator.CheckNode(map[string]any{
+		"class":         "FUNCTION",
+		"function_name": "MD5",
+	}, nil)
+
+	errs := validator.Validate()
+	if assert.Len(t, errs, 1) {
+		assert.ErrorIs(t, errs[0], ErrAccessDenied)
+		assert.EqualError(t, errs[0], "query: access denied: use of function 'md5' is not allowed")
+	}
+}

--- a/packages/server/duckdb-server-go/internal/server/server.go
+++ b/packages/server/duckdb-server-go/internal/server/server.go
@@ -321,7 +321,7 @@ func getAllowedSchemas(req *http.Request, schemaMatchHeaders []string) []string 
 	var allowedSchemas []string
 
 	for _, matchHeader := range schemaMatchHeaders {
-		allowedSchema := req.Header.Get(matchHeader)
+		allowedSchema := req.Header.Get(strings.TrimSpace(matchHeader))
 		if allowedSchema != "" {
 			allowedSchemas = append(allowedSchemas, allowedSchema)
 		}

--- a/packages/server/duckdb-server-go/internal/server/server_test.go
+++ b/packages/server/duckdb-server-go/internal/server/server_test.go
@@ -160,3 +160,13 @@ func TestHandleHTTPQueryParamsErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAllowedSchemasTrimsHeaderNames(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Tenant-Id", "tenant_a")
+	req.Header.Set("Verified-User-Id", "user_a")
+
+	got := getAllowedSchemas(req, []string{" X-Tenant-Id ", "\tVerified-User-Id "})
+	require.Equal(t, []string{"tenant_a", "user_a"}, got)
+	require.Empty(t, getAllowedSchemas(req, []string{" "}))
+}


### PR DESCRIPTION
## Stack

1. #1106 — fix(go-server): enforce query policies
2. #1117 — fix(go-server): make cached responses policy- and format-safe
3. #1118 — fix(go-server): classify query and request failures
**4. #1119 — fix(go-server): harden schema and function authorization**
5. #1120 — fix(go-server): harden SQL serializer validation
6. #1121 — docs(go-server): document query policy boundaries

This is **4 of 6**. Merge bottom-up.

## What

- validate schema references in `SHOW` and `DESCRIBE`
- reject explicitly catalog-qualified tables, functions, and metadata statements
- normalize extracted function names before blocklist matching
- trim configured schema-header names

## Why

These DuckDB AST forms are represented differently from ordinary base-table references and could otherwise fall outside the existing authorization checks.

## Impact

`SHOW ALL TABLES` is rejected under schema policy, `SHOW` requires an explicit authorized schema, and attached-catalog references fail closed.

## Verification

- `go test -tags=duckdb_arrow ./... -count=1`
- `go test -race -tags=duckdb_arrow ./... -count=1`
- `golangci-lint run`

Part of #958