### PR TITLE
fix(go-server): harden SQL serializer validation

### DIFF
--- a/packages/server/duckdb-server-go/internal/query/validator.go
+++ b/packages/server/duckdb-server-go/internal/query/validator.go
@@ -64,9 +64,8 @@ func (e ErrorDetails) Is(target error) bool {
 
 // ValidateSQL validates the given SQL query using the provided validators
 func (db *DB) ValidateSQL(ctx context.Context, sql string, validators ...Validator) error {
-	// Use json_serialize_sql to parse the SQL and extract schema references
-	// serializeSQL := fmt.Sprintf("SELECT json_serialize_sql(%s) as ast", quoteLiteral(sql))
-	serializeSQL := fmt.Sprintf("SELECT json_serialize_sql(%s, skip_default := true, skip_empty := true, skip_null := true) as ast", quoteLiteral(sql))
+	// Qualify the built-in to prevent database macros from shadowing validation.
+	serializeSQL := fmt.Sprintf("SELECT system.main.json_serialize_sql(%s, skip_default := true, skip_empty := true, skip_null := true) as ast", quoteLiteral(sql))
 
 	var m map[string]any
 
@@ -88,8 +87,13 @@ func (db *DB) ValidateSQL(ctx context.Context, sql string, validators ...Validat
 		}
 	}
 
+	statements, ok := m["statements"].([]any)
+	if !ok {
+		return errors.New("invalid SQL parser response: missing or invalid statements")
+	}
+
 	// Extract all schema references, including tables without an explicit schema reference, from the AST
-	for _, stmt := range m["statements"].([]any) {
+	for _, stmt := range statements {
 		stmtMap, ok := stmt.(map[string]any)
 		if !ok {
 			return fmt.Errorf("invalid statement format: %v", stmt)

--- a/packages/server/duckdb-server-go/internal/query/validator_test.go
+++ b/packages/server/duckdb-server-go/internal/query/validator_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestErrorDetails(t *testing.T) {
@@ -236,6 +237,26 @@ func TestDB_ValidateSQL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDB_ValidateSQLIgnoresShadowingSerializerMacro(t *testing.T) {
+	db := setupTestDB(t)
+	require.NoError(t, db.Exec(t.Context(), `
+		CREATE MACRO json_serialize_sql(
+			sql_text,
+			skip_default := true,
+			skip_empty := true,
+			skip_null := true
+		) AS {'error': false, 'statements': []}
+	`))
+
+	err := db.ValidateSQL(
+		t.Context(),
+		"SELECT * FROM tenant_b.secret",
+		newBaseTableValidator([]string{"tenant_a"}),
+	)
+	require.ErrorIs(t, err, ErrAccessDenied)
+	require.EqualError(t, err, "query: access denied: unauthorized access to schema 'tenant_b'")
 }
 
 func TestBaseTableValidatorErrors(t *testing.T) {


### PR DESCRIPTION
## Stack

1. #1106 — fix(go-server): enforce query policies
2. #1117 — fix(go-server): make cached responses policy- and format-safe
3. #1118 — fix(go-server): classify query and request failures
4. #1119 — fix(go-server): harden schema and function authorization
**5. #1120 — fix(go-server): harden SQL serializer validation**
6. #1121 — docs(go-server): document query policy boundaries

This is **5 of 6**. Merge bottom-up.

## What

- invoke `system.main.json_serialize_sql` explicitly
- validate the serializer’s `statements` field before traversing it

## Why

An unqualified serializer call could be shadowed by a database macro returning a forged AST. An unexpected serializer response could also trigger an unsafe type assertion.

## Impact

SQL policy validation uses DuckDB’s built-in serializer and fails safely on malformed responses.

## Verification

- `go test -tags=duckdb_arrow ./... -count=1`
- `go test -race -tags=duckdb_arrow ./... -count=1`
- `golangci-lint run`

Part of #958