### PR TITLE
fix(release): publish with pnpm so workspace: specifiers are rewritten

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
           echo "## Released v$VERSION" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish to npm
-        run: pnpm exec lerna publish from-git --yes
+        run: pnpm publish -r --access public --no-git-checks
 
       - name: Build Python packages
         run: |


### PR DESCRIPTION
## The break

`npm install @uwdata/mosaic-spec@0.29.2` fails in a clean directory:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:^
```

`mosaic-spec`'s own manifest is fine. The culprit is transitive — `@uwdata/mosaic-core`:

```
$ npm view @uwdata/mosaic-core@0.29.2 peerDependencies --json
{ "@uwdata/mosaic-duckdb": "workspace:^" }
```

Affected: **`@uwdata/mosaic-core` 0.29.0, 0.29.1, 0.29.2** — and nothing else. Verified by scanning full registry packuments for all 356 published versions of every package this repo publishes, plus the whole transitive graph of `mosaic-spec@0.29.2`. Since every 0.29.x package depends on `mosaic-core`, all of them are uninstallable with npm and yarn.

`peerDependenciesMeta.optional: true` is not a mitigation — npm parses the spec before honoring optionality, so it hard-errors regardless.

## Root cause

`peerDependencies` were added to `mosaic-core` in #1055 and first released in 0.29.0.

`mosaic-core` lists `@uwdata/mosaic-duckdb` in **both** `devDependencies` and `peerDependencies` — the normal pattern for an optional peer, since `NodeConnector.ts` imports it and the devDependency is what makes `tsc --build` resolve. Lerna's `updateLocalDependency` picks exactly one collection and mutates only it, in the order `dependencies` → `optionalDependencies` → `devDependencies` → `peerDependencies`, first match wins. `devDependencies` matched, so `peerDependencies` was never touched and shipped as `workspace:^`. Consumers don't install `devDependencies`, so the rewrite that did happen was the one that didn't matter.

`pnpm pack` on the same unmodified source rewrites every collection:

```
dependencies:     { "@uwdata/mosaic-sql": "^0.29.0" }
devDependencies:  { "@uwdata/mosaic-duckdb": "^0.29.0" }
peerDependencies: { "@uwdata/mosaic-duckdb": "^0.29.0" }
```

So the source manifest is correct as written. Only the publisher needed changing.

## The change

```diff
-        run: pnpm exec lerna publish from-git --yes
+        run: pnpm publish -r --access public --no-git-checks
```

`lerna version` still does the bump, tag, and push; only the publish step moves to pnpm.

Checked against pnpm 11.1.1's bundled source (matching `packageManager`) that this is a faithful replacement: private packages are skipped via `recursivePublish`'s filter, versions already on the registry are skipped via `isAlreadyPublished` (this matters — `mosaic-sql` and `mosaic-duckdb` sit at 0.29.0 while the rest are at 0.29.2), topological order is preserved, `prepublishOnly` still runs, and npm OIDC trusted publishing is supported and attempted unconditionally on GitHub Actions. There is no `.npmrc` or `NPM_TOKEN` anywhere, so OIDC is the only auth path and it keeps working with the existing trusted-publisher config. `--no-git-checks` is needed because pnpm's branch check would otherwise prompt interactively in CI.

## Verification

- `npm install @uwdata/mosaic-spec@0.29.2` in a clean directory with an npm `override` pointing `mosaic-core` at a locally pnpm-packed tarball **succeeds** (110 packages); without the override it fails with `EUNSUPPORTEDPROTOCOL`.
- Built a fixed 0.29.3 and served it from a local registry shim with the genuine packument for `mosaic-core` plus 0.29.3 grafted in. Installing `mosaic-spec`, `vgplot`, `mosaic-plot` and `mosaic-inputs` at 0.29.2 against it all resolve to 0.29.3 and succeed. `mosaic-spec@0.28.1` is unaffected as a control.

## Republishing needed

This PR cannot unbreak existing consumers on its own — 0.29.0-0.29.2 are immutable on npm. After merge, cut **0.29.3**. Only `@uwdata/mosaic-core` needs it: every dependent uses a caret range on it (no pins, no tildes, across all 0.28.x/0.29.x), so a fixed `mosaic-core@0.29.3` also retroactively repairs the already-published 0.29.0 and 0.29.1 dependents.

Caveats for the release note: `npm install @uwdata/mosaic-core@0.29.2` explicitly will fail forever, and any existing lockfile pinning 0.29.2 stays broken until regenerated. Worth running `npm deprecate '@uwdata/mosaic-core@>=0.29.0 <0.29.3'` pointing at 0.29.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)