### PR TITLE
chore: generate spec schema with ts-json-schema-generator v3 (native TypeScript 7)

### DIFF
--- a/packages/vgplot/spec/package.json
+++ b/packages/vgplot/spec/package.json
@@ -42,7 +42,9 @@
   "dependencies": {
     "@uwdata/mosaic-core": "workspace:^",
     "@uwdata/mosaic-sql": "workspace:^",
-    "@uwdata/vgplot": "workspace:^",
-    "ts-json-schema-generator": "^2.9.0"
+    "@uwdata/vgplot": "workspace:^"
+  },
+  "devDependencies": {
+    "ts-json-schema-generator": "3.0.0-native.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,9 +222,10 @@ importers:
       '@uwdata/vgplot':
         specifier: workspace:^
         version: link:../vgplot
+    devDependencies:
       ts-json-schema-generator:
-        specifier: ^2.9.0
-        version: 2.9.0
+        specifier: 3.0.0-native.0
+        version: 3.0.0-native.0
 
   packages/vgplot/vgplot:
     dependencies:
@@ -2197,10 +2198,6 @@ packages:
     resolution: {integrity: sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==}
     engines: {node: '>=12.20.0'}
 
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
-
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -3942,10 +3939,6 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  safe-stable-stringify@2.5.0:
-    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
-    engines: {node: '>=10'}
-
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -4238,9 +4231,45 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-json-schema-generator@2.9.0:
-    resolution: {integrity: sha512-NR5ZE108uiPtBHBJNGnhwoUaUx5vWTDJzDFG9YlRoqxPU76n+5FClRh92dcGgysbe1smRmYalM9Saj97GW1J4Q==}
-    engines: {node: '>=22.0.0'}
+  ts-json-schema-generator-darwin-arm64@3.0.0-native.0:
+    resolution: {integrity: sha512-dsJ8XXL0qTePuMKZo42T4sS0QF/wTzVo1f5NHHGGkvp7oFigmkhQQGTZh0raG14kbqu5Rf8xSBnZ4lv+KrVfHQ==}
+    engines: {node: '>=20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  ts-json-schema-generator-darwin-x64@3.0.0-native.0:
+    resolution: {integrity: sha512-1bhj3mrlz8lknNvO0W5aaaFpIWis0GKCy6fJFCDfbQJiTUqgLIQdVH5qEj1Nw6R0CJi7DVF8TtP1tMTrFVOluQ==}
+    engines: {node: '>=20'}
+    cpu: [x64]
+    os: [darwin]
+
+  ts-json-schema-generator-linux-arm64@3.0.0-native.0:
+    resolution: {integrity: sha512-3p/zZFpw0o4G0sS+e330v09oMMWcX7KyEWJvrmWWPaALfKPwlfrIohjVwb2yBNnfWaQmLkVMvkd4D9rqYPeDBA==}
+    engines: {node: '>=20'}
+    cpu: [arm64]
+    os: [linux]
+
+  ts-json-schema-generator-linux-x64@3.0.0-native.0:
+    resolution: {integrity: sha512-UCeXpIAwG/mVtsWCDPT8XDO2aF1yU9PTKJts8LONozYF9ai6PiqKK+22jUd7BO8F2FhCZQ1upble/0ccT41tWw==}
+    engines: {node: '>=20'}
+    cpu: [x64]
+    os: [linux]
+
+  ts-json-schema-generator-win32-arm64@3.0.0-native.0:
+    resolution: {integrity: sha512-4p9FHBh0XwTc3XBnK9DMtMFdE5He7dbWfxhXnH9iLHQ0YMcBLmYRDeGSZIzWlMJ/3X5qORUe/bue593FunsbaQ==}
+    engines: {node: '>=20'}
+    cpu: [arm64]
+    os: [win32]
+
+  ts-json-schema-generator-win32-x64@3.0.0-native.0:
+    resolution: {integrity: sha512-BFfl1B60juSzYSKx1SZD7mlMaYM8OtzkCgBl/gxv/Ep9+Pt6PNjR0MMBGye90gfhE8o4wD9SPwIJyc4r7aebKw==}
+    engines: {node: '>=20'}
+    cpu: [x64]
+    os: [win32]
+
+  ts-json-schema-generator@3.0.0-native.0:
+    resolution: {integrity: sha512-HCsUXbAaXvlp9lgj15j7pPt5qH9Mi8+noL5fgEflvVCRyXtAZIFBl2Q25EpL7bgm8sKD//fClLQkjk1iHK7qJQ==}
+    engines: {node: '>=20'}
     hasBin: true
 
   tsconfig-paths@4.2.0:
@@ -6604,8 +6633,6 @@ snapshots:
       table-layout: 4.1.1
       typical: 7.3.0
 
-  commander@14.0.3: {}
-
   commander@2.20.3: {}
 
   commander@7.2.0: {}
@@ -8766,8 +8793,6 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  safe-stable-stringify@2.5.0: {}
-
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -9069,16 +9094,32 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-json-schema-generator@2.9.0:
-    dependencies:
-      '@types/json-schema': 7.0.15
-      commander: 14.0.3
-      glob: 13.0.6
-      json5: 2.2.3
-      normalize-path: 3.0.0
-      safe-stable-stringify: 2.5.0
-      tslib: 2.8.1
-      typescript: 5.9.3
+  ts-json-schema-generator-darwin-arm64@3.0.0-native.0:
+    optional: true
+
+  ts-json-schema-generator-darwin-x64@3.0.0-native.0:
+    optional: true
+
+  ts-json-schema-generator-linux-arm64@3.0.0-native.0:
+    optional: true
+
+  ts-json-schema-generator-linux-x64@3.0.0-native.0:
+    optional: true
+
+  ts-json-schema-generator-win32-arm64@3.0.0-native.0:
+    optional: true
+
+  ts-json-schema-generator-win32-x64@3.0.0-native.0:
+    optional: true
+
+  ts-json-schema-generator@3.0.0-native.0:
+    optionalDependencies:
+      ts-json-schema-generator-darwin-arm64: 3.0.0-native.0
+      ts-json-schema-generator-darwin-x64: 3.0.0-native.0
+      ts-json-schema-generator-linux-arm64: 3.0.0-native.0
+      ts-json-schema-generator-linux-x64: 3.0.0-native.0
+      ts-json-schema-generator-win32-arm64: 3.0.0-native.0
+      ts-json-schema-generator-win32-x64: 3.0.0-native.0
 
   tsconfig-paths@4.2.0:
     dependencies:


### PR DESCRIPTION
Switches `@uwdata/mosaic-spec` schema generation to `ts-json-schema-generator@3.0.0-native.0` (npm dist-tag `native`).

## What v3 is

v3 is a native reimplementation of ts-json-schema-generator, written in Go on top of [typescript-go](https://github.com/microsoft/typescript-go) — the TypeScript 7 compiler. It ships as a prebuilt binary per platform rather than as JavaScript, and it is CLI-only: the same flags as 2.x, no Node API. Source lives at [vega/ts-json-schema-generator-go](https://github.com/vega/ts-json-schema-generator-go).

Because this repo only ever invokes the tool through its `schema` script, the CLI-only restriction costs us nothing — the command line in `packages/vgplot/spec/package.json` is unchanged:

```
ts-json-schema-generator -f tsconfig.json -p src/spec/Spec.ts -t Spec --no-type-check --no-ref-encode --functions hide > dist/mosaic-schema.json
```

## Why

- **TypeScript 7 readiness.** Schema generation now runs on the same type checker the rest of the ecosystem is migrating to, so the spec schema won't be the thing blocking a TS7 move.
- **Fewer transitive dependencies.** The JS implementation pulled in its own copy of `typescript`, `commander`, `glob`, and friends; the native package replaces those with a single platform binary. All six platform binaries (darwin/linux/win32 × arm64/x64) are recorded in the lockfile, so `--frozen-lockfile` installs work on CI and on contributor machines alike.

## Schema diff

The regenerated `dist/mosaic-schema.json` is byte-identical to the 2.9.0 output except for one definition. All 216 definitions are present, and no type, description, or enum ordering changed.

`CSSStyles` gains 27 properties and loses none. These come from TypeScript 7's newer `lib.dom`, which knows about CSS features the older lib predates — anchor positioning, scroll-driven animations, and similar:

```diff
 "all": { "type": "string" },
+"anchorName": { "type": "string" },
+"anchorScope": { "type": "string" },
 "animation": { "type": "string" },
```

The full set added: `anchorName`, `anchorScope`, `animationRange`, `animationRangeEnd`, `animationRangeStart`, `animationTimeline`, `dynamicRangeLimit`, `fieldSizing`, `fontLanguageOverride`, `fontVariantEmoji`, `mathShift`, `positionAnchor`, `positionArea`, `positionTry`, `positionTryFallbacks`, `positionTryOrder`, `positionVisibility`, `scrollTimeline`, `scrollTimelineAxis`, `scrollTimelineName`, `textAutospace`, `textJustify`, `timelineScope`, `viewTimeline`, `viewTimelineAxis`, `viewTimelineInset`, `viewTimelineName`.

Validation behavior is unchanged. `CSSStyles` carries `additionalProperties: {"type": "string"}` in both versions, so these names already validated against the index signature as strings; each new entry is likewise `{"type": "string"}`. The schema just names them explicitly now, which is what editor completion reads. The generated Python API and the example specs are unaffected — both CI "verify generated output does not change" gates produce an empty diff.

## Dependency placement

The generator moves from `dependencies` to `devDependencies`. Nothing under `src/` imports it; it is used only by the build-time `schema` script, so shipping it as a runtime dependency forced every consumer of `@uwdata/mosaic-spec` to install a compiler toolchain they never call. This matches how the repo treats other build-time tooling (`esbuild` and `anywidget` in `mosaic-widget`, `vite` in the examples).

## Testing

`pnpm run lint`, `pnpm run build`, and `pnpm run test` all pass (566 tests across 45 files, including the ajv validation of every example spec against the regenerated schema). `pnpm run generate:python-api` and `pnpm run docs:examples` both leave the tracked generated files unchanged.

Nothing else in the tree changes: `packages/vgplot/spec/dist` is gitignored, and the versioned copies under `docs/public/schema` are written at release time by `bin/publish-schema.js`, not by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
