### PR TITLE
fix: correct JSDoc parameter and tuple annotations

### DIFF
--- a/packages/vgplot/plot/src/interactors/util/parse-path.js
+++ b/packages/vgplot/plot/src/interactors/util/parse-path.js
@@ -9,7 +9,7 @@ const errmsg = attr => `Invalid SVG path, incorrect parameter ${attr}`;
 /**
  * Parse an SVG path into a list of drawing commands.
  * @param {string} path The SVG path string to parse
- * @returns {[string, ...number][]} A list of drawing commands.
+ * @returns {[string, ...number[]][]} A list of drawing commands.
  *  Each command has a single letter as the first entry. All subsequent
  *  entries are numeric parameter values.
  */

--- a/packages/vgplot/plot/src/marks/Mark.js
+++ b/packages/vgplot/plot/src/marks/Mark.js
@@ -251,7 +251,7 @@ export class Mark extends MosaicClient {
  * Checks if a constant value or a data field is needed.
  * Also avoids misinterpretation of data values as color names.
  * @param {*} c a visual encoding channel spec
- * @param {object} columns named data column arrays
+ * @param {object} [columns] named data column arrays
  * @returns the Plot channel option
  */
 export function channelOption(c, columns) {


### PR DESCRIPTION
Two JSDoc type annotations describe contracts the code does not have. Both are annotation-only corrections — no runtime change, and no behavior depends on them.

## Changes

**`packages/vgplot/plot/src/marks/Mark.js`** — `channelOption` declared `@param {object} columns` as required, but the body reads `columns?.[c.as]` and `ContourMark.plotSpecs` calls it with a single argument in two places. Annotated as `@param {object} [columns]`.

**`packages/vgplot/plot/src/interactors/util/parse-path.js`** — `parsePath` was annotated `@returns {[string, ...number][]}`. A rest element in a tuple type must be an array type. The function pushes `[cmd, ...params.slice(...)]` where `cmd` is a string and the spread elements are numbers, so the type is `[string, ...number[]][]`.

## Effect

Neither produces a diagnostic under the pinned TypeScript 5.9, but the `parsePath` annotation reaches the published declarations as an **invalid type**. Type-checking `@uwdata/mosaic-plot`'s emitted `dist` with `skipLibCheck: false` on the current `main`:

```
packages/vgplot/plot/dist/src/interactors/util/parse-path.d.ts(8,51):
  error TS2574: A rest element type must be an array type.
```

This change removes that error, so consumers who type-check dependency declarations get one fewer failure. (`main` has 9 such errors across the workspace; this takes it to 8. The rest are unrelated and out of scope here.)

The emit impact is exactly four files — `parse-path.d.ts`, `Mark.d.ts` and their source maps. No emitted `.js` file changes:

```
export function channelOption(c: any, columns: object): any;    // before
export function channelOption(c: any, columns?: object): any;   // after

export function parsePath(path: string): [string, ...number][];    // before, invalid
export function parsePath(path: string): [string, ...number[]][];  // after
```

Build, typecheck, lint, and the test suite (566 tests) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)