### PR TITLE
refactor(go-server): simplify extension repositories

### DIFF
--- a/packages/server/duckdb-server-go/README.md
+++ b/packages/server/duckdb-server-go/README.md
@@ -32,7 +32,7 @@ You can customize the server behavior with the following command-line flags:
 -   `--cert <path>`: Path to a TLS certificate file to enable HTTPS.
 -   `--key <path>`: Path to a TLS private key file to enable HTTPS.
 -   `--schema-match-headers`: Comma-separated list of headers to match against schema names for multi-tenant access control (e.g., `X-Tenant-Id,verified-user-id`).
--   `--load-extensions`: Comma-separated list of extensions to install and load at startup. Use a pipe after the extension name to specify the repository. Unspecified repositories use DuckDB's default. (e.g. `mysql_scanner,netquack|community,aws|core_nightly`
+-   `--load-extensions`: Comma-separated list of extensions to install and load at startup. Use a pipe after the extension name to specify a DuckDB repository alias. Unspecified repositories use DuckDB's default (e.g. `mysql_scanner,netquack|community,aws|core_nightly`).
 -   `--function-blocklist`: Comma-separated list of functions to block, useful for blocking functions that may pose security or performance risks. (e.g., 'bigquery_query,read_parquet')`
 
 By default, the server will look for `localhost.pem` and `localhost-key.pem` in the current directory to enable HTTPS if the `--cert` and `--key` flags are not provided.
@@ -46,106 +46,18 @@ mkcert localhost # create localhost.pem and localhost-key.pem
 
 ### Programmatic Extension Initialization
 
-The `pkg/extensions` package accepts the same extension strings as `--load-extensions`, while keeping flag parsing and
-logging out of the reusable API:
-
-```go
-import (
-	"context"
-	"database/sql"
-	"database/sql/driver"
-
-	"github.com/duckdb/duckdb-go/v2"
-	"github.com/uwdata/mosaic/packages/server/duckdb-server-go/pkg/extensions"
-)
-
-func openDB(connectorCtx context.Context) (*sql.DB, error) {
-	values := []string{
-		"httpfs",
-		"netquack|community",
-		"aws|core_nightly",
-	}
-	connector, err := duckdb.NewConnector(":memory:", func(execer driver.ExecerContext) error {
-		return extensions.ParseAndInstall(connectorCtx, execer, values...)
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	db := sql.OpenDB(connector)
-	if err := db.PingContext(connectorCtx); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
-	return db, nil
-}
-```
-
-`duckdb.NewConnector` is lazy: creating it does not invoke the callback. `PingContext`, the first query, or an explicit
-`Connect` forces the first physical connection and therefore verifies extension initialization before the application
-reports itself ready. The callback reuses `connectorCtx` for every connection, so it must be a long-lived
-connector-lifetime context rather than a request context.
-
-For explicit lifecycle control, call the helpers directly from the connector callback:
+Use `pkg/extensions` from a DuckDB connector callback:
 
 ```go
 connector, err := duckdb.NewConnector(":memory:", func(execer driver.ExecerContext) error {
-	if err := extensions.LoadInstalled(connectorCtx, execer, "httpfs"); err != nil {
-		return err
-	}
-	if err := extensions.InstallAndLoad(
-		connectorCtx,
-		execer,
-		"custom_scanner",
-		"/srv/duckdb/repository",
-	); err != nil {
-		return err
-	}
-	if err := extensions.LoadFile(
-		connectorCtx,
-		execer,
-		"/opt/duckdb/custom_reader.duckdb_extension",
-	); err != nil {
-		return err
-	}
-	return extensions.InstallAndLoadFile(
-		connectorCtx,
-		execer,
-		"/opt/duckdb/custom_writer.duckdb_extension",
-	)
+	return extensions.ParseAndInstall(connectorCtx, execer, "httpfs", "netquack|community")
 })
 ```
 
-A custom repository path names a directory laid out as a DuckDB extension repository; it is not the path of a single
-`.duckdb_extension` file. Use `LoadFile` or `InstallAndLoadFile` for a standalone file. `LoadInstalled` skips installation
-and loads an extension that is already present in DuckDB's extension directory, which supports images or hosts where
-extensions are provisioned before server startup. `LoadFile` loads the source path directly on every connection.
-`InstallAndLoadFile` first copies the file into DuckDB's extension directory, then loads the installed extension name
-DuckDB derives from the filename (`custom_writer.duckdb_extension` becomes `custom_writer`), so the source path is only
-needed while installation runs. Bare relative filenames are emitted with a `./` prefix so DuckDB treats them as files
-rather than extension names. Likewise, prefix a bare relative repository directory with `./` to distinguish it from a
-DuckDB repository name.
-
-`ParseAndInstall` trims surrounding command-line grammar whitespace, rejects blank entries or extra repository
-delimiters, and executes entries immediately. Extension and repository semantics are left to DuckDB. Values passed to
-helper functions are literal because whitespace can be part of a valid path; callers reading them from YAML,
-environment variables, or similar configuration should normalize them if that is their desired policy.
-Call `Validate` first when malformed grammar should be reported before the connector opens; the example server does so
-for `--load-extensions`.
-
-The package safely quotes extension names, file paths, and custom repositories, then delegates extension names, aliases,
-repositories, file compatibility, and repeated or conflicting entries to DuckDB. Entries are executed in caller order
-without deduplication, so DuckDB's own errors remain the source of truth.
-
-DuckDB applies `LOAD` to each physical connection, so the connector callback repeats its complete ordered work whenever
-the connector creates one. Install-and-load calls repeat `INSTALL` as well; DuckDB decides whether an installed artifact
-can be reused, while each connection still receives its own `LOAD`. The first failed `INSTALL` or `LOAD` stops the
-callback and returns a contextual error, so that connection is not created. A later connection retries from the
-beginning. The example server's extension inventory query provides this preflight before HTTP serving starts.
-
-Extensions are trusted native code that run with the server process's privileges. Load only trusted repositories and
-files. DuckDB signature verification is an important safeguard where it applies; allowing unsigned extensions removes
-that safeguard. Local binaries must also match the DuckDB version, extension ABI, operating system, and architecture.
+Repository suffixes are DuckDB aliases. Use `InstallAndLoadFromCustomRepository` for repository URLs or paths, and
+`LoadInstalled`, `LoadFile`, or `InstallAndLoadFile` for pre-provisioned extensions. The callback runs for every physical
+connection; use a long-lived context and call `PingContext` before serving to force initialization. The first failure
+aborts the connection. Extensions are trusted native code, so load only trusted repositories and files.
 
 ### Multi-Tenant Access Control
 

--- a/packages/server/duckdb-server-go/main.go
+++ b/packages/server/duckdb-server-go/main.go
@@ -29,7 +29,7 @@ func main() {
 	certFile := flag.String("cert", "", "Path to TLS certificate file (optional, enables HTTPS)")
 	keyFile := flag.String("key", "", "Path to TLS private key file (optional, enables HTTPS)")
 	schemaMatchHeadersStr := flag.String("schema-match-headers", "", "Comma-separated list of headers to match against schema names for multi-tenant access control (e.g., \"X-Tenant-Id,verified-user-id\")")
-	extensionsStr := flag.String("load-extensions", "", "Comma-separated list of extensions to install and load at startup. Use a pipe after the extension name to specify the repository. Unspecified repositories use DuckDB's default. (e.g. mysql_scanner,netquack|community,aws|core_nightly")
+	extensionsStr := flag.String("load-extensions", "", "Comma-separated list of extensions to install and load at startup. Use a pipe after the extension name to specify a DuckDB repository alias. Unspecified repositories use DuckDB's default (e.g. mysql_scanner,netquack|community,aws|core_nightly).")
 	functionBlocklistStr := flag.String("function-blocklist", "", "Comma-separated list of functions to block, useful for blocking functions that may pose security or performance risks. (e.g., 'bigquery_query,read_parquet')")
 	flag.Parse()
 

--- a/packages/server/duckdb-server-go/pkg/extensions/extensions.go
+++ b/packages/server/duckdb-server-go/pkg/extensions/extensions.go
@@ -30,8 +30,8 @@ func Validate(values ...string) error {
 
 // ParseAndInstall accepts the command-line grammar name|repository,name2 and
 // installs and loads each entry in order. Each argument may contain comma-
-// separated entries, so a []string can be expanded directly. An omitted
-// repository uses DuckDB's default.
+// separated entries, so a []string can be expanded directly. Repository values
+// are DuckDB aliases; an omitted repository uses DuckDB's default.
 func ParseAndInstall(
 	ctx context.Context,
 	execer driver.ExecerContext,
@@ -105,11 +105,36 @@ func parseEntryError(valueIndex, entryIndex int, err error) error {
 }
 
 // InstallAndLoad uses DuckDB's default repository when repository is empty.
+// Otherwise, repository is a DuckDB repository alias.
 func InstallAndLoad(
 	ctx context.Context,
 	execer driver.ExecerContext,
 	name string,
 	repository string,
+) error {
+	repositorySQL := ""
+	if repository != "" {
+		repositorySQL = quoteIdentifier(repository)
+	}
+	return installAndLoad(ctx, execer, name, repository, repositorySQL)
+}
+
+// InstallAndLoadFromCustomRepository installs from a repository URL or path.
+func InstallAndLoadFromCustomRepository(
+	ctx context.Context,
+	execer driver.ExecerContext,
+	name string,
+	repository string,
+) error {
+	return installAndLoad(ctx, execer, name, repository, quote(repository))
+}
+
+func installAndLoad(
+	ctx context.Context,
+	execer driver.ExecerContext,
+	name string,
+	repository string,
+	repositorySQL string,
 ) error {
 	if err := validate(ctx, execer); err != nil {
 		return err
@@ -117,8 +142,8 @@ func InstallAndLoad(
 
 	nameSQL := quote(name)
 	query := "INSTALL " + nameSQL
-	if repository != "" {
-		query += " FROM " + repositorySQL(repository)
+	if repositorySQL != "" {
+		query += " FROM " + repositorySQL
 	}
 	if _, err := execer.ExecContext(ctx, query, nil); err != nil {
 		return namedError(ErrInstall, name, repository, err)
@@ -208,27 +233,8 @@ func filePath(path string) string {
 	return "./" + path
 }
 
-// DuckDB distinguishes repository names from paths by SQL token type. A bare
-// relative repository path therefore needs an explicit ./ prefix.
-func repositorySQL(repository string) string {
-	if repositoryIdentifier(repository) {
-		return repository
-	}
-	return quote(repository)
-}
-
-func repositoryIdentifier(repository string) bool {
-	for index := 0; index < len(repository); index++ {
-		char := repository[index]
-		if char == '_' || char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' {
-			continue
-		}
-		if index > 0 && char >= '0' && char <= '9' {
-			continue
-		}
-		return false
-	}
-	return repository != ""
+func quoteIdentifier(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
 }
 
 func quote(value string) string {

--- a/packages/server/duckdb-server-go/pkg/extensions/extensions_test.go
+++ b/packages/server/duckdb-server-go/pkg/extensions/extensions_test.go
@@ -30,17 +30,15 @@ func TestParseAndInstall(t *testing.T) {
 		{
 			name: "comma grammar",
 			values: []string{
-				"spatial, h3|community, aws | core_nightly, custom|https://example.test/extensions",
+				"spatial, h3|community, aws | core_nightly",
 			},
 			want: []string{
 				"INSTALL 'spatial'",
 				"LOAD 'spatial'",
-				"INSTALL 'h3' FROM community",
+				"INSTALL 'h3' FROM \"community\"",
 				"LOAD 'h3'",
-				"INSTALL 'aws' FROM core_nightly",
+				"INSTALL 'aws' FROM \"core_nightly\"",
 				"LOAD 'aws'",
-				"INSTALL 'custom' FROM 'https://example.test/extensions'",
-				"LOAD 'custom'",
 			},
 		},
 		{
@@ -49,25 +47,25 @@ func TestParseAndInstall(t *testing.T) {
 			want: []string{
 				"INSTALL 'spatial'",
 				"LOAD 'spatial'",
-				"INSTALL 'h3' FROM community",
+				"INSTALL 'h3' FROM \"community\"",
 				"LOAD 'h3'",
-				"INSTALL 'aws' FROM core_nightly",
+				"INSTALL 'aws' FROM \"core_nightly\"",
 				"LOAD 'aws'",
 			},
 		},
 		{
-			name:   "custom local repository",
-			values: []string{"custom| /opt/duckdb repository "},
+			name:   "repository alias is an identifier",
+			values: []string{"custom| duckdb extensions "},
 			want: []string{
-				"INSTALL 'custom' FROM '/opt/duckdb repository'",
+				"INSTALL 'custom' FROM \"duckdb extensions\"",
 				"LOAD 'custom'",
 			},
 		},
 		{
 			name:   "semantic values are left to DuckDB",
-			values: []string{"custom'; DROP TABLE secrets; --|Core"},
+			values: []string{"custom'; DROP TABLE secrets; --|repo\"; DROP TABLE secrets; --"},
 			want: []string{
-				"INSTALL 'custom''; DROP TABLE secrets; --' FROM Core",
+				"INSTALL 'custom''; DROP TABLE secrets; --' FROM \"repo\"\"; DROP TABLE secrets; --\"",
 				"LOAD 'custom''; DROP TABLE secrets; --'",
 			},
 		},
@@ -178,18 +176,15 @@ func TestDirectOperations(t *testing.T) {
 	if err := extensions.InstallAndLoad(ctx, execer, "future_repo", "future7"); err != nil {
 		t.Fatalf("InstallAndLoad() error = %v", err)
 	}
-	if err := extensions.InstallAndLoad(
+	if err := extensions.InstallAndLoadFromCustomRepository(
 		ctx,
 		execer,
 		"custom_repo",
 		"https://example.test/O'Brien repo",
 	); err != nil {
-		t.Fatalf("InstallAndLoad() error = %v", err)
+		t.Fatalf("InstallAndLoadFromCustomRepository() error = %v", err)
 	}
 	if err := extensions.InstallAndLoad(ctx, execer, "case_sensitive_repo", "Core"); err != nil {
-		t.Fatalf("InstallAndLoad() error = %v", err)
-	}
-	if err := extensions.InstallAndLoad(ctx, execer, "relative_custom_repo", "./Core"); err != nil {
 		t.Fatalf("InstallAndLoad() error = %v", err)
 	}
 	if err := extensions.LoadInstalled(ctx, execer, "preinstalled"); err != nil {
@@ -215,14 +210,12 @@ func TestDirectOperations(t *testing.T) {
 	wantQueries := []string{
 		"INSTALL 'default_repo'",
 		"LOAD 'default_repo'",
-		"INSTALL 'future_repo' FROM future7",
+		"INSTALL 'future_repo' FROM \"future7\"",
 		"LOAD 'future_repo'",
 		"INSTALL 'custom_repo' FROM 'https://example.test/O''Brien repo'",
 		"LOAD 'custom_repo'",
-		"INSTALL 'case_sensitive_repo' FROM Core",
+		"INSTALL 'case_sensitive_repo' FROM \"Core\"",
 		"LOAD 'case_sensitive_repo'",
-		"INSTALL 'relative_custom_repo' FROM './Core'",
-		"LOAD 'relative_custom_repo'",
 		"LOAD 'preinstalled'",
 		"INSTALL '/opt/O''Brien/custom.duckdb_extension'",
 		"LOAD 'custom'",
@@ -336,9 +329,9 @@ func TestParseAndInstallRepeatsEachInvocation(t *testing.T) {
 	}
 
 	want := []string{
-		"INSTALL 'spatial' FROM core",
+		"INSTALL 'spatial' FROM \"core\"",
 		"LOAD 'spatial'",
-		"INSTALL 'spatial' FROM core",
+		"INSTALL 'spatial' FROM \"core\"",
 		"LOAD 'spatial'",
 	}
 	if got := queries(execer.snapshot()); !reflect.DeepEqual(got, want) {
@@ -363,9 +356,9 @@ func TestParseAndInstallPreservesOrderAndDuplicates(t *testing.T) {
 		"LOAD 'httpfs'",
 		"INSTALL 'HTTPFS'",
 		"LOAD 'HTTPFS'",
-		"INSTALL 'spatial' FROM core",
+		"INSTALL 'spatial' FROM \"core\"",
 		"LOAD 'spatial'",
-		"INSTALL 'SPATIAL' FROM community",
+		"INSTALL 'SPATIAL' FROM \"community\"",
 		"LOAD 'SPATIAL'",
 		"INSTALL 'httpfs'",
 		"LOAD 'httpfs'",
@@ -384,12 +377,20 @@ func TestDirectOperationsQuoteDuckDBValues(t *testing.T) {
 		ctx,
 		execer,
 		"custom'; DROP TABLE secrets; --",
-		"/srv/O'Brien; ATTACH 'evil.db",
+		"repo\"; DROP TABLE secrets; --",
 	); err != nil {
 		t.Fatalf("InstallAndLoad() error = %v", err)
 	}
-	if err := extensions.InstallAndLoad(ctx, execer, "literal", " /srv/repository "); err != nil {
+	if err := extensions.InstallAndLoad(ctx, execer, "literal", " alias name "); err != nil {
 		t.Fatalf("InstallAndLoad() error = %v", err)
+	}
+	if err := extensions.InstallAndLoadFromCustomRepository(
+		ctx,
+		execer,
+		"remote",
+		"/srv/O'Brien; ATTACH 'evil.db",
+	); err != nil {
+		t.Fatalf("InstallAndLoadFromCustomRepository() error = %v", err)
 	}
 	if err := extensions.LoadFile(
 		ctx,
@@ -407,10 +408,12 @@ func TestDirectOperationsQuoteDuckDBValues(t *testing.T) {
 	}
 
 	want := []string{
-		"INSTALL 'custom''; DROP TABLE secrets; --' FROM '/srv/O''Brien; ATTACH ''evil.db'",
+		"INSTALL 'custom''; DROP TABLE secrets; --' FROM \"repo\"\"; DROP TABLE secrets; --\"",
 		"LOAD 'custom''; DROP TABLE secrets; --'",
-		"INSTALL 'literal' FROM ' /srv/repository '",
+		"INSTALL 'literal' FROM \" alias name \"",
 		"LOAD 'literal'",
+		"INSTALL 'remote' FROM '/srv/O''Brien; ATTACH ''evil.db'",
+		"LOAD 'remote'",
 		"LOAD ' /opt/O''Brien; DROP TABLE secrets.duckdb_extension '",
 		"INSTALL '/opt/O''Brien''; DROP TABLE secrets.duckdb_extension'",
 		"LOAD 'O''Brien''; DROP TABLE secrets'",
@@ -464,7 +467,7 @@ func TestParseAndInstallIsSafeForConcurrentUse(t *testing.T) {
 				errorsCh <- err
 				return
 			}
-			want := []string{"INSTALL 'spatial' FROM core", "LOAD 'spatial'"}
+			want := []string{"INSTALL 'spatial' FROM \"core\"", "LOAD 'spatial'"}
 			if got := queries(execer.snapshot()); !reflect.DeepEqual(got, want) {
 				errorsCh <- errors.New("unexpected statements")
 			}
@@ -503,6 +506,17 @@ func TestOperationsValidateDependencies(t *testing.T) {
 			name: "install and load",
 			call: func(ctx context.Context, execer driver.ExecerContext) error {
 				return extensions.InstallAndLoad(ctx, execer, "spatial", "")
+			},
+		},
+		{
+			name: "install and load from custom repository",
+			call: func(ctx context.Context, execer driver.ExecerContext) error {
+				return extensions.InstallAndLoadFromCustomRepository(
+					ctx,
+					execer,
+					"spatial",
+					"https://example.test/extensions",
+				)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

- treat `name|repository` and `InstallAndLoad` repository values as DuckDB aliases
- add `InstallAndLoadFromCustomRepository` for repository URLs and paths, removing alias/path inference
- update tests and CLI help, and condense the programmatic extension documentation

## Why

DuckDB distinguishes repository aliases from custom repositories by SQL token type. The helper choice now expresses that intent directly, while DuckDB remains responsible for validating whether an alias or repository exists during startup.

## Validation

- `go test -tags=duckdb_arrow ./... -count=1`
- `go test -race -tags=duckdb_arrow ./pkg/extensions -count=1`
- `go build -tags=duckdb_arrow ./...`
- `go vet -tags=duckdb_arrow ./...`
- `golangci-lint run`
- `git diff --check origin/main...HEAD`
