### PR TITLE
chore(typing): Use `View` in type annotations

### DIFF
--- a/packages/vgplot/vgplot-python/tests/test_python_api.py
+++ b/packages/vgplot/vgplot-python/tests/test_python_api.py
@@ -67,7 +67,7 @@ class TestAutoNaming:
         view = vg.plot(vg.dot("t", x=unnamed))
         # The explicit param already occupies "_param0"; the in-view param must
         # not collide with it.
-        d = Spec(params={"_param0": named}, view=view).to_dict()  # ty: ignore[invalid-argument-type]
+        d = Spec(params={"_param0": named}, view=view).to_dict()
         assert d["params"]["_param0"] == 1
         assert d["params"]["_param1"] == 2
         assert d["plot"][0]["x"] == "$_param1"

--- a/packages/vgplot/vgplot-python/tests/test_python_api.py
+++ b/packages/vgplot/vgplot-python/tests/test_python_api.py
@@ -3,7 +3,6 @@
 from typing import TYPE_CHECKING
 
 import pytest
-
 import vgplot as vg
 from vgplot.plot import Mark
 
@@ -68,7 +67,7 @@ class TestAutoNaming:
         view = vg.plot(vg.dot("t", x=unnamed))
         # The explicit param already occupies "_param0"; the in-view param must
         # not collide with it.
-        d = Spec(params={"_param0": named}, view=view).to_dict()
+        d = Spec(params={"_param0": named}, view=view).to_dict()  # ty: ignore[invalid-argument-type]
         assert d["params"]["_param0"] == 1
         assert d["params"]["_param1"] == 2
         assert d["plot"][0]["x"] == "$_param1"

--- a/packages/vgplot/vgplot-python/tests/test_python_api.py
+++ b/packages/vgplot/vgplot-python/tests/test_python_api.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 import pytest
+
 import vgplot as vg
 from vgplot.plot import Mark
 

--- a/packages/vgplot/vgplot-python/vgplot/plot.py
+++ b/packages/vgplot/vgplot-python/vgplot/plot.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from .util import camelize, omit_none
-from .params import _ParamBase
 from .data import DataDef, is_frame
+from .params import _ParamBase
+from .util import camelize, omit_none
+
+if TYPE_CHECKING:
+    from vgplot.spec import View
 
 
 class FromRef:
@@ -95,7 +98,7 @@ def plot(
     *items: Mark | Directive | Mapping[str, Any],
     param_names: dict[int, str] | None = None,
     **kwargs: Any,
-) -> Any:
+) -> View:
     from .spec import View
 
     marks: list[dict[str, Any]] = []
@@ -172,7 +175,7 @@ def _encode_component(
 # Layout helpers
 def vconcat(
     *items: Any, param_names: dict[int, str] | None = None, **kwargs: Any
-) -> Any:
+) -> View:
     from .spec import View
 
     return View(
@@ -182,7 +185,7 @@ def vconcat(
 
 def hconcat(
     *items: Any, param_names: dict[int, str] | None = None, **kwargs: Any
-) -> Any:
+) -> View:
     from .spec import View
 
     return View(
@@ -190,13 +193,13 @@ def hconcat(
     )
 
 
-def hspace(value: int | str) -> Any:
+def hspace(value: int | str) -> View:
     from .spec import View
 
     return View({"hspace": value})
 
 
-def vspace(value: int | str) -> Any:
+def vspace(value: int | str) -> View:
     from .spec import View
 
     return View({"vspace": value})
@@ -417,7 +420,7 @@ def symbol_legend(
 _INPUT_ALIASES = {"bind": "as", "source": "from"}
 
 
-def input(kind: str, **opts: Any) -> Any:
+def input(kind: str, **opts: Any) -> View:
     from .spec import View
 
     payload: dict[str, Any] = {"input": kind}
@@ -443,7 +446,7 @@ def slider(
     step: Any = None,
     value: Any = None,
     **opts: Any,
-) -> Any:
+) -> View:
     return input(
         "slider",
         label=label,
@@ -463,7 +466,7 @@ def select(
     multiple: bool = False,
     value: Any = None,
     **opts: Any,
-) -> Any:
+) -> View:
     return input(
         "select",
         label=label,
@@ -475,7 +478,7 @@ def select(
     )
 
 
-def checkbox(label: str, bind: Any, value: bool = False, **opts: Any) -> Any:
+def checkbox(label: str, bind: Any, value: bool = False, **opts: Any) -> View:
     return input("checkbox", label=label, bind=bind, value=value, **opts)
 
 
@@ -488,7 +491,7 @@ def menu(
     column: Any = None,
     filter_by: Any = None,
     **opts: Any,
-) -> Any:
+) -> View:
     return input(
         "menu",
         label=label,
@@ -510,7 +513,7 @@ def search(
     filter_by: Any = None,
     type: Any = None,
     **opts: Any,
-) -> Any:
+) -> View:
     return input(
         "search",
         label=label,
@@ -534,7 +537,7 @@ def table_input(
     row_batch: Any = None,
     align: Any = None,
     **opts: Any,
-) -> Any:
+) -> View:
     return input(
         "table",
         source=source,

--- a/packages/vgplot/vgplot-python/vgplot/spec.py
+++ b/packages/vgplot/vgplot-python/vgplot/spec.py
@@ -4,10 +4,10 @@ import inspect
 import json
 from typing import Any
 
-from .util import omit_none
-from .params import _ParamBase
 from .data import DataDef, is_frame
+from .params import _ParamBase
 from .plot import _encode_component
+from .util import omit_none
 
 
 def _caller_locals() -> dict[str, Any]:
@@ -83,7 +83,7 @@ class Spec:
         plotDefaults: dict[str, Any] | None = None,
         plot_defaults: dict[str, Any] | None = None,
         config: dict[str, Any] | None = None,
-        view: dict[str, Any] | None = None,
+        view: dict[str, Any] | View | None = None,
         **extra: Any,
     ) -> None:
         # Serialize any DataDef values in data and build id->name mapping
@@ -180,8 +180,8 @@ class Spec:
 
     def show(self, con=None, data=None):
         try:
-            from mosaic_widget import MosaicWidget
             from IPython.display import display
+            from mosaic_widget import MosaicWidget
         except ImportError as e:
             raise ImportError("pip install mosaic-widget") from e
         widget = MosaicWidget(self.to_dict(), con=con, data=data)
@@ -271,7 +271,7 @@ def spec(
     plotDefaults: dict[str, Any] | None = None,
     plot_defaults: dict[str, Any] | None = None,
     config: dict[str, Any] | None = None,
-    view: dict[str, Any] | None = None,
+    view: dict[str, Any] | View | None = None,
     **extra: Any,
 ) -> Spec:
     """Assemble a Spec from a view plus data sources and params.


### PR DESCRIPTION
## Description
I think `Any` was used before to deal with cyclic imports, if so this fixes the issue 