### PR TITLE
fix(sql): handle schema-qualified tables in filter pushdown

### DIFF
--- a/packages/mosaic/sql/src/transforms/filter-query.ts
+++ b/packages/mosaic/sql/src/transforms/filter-query.ts
@@ -14,7 +14,9 @@ import { WithClauseNode } from '../ast/with.js';
  * the given base table via a CTE, so every reference to the table sees the
  * filtered rows. Skips scalar subqueries.
  * @param query The query to clone and extend.
- * @param table The base table as a table name or table reference node.
+ * @param table The base table as a table name or table reference node. The
+ *  query is matched on the full table path, including any database or schema
+ *  namespaces, so a query over `s.t1` is not filtered by a bare `t1`.
  * @param filter The filter predicate expression to add. May only reference
  *  columns of the table, not aliases assigned elsewhere in the query.
  */
@@ -31,15 +33,20 @@ export function filterPushdown(
     return clone;
   }
 
-  // determine unique name for filtered CTE
+  // collect referenced table paths (to test for the filtered table) and
+  // visible names (to avoid collisions with the filtered CTE name)
+  const paths = new Set<string>();
   const names = new Set<string>();
   walk(clone, (node) => {
     if (isTableRef(node)) {
+      paths.add(pathKey(node.table));
       names.add(node.name);
     }
   });
-  if (!names.has(tableRef.name)) {
-    // filtered table not present in query, nothing to do
+  if (!paths.has(pathKey(tableRef.table))) {
+    // filtered table not present in query, nothing to do. This must match on
+    // the full path, like the rewrite below: a query over "s"."t1" does not
+    // reference a bare "t1", and vice versa.
     return clone;
   }
   let filteredName = `_${tableRef.name}`;
@@ -58,7 +65,14 @@ export function filterPushdown(
       return; // not a reference to the filtered table
     }
     if (parent instanceof ColumnRefNode) {
-      return; // column qualifiers keep binding to the visible name
+      if (node.table.length > 1) {
+        // a multi-part qualifier names a catalog location, which a CTE can
+        // never occupy, so it can not be kept visible: rewrite it to the
+        // visible name the filtered source is aliased to
+        // @ts-expect-error set read-only property
+        node.table = [visibleName];
+      }
+      return; // single-part qualifiers keep binding to the visible name
     }
     // @ts-expect-error set read-only property
     node.table = [filteredName];
@@ -86,6 +100,10 @@ export function filterPushdown(
  */
 export function filterQuery(query: Query, table: string | TableRefNode) {
   return (filter: FilterExpr) => filterPushdown(query, table, filter);
+}
+
+function pathKey(table: string[]) {
+  return JSON.stringify(table);
 }
 
 function arrayEquals(a: unknown[], b: unknown[]) {

--- a/packages/mosaic/sql/test/filter-pushdown.test.ts
+++ b/packages/mosaic/sql/test/filter-pushdown.test.ts
@@ -141,4 +141,72 @@ describe('filterPushdown', () => {
       'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT ("num1" / (SELECT count(*) AS "count" FROM "t1")) AS "norm" FROM "_t1" AS "t1"'
     );
   });
+
+  it('updates schema-qualified tables', async () => {
+    const t1 = new TableRefNode(['s', 't1']);
+    const q = Query.select(column('num1', t1)).from(t1);
+    const f = filterPushdown(q, t1, gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "s"."t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1"'
+    );
+  });
+
+  it('updates catalog-qualified tables', async () => {
+    // "memory" is the catalog name of DuckDB's default in-memory database
+    const t1 = new TableRefNode(['memory', 's', 't1']);
+    const q = Query.select(column('num1', t1)).from(t1);
+    const f = filterPushdown(q, t1, gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "memory"."s"."t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1"'
+    );
+  });
+
+  it('updates schema-qualified tables in joins', async () => {
+    const t1 = new TableRefNode(['s', 't1']);
+    const t2 = new TableRefNode(['s', 't2']);
+    const q = Query
+      .select(column('num1', t1))
+      .from(join(t1, t2, {
+        on: eq(column('num3', t1), column('num3', t2))
+      }));
+    const f = filterPushdown(q, t1, gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "s"."t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1" JOIN "s"."t2" ON ("t1"."num3" = "s"."t2"."num3")'
+    );
+  });
+
+  it('updates schema-qualified tables in subqueries', async () => {
+    const t1 = new TableRefNode(['s', 't1']);
+    const q = Query
+      .select('v')
+      .from(Query.select({ v: column('num2', t1) }).from(t1));
+    const f = filterPushdown(q, t1, gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "s"."t1" WHERE ("num2" > 2)) SELECT "v" FROM (SELECT "t1"."num2" AS "v" FROM "_t1" AS "t1")'
+    );
+  });
+
+  it('skips schema-qualified tables in scalar subqueries', async () => {
+    const t1 = new TableRefNode(['s', 't1']);
+    const sub = new ScalarSubqueryNode(
+      Query.select({ count: count(column('num1', t1)) }).from(t1)
+    );
+    const q = Query.select({ norm: div(column('num1', t1), sub) }).from(t1);
+    const f = filterPushdown(q, t1, gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "s"."t1" WHERE ("num2" > 2)) SELECT ("t1"."num1" / (SELECT count("s"."t1"."num1") AS "count" FROM "s"."t1")) AS "norm" FROM "_t1" AS "t1"'
+    );
+  });
+
+  it('does nothing given a table name that matches a different path', async () => {
+    const q = Query.select('num1').from(new TableRefNode(['s', 't1']));
+    const f = filterPushdown(q, 't1', gt('num2', 2));
+    await expect(f).toBeValidQuery('SELECT "num1" FROM "s"."t1"');
+  });
+
+  it('does nothing given a table path that matches a different name', async () => {
+    const q = Query.select('num1').from('t1');
+    const f = filterPushdown(q, new TableRefNode(['s', 't1']), gt('num2', 2));
+    await expect(f).toBeValidQuery('SELECT "num1" FROM "t1"');
+  });
 });

--- a/packages/mosaic/sql/test/util/validate.ts
+++ b/packages/mosaic/sql/test/util/validate.ts
@@ -11,8 +11,9 @@ import { DuckDB } from '@uwdata/mosaic-duckdb';
  * ## Fixture schema
  *
  * Two identical tables, `t1` and `t2` (`t2` exists for joins and set
- * operations). Every column name encodes its type, and each name maps to
- * exactly one type.
+ * operations), plus a copy of each in the `s` schema (`s.t1` and `s.t2` exist
+ * for schema-qualified table references). Every column name encodes its type,
+ * and each name maps to exactly one type.
  *
  * | column           | type        |
  * | ---------------- | ----------- |
@@ -34,6 +35,8 @@ const COLUMNS: Record<string, string> = {
 
 const TABLES = ['t1', 't2'];
 
+const SCHEMAS = ['s'];
+
 const columnDefs = Object.entries(COLUMNS)
   .map(([name, type]) => `"${name}" ${type}`)
   .join(', ');
@@ -42,6 +45,12 @@ async function createDB(): Promise<DuckDB> {
   const db = new DuckDB();
   for (const table of TABLES) {
     await db.exec(`CREATE TABLE ${table} (${columnDefs})`);
+  }
+  for (const schema of SCHEMAS) {
+    await db.exec(`CREATE SCHEMA ${schema}`);
+    for (const table of TABLES) {
+      await db.exec(`CREATE TABLE ${schema}.${table} (${columnDefs})`);
+    }
   }
   return db;
 }


### PR DESCRIPTION
This PR proposes a fix for the two ways `filterPushdown` mishandles schema-qualified table references (Fixes #1101). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/211. You can sign in with your GitHub ID to claim ownership of the project.

## What was wrong

`filterPushdown` identified the filtered table in two different ways. The presence check compared visible names (`node.name`) while the rewrite compared full table paths (`node.table`), so when only the name matched, the rewrite did nothing and the query kept reading the unfiltered table behind a stray CTE. Separately, multi-part column qualifiers were left untouched under the "keep every source visible under its original name" invariant, which a CTE cannot honour: a CTE lives in no schema and an alias is a single identifier, so `"s"."t1"."num1"` no longer binds once the rows come from `"_t1" AS "t1"`.

Both reproduce on `main` at 55b83af. First, dangling full-path qualifiers:

```js
import { column, filterPushdown, gt, Query, TableRefNode } from '@uwdata/mosaic-sql';

const t1 = new TableRefNode(['s', 't1']);
String(filterPushdown(Query.select(column('num1', t1)).from(t1), t1, gt('num2', 2)));
```

```sql
WITH "_t1" AS (SELECT * FROM "s"."t1" WHERE ("num2" > 2)) SELECT "s"."t1"."num1" AS "num1" FROM "_t1" AS "t1"
```

DuckDB rejects that with `Binder Error: Referenced table "s.t1" not found! Candidate tables: "t1"`. Second, the name-versus-path mismatch, where the filter is dropped without any complaint at all:

```js
String(filterPushdown(Query.select('num1').from(new TableRefNode(['s', 't1'])), 't1', gt('num2', 2)));
// WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "num1" FROM "s"."t1"
```

## The change

`packages/mosaic/sql/src/transforms/filter-query.ts` now collects referenced table paths alongside visible names, and the presence check tests the full path so that it agrees with the rewrite: a query over `s.t1` is no longer matched by a bare `t1`, in either direction, and no CTE is emitted when nothing will be rewritten. The CTE-name collision check still uses visible names, since a CTE name is a single identifier. Multi-part qualifiers of the filtered table are rewritten to the visible name (`"s"."t1"."num1"` becomes `"t1"."num1"`), single-part qualifiers keep binding exactly as before, and qualifiers inside scalar subqueries are left alone, so the exemption still reads the unfiltered table.

No exported signature changed. Because a full-path match implies a name match, the new presence check can only skip work the old one attempted — it never rewrites anything the old one did not.

## Verification

Seven cases were added to `packages/mosaic/sql/test/filter-pushdown.test.ts`: the two reports above, plus a schema-qualified join, a schema-qualified subquery, a catalog-qualified (three-part) path, and the scalar-subquery exemption. All of them assert through `toBeValidQuery`, so DuckDB's binder checks each generated statement rather than a string alone; `test/util/validate.ts` gains an `s` schema alongside the existing fixture tables to make that possible. Reverting only `src/transforms/filter-query.ts` to `main` turns all seven red and leaves the fourteen existing cases green.

Full run on `main` at 55b83af: 566 tests passing across 45 files. With this branch: 573 across the same 45 files, no new failures, with `pnpm run typecheck` and `pnpm lint` clean before and after.

## How this was managed

We imported this repository's issues and pull requests into a live board — 984 stories — and used it to manage this work: [the story behind this change](https://eastagiletracker.com/projects/211/stories/77690), on [the Mosaic board](https://eastagiletracker.com/projects/211).

![board](https://raw.githubusercontent.com/eastagiletracker/mosaic/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
