### PR TITLE
fix(sql): make verbatim window detection whitespace-tolerant

### DIFF
--- a/packages/mosaic/sql/src/visit/visitors.ts
+++ b/packages/mosaic/sql/src/visit/visitors.ts
@@ -14,6 +14,9 @@ const aggrRegExp = new RegExp(`^(${aggregateNames.join('|')})$`);
 // function call tokens will have a pattern like "name(".
 const funcRegExp = /(\\'|\\"|"(?:\\"|[^"])*"|'(?:\\'|[^'])*'|\w+\()/g;
 
+// regexp to match window function calls with inline or named definitions
+const windowRegExp = /\)\s*over(\s*\(|\s+[\w"])/;
+
 function hasVerbatimAggregate(s: string) {
   return s
     .split(funcRegExp)
@@ -46,7 +49,7 @@ export function isAggregateExpression(root: SQLNode) {
         if (sub >= 0) s = s.slice(0, sub);
 
         // exit if expression includes windowing
-        if (s.includes(') over ')) return -1;
+        if (windowRegExp.test(s)) return -1;
         if (hasVerbatimAggregate(s)) {
           agg |= 2;
           return -1;

--- a/packages/mosaic/sql/test/visitors.test.ts
+++ b/packages/mosaic/sql/test/visitors.test.ts
@@ -1,7 +1,20 @@
 import { expect, describe, it } from 'vitest';
-import { abs, add, asVerbatim, collectAggregates, collectColumns, collectParams, column, count, div, eq, isAggregateExpression, join, Query, ScalarSubqueryNode, sql, sum } from '../src/index.js';
+import { abs, add, asVerbatim, collectAggregates, collectColumns, collectParams, column, count, div, eq, isAggregateExpression, join, Query, ScalarSubqueryNode, sql, sum, WindowDefNode } from '../src/index.js';
+import type { ExprNode } from '../src/index.js';
 import { stubParam } from './util/stub-param.js';
 import { validateQuery } from './util/validate.js';
+
+// mirrors vgplot markQuery: fields not detected as aggregates become
+// GROUP BY dimensions
+function markStyleQuery(fields: Record<string, ExprNode>) {
+  const q = Query.from('t1').select(fields);
+  const entries = Object.entries(fields);
+  const dims = entries
+    .filter(([, f]) => !isAggregateExpression(f))
+    .map(([as]) => as);
+  if (dims.length < entries.length) q.groupby(dims);
+  return q;
+}
 
 describe('Visitor functions', () => {
   it('include column collection', () => {
@@ -74,6 +87,32 @@ describe('Visitor functions', () => {
     expect(isAggregateExpression(count().orderby('a'))).toBe(0);
     expect(isAggregateExpression(asVerbatim('count(*) OVER (ORDER BY a)'))).toBe(0);
     expect(isAggregateExpression(sql`count(*) OVER (ORDER BY a)`)).toBe(0);
-    expect(isAggregateExpression(sql`count(${column('a')}) OVER (ORDER BY a)`)).toBe(0);    
+    expect(isAggregateExpression(sql`count(${column('a')}) OVER (ORDER BY a)`)).toBe(0);
+  });
+
+  it('include whitespace-tolerant verbatim window detection', async () => {
+    const variants: [string, ExprNode][] = [
+      ['avg(num1) OVER(PARTITION BY txt1)', sql`avg(num1) OVER(PARTITION BY txt1)`],
+      ['avg(num1)\nOVER (PARTITION BY txt1)', sql`avg(num1)\nOVER (PARTITION BY txt1)`],
+      ['avg(num1)  over (partition by txt1)', sql`avg(num1)  over (partition by txt1)`],
+      ['avg(num1) OVER (PARTITION BY txt1)', sql`avg(num1) OVER (PARTITION BY txt1)`]
+    ];
+    for (const [text, expr] of variants) {
+      expect(isAggregateExpression(expr)).toBe(0);
+      await expect(markStyleQuery({ y: expr, d: sql`txt2` })).toBeValidQuery(
+        `SELECT ${text} AS "y", txt2 AS "d" FROM "t1"`
+      );
+    }
+  });
+
+  it('include named-window verbatim window detection', async () => {
+    const expr = sql`avg(num1) OVER win`;
+    expect(isAggregateExpression(expr)).toBe(0);
+    const q = markStyleQuery({ y: expr, d: sql`txt2` })
+      .window({ win: new WindowDefNode().partitionby('txt1') });
+    await expect(q).toBeValidQuery(
+      'SELECT avg(num1) OVER win AS "y", txt2 AS "d" FROM "t1" '
+      + 'WINDOW "win" AS (PARTITION BY "txt1")'
+    );
   });
 });


### PR DESCRIPTION
Fixes #1144.

> **Note:** This fix was created by Claude (an agent team ran a binder-error audit of the SQL layer; the fix went through automated implementation, simplification, and adversarial review passes, plus review notes from @domoritz).

## What changed

The literal `s.includes(') over ')` check in `isAggregateExpression` is replaced by a small regex:

```ts
// regexp to match window function calls with inline or named definitions
const windowRegExp = /\)\s*over(\s*\(|\s+[\w"])/;
```

It tolerates arbitrary whitespace (including none) around `over` and also matches the named-window form (`... over win` / `... over "win"`). Requiring `(` or whitespace-plus-identifier after `over` avoids false positives on `OVERLAPS` / `overlay(...)` — which the old literal check also didn't match.

Regression tests in `test/visitors.test.ts`: the three whitespace variants plus a single-space control, each asserting `isAggregateExpression(...) === 0` and binder-validating the generated markQuery-shaped statement via `toBeValidQuery` (no `GROUP BY` emitted), plus a named-window case using a `WINDOW` clause.

Out of scope (unchanged behavior): a correctly-classified window expression combined with a real aggregate in the same mark still hits vgplot's `markQuery` limitation tracked in #259.

(“F-FN-02” in the commit message is the internal finding ID from the audit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

