### PR TITLE
fix: Issue Querying Motherduck

### DIFF
--- a/packages/mosaic/core/src/util/field-info.ts
+++ b/packages/mosaic/core/src/util/field-info.ts
@@ -11,6 +11,12 @@ export const Min = 'min';
 export const Distinct = 'distinct';
 export const Stats = { Count, Nulls, Max, Min, Distinct };
 
+const UNKNOWN_COLUMN: ColumnDescription = {
+  column_name: 'column',
+  column_type: 'DOUBLE',
+  null: 'YES'
+};
+
 const statMap: Record<Stat, (column: FieldRef) => AggregateNode> = {
   [Count]: count,
   [Distinct]: column => count(column).distinct(),
@@ -66,21 +72,18 @@ async function getFieldInfo(mc: Coordinator, { table, column, stats }: FieldInfo
     .select({ column }, isAggregate ? '*' : {})
     .groupby(isAggregate ? sql`ALL` : []);
 
-  let desc: ColumnDescription;
+  let desc: ColumnDescription | undefined;
   try {
     [desc] = Array.from(
       await mc.query(Query.describe(q))
     ) as ColumnDescription[];
   } catch {
-    // provide dummy description node upon query failure
-    // this handles true aggregates within window functions
-    // DuckDB fails to handle these when using GROUP BY ALL
-    desc = {
-      column_name: 'column',
-      column_type: 'DOUBLE',
-      null: 'YES'
-    };
+    // fall back to the dummy description below
   }
+
+  // a query failure or an empty result both leave the column undescribed
+  // DuckDB fails to handle when using GROUP BY ALL
+  desc ??= UNKNOWN_COLUMN;
 
   const info: FieldInfo = {
     table,

--- a/packages/mosaic/core/src/util/to-data-columns.ts
+++ b/packages/mosaic/core/src/util/to-data-columns.ts
@@ -15,6 +15,13 @@ type DataColumns =
   | { numRows: number; columns: Record<string, Arrayish> }
   | { numRows: number; values: Arrayish };
 
+type ArrowLikeTable = {
+  numRows: number;
+  schema?: { fields?: { name: string }[] };
+  toColumns?: () => Record<string, Arrayish>;
+  getChild: (name: string) => { toArray: () => Arrayish } | null;
+};
+
 /**
  * Convert input data to a set of column arrays.
  * @param data The input data.
@@ -36,8 +43,16 @@ export function toDataColumns(data: unknown): DataColumns {
  * @returns An object with named column arrays.
  */
 function arrowToColumns(data: Table): DataColumns {
-  const { numRows } = data;
-  return { numRows, columns: data.toColumns() as Record<string, Arrayish> };
+  const table = data as unknown as ArrowLikeTable;
+  const { numRows } = table;
+  if (typeof table.toColumns === 'function') {
+    return { numRows, columns: table.toColumns() };
+  }
+  const columns: Record<string, Arrayish> = {};
+  for (const field of table.schema?.fields ?? []) {
+    columns[field.name] = table.getChild(field.name)?.toArray() ?? [];
+  }
+  return { numRows, columns };
 }
 
 /**

--- a/packages/mosaic/core/test/field-info.test.ts
+++ b/packages/mosaic/core/test/field-info.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import type { Coordinator, FieldInfoRequest } from '../src/index.js';
+import { queryFieldInfo } from '../src/index.js';
+
+/**
+ * Stub coordinator that serves describe and summarize queries.
+ * Field info lookups use the coordinator query method only.
+ * @param describeResult Result for the column describe query.
+ * @param summarizeResult Result for the summary statistics query.
+ */
+function stubCoordinator(
+  describeResult: () => unknown,
+  summarizeResult: () => unknown = () => [{}]
+): Coordinator {
+  return {
+    query(query: unknown) {
+      // describe queries are generated as DESC <query>
+      return String(query).startsWith('DESC')
+        ? Promise.resolve(describeResult())
+        : Promise.resolve(summarizeResult());
+    }
+  } as unknown as Coordinator;
+}
+
+const request: FieldInfoRequest = { table: 'taxi', column: 'tip_amount' };
+
+const fallbackInfo = {
+  table: 'taxi',
+  column: 'tip_amount',
+  sqlType: 'DOUBLE',
+  type: 'number',
+  nullable: true
+};
+
+describe('queryFieldInfo', () => {
+  it('falls back to a dummy description for an empty describe result', async () => {
+    const mc = stubCoordinator(() => []);
+    expect(await queryFieldInfo(mc, [request])).toEqual([fallbackInfo]);
+  });
+
+  it('falls back to a dummy description for a failed describe query', async () => {
+    const mc = stubCoordinator(() => { throw new Error('describe failed'); });
+    expect(await queryFieldInfo(mc, [request])).toEqual([fallbackInfo]);
+  });
+
+  it('maps a describe result to field info', async () => {
+    const mc = stubCoordinator(() => [
+      { column_name: 'tip_amount', column_type: 'VARCHAR', null: 'NO' }
+    ]);
+    expect(await queryFieldInfo(mc, [request])).toEqual([{
+      table: 'taxi',
+      column: 'tip_amount',
+      sqlType: 'VARCHAR',
+      type: 'string',
+      nullable: false
+    }]);
+  });
+
+  it('merges requested summary statistics', async () => {
+    const mc = stubCoordinator(
+      () => [{ column_name: 'tip_amount', column_type: 'DOUBLE', null: 'NO' }],
+      () => [{ count: 10, max: 5 }]
+    );
+    const stats: FieldInfoRequest = { ...request, stats: ['count', 'max'] };
+    expect(await queryFieldInfo(mc, [stats])).toEqual([{
+      table: 'taxi',
+      column: 'tip_amount',
+      sqlType: 'DOUBLE',
+      type: 'number',
+      nullable: false,
+      count: 10,
+      max: 5
+    }]);
+  });
+});

--- a/packages/mosaic/core/test/to-data-columns.test.ts
+++ b/packages/mosaic/core/test/to-data-columns.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { toDataColumns } from '../src/index.js';
+
+/**
+ * Stub for a Flechette table, which exposes named columns via toColumns.
+ */
+function flechetteTable(columns: Record<string, unknown[]>, numRows: number) {
+  return {
+    numRows,
+    getChild: () => null,
+    toColumns: () => columns
+  };
+}
+
+/**
+ * Stub for an Arrow table that lacks toColumns, as returned by apache-arrow.
+ * Third-party database connectors may provide tables in this form.
+ */
+function arrowTable(columns: Record<string, unknown[]>, numRows: number) {
+  return {
+    numRows,
+    schema: { fields: Object.keys(columns).map(name => ({ name })) },
+    getChild: (name: string) => name in columns
+      ? { toArray: () => columns[name] }
+      : null
+  };
+}
+
+describe('toDataColumns', () => {
+  it('extracts columns from a Flechette table', () => {
+    const data = flechetteTable({ a: [1, 2], b: ['x', 'y'] }, 2);
+    expect(toDataColumns(data)).toEqual({
+      numRows: 2,
+      columns: { a: [1, 2], b: ['x', 'y'] }
+    });
+  });
+
+  it('extracts columns from an Arrow table without toColumns', () => {
+    const data = arrowTable({ a: [1, 2], b: ['x', 'y'] }, 2);
+    expect(toDataColumns(data)).toEqual({
+      numRows: 2,
+      columns: { a: [1, 2], b: ['x', 'y'] }
+    });
+  });
+
+  it('extracts empty columns for absent Arrow children', () => {
+    const data = {
+      numRows: 0,
+      schema: { fields: [{ name: 'a' }] },
+      getChild: () => null
+    };
+    expect(toDataColumns(data)).toEqual({ numRows: 0, columns: { a: [] } });
+  });
+
+  it('extracts named columns from an array of objects', () => {
+    const data = [{ a: 1, b: 'x' }, { a: 2, b: 'y' }];
+    expect(toDataColumns(data)).toEqual({
+      numRows: 2,
+      columns: { a: [1, 2], b: ['x', 'y'] }
+    });
+  });
+
+  it('extracts values from an array of primitives', () => {
+    expect(toDataColumns([1, 2, 3])).toEqual({ numRows: 3, values: [1, 2, 3] });
+  });
+
+  it('throws for unrecognized data', () => {
+    expect(() => toDataColumns({})).toThrow(/Unrecognized data format/);
+  });
+});


### PR DESCRIPTION
**1. Empty `DESCRIBE` result** — `packages/mosaic/core/src/util/field-info.ts`

`getFieldInfo` wrapped the describe query in a `try/catch`, which covers a *thrown*
query but not a *successful query that returns zero rows*. In that case
`[desc] = Array.from(...)` leaves `desc` undefined and the next line dereferences it:

```
TypeError: Cannot read properties of undefined (reading 'column_type')
  at getFieldInfo (field-info.js:75)
```

The dummy description is now a module constant applied via `desc ??= UNKNOWN_COLUMN`,
so it covers the empty result and the pre-existing window-aggregate failure path alike.

Related upstream: duckdb/duckdb#16017, where `DESCRIBE` discarded renamed columns.
Mosaic's field-info query always aliases `AS "column"`, so it sits directly on that
path — but Mosaic should not crash on an empty result regardless of the backend.

**2. apache-arrow tables** — `packages/mosaic/core/src/util/to-data-columns.ts`

`isArrowTable` duck-types on `getChild` alone, so an `apache-arrow` `Table` passes the
check, but `toColumns()` is Flechette-only:

```
TypeError: data.toColumns is not a function
  at arrowToColumns (to-data-columns.js:35)
```

`arrowToColumns` now calls `toColumns()` when present and otherwise reads columns via
`schema.fields` + `getChild(name).toArray()`, which both implementations support. A
local `ArrowLikeTable` structural type keeps `tsc --build` clean without scattering
casts. The loose `isArrowTable` check is deliberately unchanged — it is what routes
apache-arrow tables into the new branch.


Relates to #662 