### PR TITLE
feat(go-server): reject remote URI literals

### DIFF
--- a/docs/server/index.md
+++ b/docs/server/index.md
@@ -10,32 +10,6 @@ This package provides a local DuckDB server. To instead use DuckDB-WASM in the b
 DuckDB can also connect to and query other databases, such as PostgreSQL and MySQL. See the [multi-database support page](/api/core/multi-database-support) for examples.
 :::
 
-## Go Server
-
-Mosaic also provides an embeddable [DuckDB Go server](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go).
-Applications that need local file readers but want to reject common caller-supplied remote locations can enable the strict
-query option:
-
-```go
-query.WithRemoteURILiteralRejection()
-```
-
-The option rejects recognized remote URI literals in DuckDB replacement scans and
-[reviewed function path arguments](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go/pkg/functionset/remoteread),
-including literal lists and literals within path expressions. Matching is case-insensitive and uses DuckDB 1.5.5's
-prefixes: `http://`, `https://`, `s3://`, `s3a://`, `s3n://`, `gcs://`, `gs://`, `r2://`, `hf://`, `azure://`, `az://`,
-and `abfss://`. Unrelated string literals remain unaffected. Ordinary local paths remain usable unless the path string
-itself contains a recognized marker. Trusted connector initialization can load extensions and attach remote catalogs
-before serving queries; subsequent queries against those catalogs remain usable.
-
-DuckDB's serialized AST cannot distinguish a replacement-scan string from a quoted table or CTE identifier, so URI-shaped
-identifiers are rejected too. This check is best-effort, not a network sandbox. Split or computed strings, macros, views,
-nested SQL, extension-defined schemes, GDAL virtual paths, remote locations reached through local Iceberg or Delta
-metadata, and SQL stored in SQLite views can evade it. Enabling the option also rejects `exec` commands, leaving only
-validated query forms. See the Go server's
-[security documentation](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go#remote-uri-literal-policy)
-for the full boundary.
-
 ## Usage
 
 The server package is available on [PyPi](https://pypi.org/project/duckdb-server/).
@@ -51,3 +25,9 @@ Alternatively, you can install the server with `pip install duckdb-server`. Then
 ## Developer Setup
 
 To run the server from the Mosaic repository and to run the server in development mode, follow the [instructions for the duckdb-server package](https://github.com/uwdata/mosaic/blob/main/packages/server/duckdb-server/README.md).
+
+## Go Server
+
+Mosaic also provides an embeddable [DuckDB Go server](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go).
+See its README for the Go API, query authorization options, and the best-effort
+[remote URI literal policy](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go#remote-uri-literal-policy).

--- a/docs/server/index.md
+++ b/docs/server/index.md
@@ -22,11 +22,11 @@ query.WithRemoteURILiteralRejection()
 
 The option rejects recognized remote URI literals in DuckDB replacement scans and
 [reviewed function path arguments](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go/pkg/functionset/remoteread),
-including literal lists and literals within path expressions. It uses DuckDB 1.5.5's prefixes: `http://`, `https://`,
-`s3://`, `s3a://`, `s3n://`, `gcs://`, `gs://`, `r2://`, `hf://`, `azure://`, `az://`, and `abfss://`. Unrelated string
-literals remain unaffected. Ordinary local paths remain usable unless the path string itself contains a recognized marker.
-Trusted connector initialization can load extensions and attach remote catalogs before serving queries; subsequent queries
-against those catalogs remain usable.
+including literal lists and literals within path expressions. Matching is case-insensitive and uses DuckDB 1.5.5's
+prefixes: `http://`, `https://`, `s3://`, `s3a://`, `s3n://`, `gcs://`, `gs://`, `r2://`, `hf://`, `azure://`, `az://`,
+and `abfss://`. Unrelated string literals remain unaffected. Ordinary local paths remain usable unless the path string
+itself contains a recognized marker. Trusted connector initialization can load extensions and attach remote catalogs
+before serving queries; subsequent queries against those catalogs remain usable.
 
 DuckDB's serialized AST cannot distinguish a replacement-scan string from a quoted table or CTE identifier, so URI-shaped
 identifiers are rejected too. This check is best-effort, not a network sandbox. Split or computed strings, macros, views,

--- a/docs/server/index.md
+++ b/docs/server/index.md
@@ -25,9 +25,3 @@ Alternatively, you can install the server with `pip install duckdb-server`. Then
 ## Developer Setup
 
 To run the server from the Mosaic repository and to run the server in development mode, follow the [instructions for the duckdb-server package](https://github.com/uwdata/mosaic/blob/main/packages/server/duckdb-server/README.md).
-
-## Go Server
-
-Mosaic also provides an embeddable [DuckDB Go server](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go).
-See its README for the Go API, query authorization options, and the best-effort
-[remote URI literal policy](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go#remote-uri-literal-policy).

--- a/docs/server/index.md
+++ b/docs/server/index.md
@@ -10,6 +10,32 @@ This package provides a local DuckDB server. To instead use DuckDB-WASM in the b
 DuckDB can also connect to and query other databases, such as PostgreSQL and MySQL. See the [multi-database support page](/api/core/multi-database-support) for examples.
 :::
 
+## Go Server
+
+Mosaic also provides an embeddable [DuckDB Go server](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go).
+Applications that need local file readers but want to reject common caller-supplied remote locations can enable the strict
+query option:
+
+```go
+query.WithRemoteURILiteralRejection()
+```
+
+The option rejects recognized remote URI literals in DuckDB replacement scans and
+[reviewed function path arguments](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go/pkg/functionset/remoteread),
+including literal lists and literals within path expressions. It uses DuckDB 1.5.5's prefixes: `http://`, `https://`,
+`s3://`, `s3a://`, `s3n://`, `gcs://`, `gs://`, `r2://`, `hf://`, `azure://`, `az://`, and `abfss://`. Unrelated string
+literals remain unaffected. Ordinary local paths remain usable unless the path string itself contains a recognized marker.
+Trusted connector initialization can load extensions and attach remote catalogs before serving queries; subsequent queries
+against those catalogs remain usable.
+
+DuckDB's serialized AST cannot distinguish a replacement-scan string from a quoted table or CTE identifier, so URI-shaped
+identifiers are rejected too. This check is best-effort, not a network sandbox. Split or computed strings, macros, views,
+nested SQL, extension-defined schemes, GDAL virtual paths, remote locations reached through local Iceberg or Delta
+metadata, and SQL stored in SQLite views can evade it. Enabling the option also rejects `exec` commands, leaving only
+validated query forms. See the Go server's
+[security documentation](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go#remote-uri-literal-policy)
+for the full boundary.
+
 ## Usage
 
 The server package is available on [PyPi](https://pypi.org/project/duckdb-server/).

--- a/packages/server/duckdb-server-go/README.md
+++ b/packages/server/duckdb-server-go/README.md
@@ -193,9 +193,10 @@ is a useful autoloading cross-check, but it is not exhaustive: the pinned Azure 
 
 Trusted initialization can still load filesystem extensions and attach remote Iceberg or other catalogs before accepting
 queries. Queries against those attached catalogs use catalog and table identifiers rather than caller-supplied URI
-literals, so they remain usable. Enabling this policy rejects all `exec` commands and rejects the known nested-SQL table
-functions `query` and `json_execute_serialized_sql` outright. `json` and `arrow` requests are limited to statements
-DuckDB can serialize for validation. Connector initialization is outside that command path.
+literals, so they remain usable. Enabling this policy rejects all `exec` commands and rejects the known nested-SQL
+binders and executors `query`, `json_execute_serialized_sql`, and `json_serialize_plan` outright. `json` and `arrow`
+requests are limited to statements DuckDB can serialize for validation. Connector initialization is outside that command
+path.
 
 DuckDB's serialized AST does not distinguish a replacement-scan string from a quoted table or CTE identifier, so a
 URI-shaped identifier is rejected too.

--- a/packages/server/duckdb-server-go/README.md
+++ b/packages/server/duckdb-server-go/README.md
@@ -174,28 +174,39 @@ checks literal lists and every decoded string literal within a path expression, 
 such as `WHERE url = 'https://example.com'` remain unaffected. Ordinary local paths without a recognized marker remain
 usable; a local path string containing one of the markers is intentionally rejected.
 
-Matching is case-insensitive and rejects a literal if it contains any prefix from DuckDB 1.5.5's
-[extension-prefix map](https://github.com/duckdb/duckdb/blob/v1.5.5/src/include/duckdb/main/extension_entries.hpp#L1275-L1280):
+Matching is case-insensitive and rejects a literal if it contains any prefix reviewed against DuckDB 1.5.5's pinned
+[HTTP](https://github.com/duckdb/duckdb-httpfs/blob/827222fb45a043a7a852d1f7aae46901492a3cda/src/httpfs.cpp#L808-L810),
+[S3-compatible](https://github.com/duckdb/duckdb-httpfs/blob/827222fb45a043a7a852d1f7aae46901492a3cda/src/s3fs.cpp#L843-L848),
+[Hugging Face](https://github.com/duckdb/duckdb-httpfs/blob/827222fb45a043a7a852d1f7aae46901492a3cda/src/include/hffs.hpp#L33-L35),
+[Azure Blob](https://github.com/duckdb/duckdb-azure/blob/003214c96d0caa39d5c3e27a9e1976a0692c7d37/src/azure_blob_filesystem.cpp#L32-L36),
+and [Azure DFS](https://github.com/duckdb/duckdb-azure/blob/003214c96d0caa39d5c3e27a9e1976a0692c7d37/src/azure_dfs_filesystem.cpp#L27-L34)
+filesystem handlers:
 
 ```text
 http://  https://  s3://  s3a://  s3n://  gcs://
-gs://    r2://     hf://  azure://  az://   abfss://
+gs://    r2://     hf://  azure://  az://   abfs://  abfss://
 ```
+
+DuckDB's generated
+[extension-prefix map](https://github.com/duckdb/duckdb/blob/v1.5.5/src/include/duckdb/main/extension_entries.hpp#L1275-L1280)
+is a useful autoloading cross-check, but it is not exhaustive: the pinned Azure DFS filesystem also accepts `abfs://`.
 
 Trusted initialization can still load filesystem extensions and attach remote Iceberg or other catalogs before accepting
 queries. Queries against those attached catalogs use catalog and table identifiers rather than caller-supplied URI
-literals, so they remain usable. Enabling this policy rejects all `exec` commands; `json` and `arrow` requests are limited
-to statements DuckDB can serialize for validation. Connector initialization is outside that command path.
+literals, so they remain usable. Enabling this policy rejects all `exec` commands and rejects the known nested-SQL table
+functions `query` and `json_execute_serialized_sql` outright. `json` and `arrow` requests are limited to statements
+DuckDB can serialize for validation. Connector initialization is outside that command path.
 
 DuckDB's serialized AST does not distinguish a replacement-scan string from a quoted table or CTE identifier, so a
 URI-shaped identifier is rejected too.
 
-This is an intentionally incomplete hardening layer, not a filesystem or network sandbox. A constructed value can evade
-detection when no individual literal contains a complete reviewed prefix, as in `'gc' || 's://bucket/file.parquet'`.
-Macros and views are not expanded, nested SQL strings are not recursively inspected, and extensions can define unreviewed
-functions or schemes. Other known gaps include GDAL virtual paths such as `/vsis3/`, local Iceberg or Delta metadata that
-refers to remote files, and SQL stored in a local SQLite view. Keep catalogs, extensions, and initialization SQL trusted,
-and restrict the server process's filesystem, network, and credentials independently.
+This is intentionally incomplete hardening against common accidental or opportunistic remote scans, not a filesystem or
+network sandbox. Split or otherwise computed path values can evade detection when no individual literal contains a
+complete reviewed prefix, as in `'gc' || 's://bucket/file.parquet'`. Macros and views are not expanded, and unreviewed
+extensions can define other nested-SQL executors, reader functions, or schemes. Other known gaps include GDAL virtual
+paths such as `/vsis3/`, local Iceberg or Delta metadata that refers to remote files, and SQL stored in a local SQLite
+view. Keep catalogs, extensions, and initialization SQL trusted, and restrict the server process's filesystem, network,
+and credentials independently.
 
 ### Multi-Tenant Access Control
 

--- a/packages/server/duckdb-server-go/README.md
+++ b/packages/server/duckdb-server-go/README.md
@@ -140,11 +140,12 @@ An empty row means the extension has no reviewed function-call names, not that i
 | `Vortex` | 0 | 2 | Readers verified against the pinned nested source revision. |
 | `VSS` | 0 | 5 | Index access and management operations. |
 
-These groups authorize names only; extension loading and file or network access are separate concerns. Validation is
-syntactic and name-only: it does not bind function identity, inspect arguments, expand macros or views, recursively inspect
-SQL strings, or cover replacement scans and attached-table binding. Keep catalogs and the search path trusted, and enforce
-resource access outside this policy. Pre-provisioned views and attached tables can deliberately expose curated datasets
-while reader functions remain excluded; catalog integrity and process resource controls then carry the boundary.
+These groups authorize names only; extension loading and file or network access are separate concerns. Function-policy
+validation is syntactic and name-only: it does not bind function identity, inspect arguments, expand macros or views,
+recursively inspect SQL strings, or cover replacement scans and attached-table binding. Keep catalogs and the search path
+trusted, and enforce resource access outside this policy. Pre-provisioned views and attached tables can deliberately expose
+curated datasets while reader functions remain excluded; catalog integrity and process resource controls then carry the
+boundary.
 
 In Go, `Exclude` wins over `Include`, and `DisableDefaults` creates an exact-only policy. Omitting
 `WithFunctionAllowlist` is unrestricted; configuring an exact-empty policy denies all function calls. A function
@@ -153,6 +154,48 @@ allowlist cannot be combined with a non-empty blocklist, and any configured func
 Spatial compute defaults cover Mosaic rendering over existing geometry data, but the `ST_Read` loader remains elevated.
 Current-time functions are omitted from defaults because persistent cache entries do not expire by default; keyword forms
 such as `CURRENT_DATE` are not function nodes and remain outside this policy.
+
+### Remote URI Literal Policy
+
+Programs embedding `pkg/query` can make a best-effort to reject caller-supplied remote file locations while keeping local
+file readers enabled:
+
+```go
+db, err := query.New(ctx, connector,
+	query.WithRemoteURILiteralRejection(),
+)
+```
+
+The option rejects recognized remote URI literals in DuckDB replacement scans, such as
+`FROM 'gcs://bucket/file.parquet'`, and in the reviewed positional and named path arguments of
+[remote-read-capable functions](./pkg/functionset/remoteread/README.md). It also
+checks literal lists and every decoded string literal within a path expression, so
+`read_parquet('gcs://' || 'bucket/file.parquet')` is rejected. Only reviewed path arguments are checked; unrelated values
+such as `WHERE url = 'https://example.com'` remain unaffected. Ordinary local paths without a recognized marker remain
+usable; a local path string containing one of the markers is intentionally rejected.
+
+Matching is case-sensitive and rejects a literal if it contains any prefix from DuckDB 1.5.5's
+[extension-prefix map](https://github.com/duckdb/duckdb/blob/v1.5.5/src/include/duckdb/main/extension_entries.hpp#L1264-L1269):
+
+```text
+http://  https://  s3://  s3a://  s3n://  gcs://
+gs://    r2://     hf://  azure://  az://   abfss://
+```
+
+Trusted initialization can still load filesystem extensions and attach remote Iceberg or other catalogs before accepting
+queries. Queries against those attached catalogs use catalog and table identifiers rather than caller-supplied URI
+literals, so they remain usable. Enabling this policy rejects all `exec` commands; `json` and `arrow` requests are limited
+to statements DuckDB can serialize for validation. Connector initialization is outside that command path.
+
+DuckDB's serialized AST does not distinguish a replacement-scan string from a quoted table or CTE identifier, so a
+URI-shaped identifier is rejected too.
+
+This is an intentionally incomplete hardening layer, not a filesystem or network sandbox. A constructed value can evade
+detection when no individual literal contains a complete reviewed prefix, as in `'gc' || 's://bucket/file.parquet'`.
+Macros and views are not expanded, nested SQL strings are not recursively inspected, and extensions can define unreviewed
+functions or schemes. Other known gaps include GDAL virtual paths such as `/vsis3/`, local Iceberg or Delta metadata that
+refers to remote files, and SQL stored in a local SQLite view. Keep catalogs, extensions, and initialization SQL trusted,
+and restrict the server process's filesystem, network, and credentials independently.
 
 ### Multi-Tenant Access Control
 

--- a/packages/server/duckdb-server-go/README.md
+++ b/packages/server/duckdb-server-go/README.md
@@ -174,8 +174,8 @@ checks literal lists and every decoded string literal within a path expression, 
 such as `WHERE url = 'https://example.com'` remain unaffected. Ordinary local paths without a recognized marker remain
 usable; a local path string containing one of the markers is intentionally rejected.
 
-Matching is case-sensitive and rejects a literal if it contains any prefix from DuckDB 1.5.5's
-[extension-prefix map](https://github.com/duckdb/duckdb/blob/v1.5.5/src/include/duckdb/main/extension_entries.hpp#L1264-L1269):
+Matching is case-insensitive and rejects a literal if it contains any prefix from DuckDB 1.5.5's
+[extension-prefix map](https://github.com/duckdb/duckdb/blob/v1.5.5/src/include/duckdb/main/extension_entries.hpp#L1275-L1280):
 
 ```text
 http://  https://  s3://  s3a://  s3n://  gcs://

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/AGENTS.md
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/AGENTS.md
@@ -23,6 +23,16 @@ directory.
 - Separately audit replacement scans and non-function read surfaces on every
   DuckDB upgrade. Document them in `README.md`; do not add them to this
   function-argument API.
+- Re-audit core nested-SQL table functions on every DuckDB upgrade. Keep the
+  query policy's rejection list and tests synchronized; do not add SQL-string
+  arguments to this path inventory.
+- Re-audit the query policy's remote prefixes against every bundled or loaded
+  filesystem's `CanHandleFile` implementation, its helper predicates, and its
+  scheme constants at the exact pinned extension revisions. Review HTTPFS's
+  HTTP, S3-compatible, GCS, R2, and Hugging Face handlers and Azure's Blob and
+  DFS handlers. Treat DuckDB's generated extension-prefix map as an autoloading
+  cross-check, not an exhaustive filesystem inventory; DuckDB 1.5.5's map omits
+  `abfs://`, which its pinned Azure DFS filesystem accepts.
 - Run `go test ./pkg/functionset/remoteread` from
   `packages/server/duckdb-server-go`. The invariant tests must cover every
   inventoried name and selector.

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/AGENTS.md
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/AGENTS.md
@@ -1,0 +1,28 @@
+# Remote-read function inventory
+
+These rules extend the parent `functionset` inventory guidance for this
+directory.
+
+- Keep this package data-only. It identifies arguments through which reviewed
+  functions can receive a caller-controlled URI or path; query parsing,
+  expression traversal, URI-prefix matching, replacement scans, and policy
+  errors belong to the query package.
+- Audit the exact DuckDB release bundled by `duckdb-go` and the exact external
+  extension revisions pinned by that release. Trace registrations, overloads,
+  aliases, macros, parser rewrites, and the code that opens or resolves the
+  argument. Use `duckdb_functions()` only as a cross-check.
+- Include every positional and named selector that can carry a path across all
+  overloads. Positional indexes are zero-based among unnamed SQL arguments;
+  named selectors use DuckDB's lowercase serialized names.
+- This is a deny-oriented sink inventory. Do not silently omit a credible but
+  uncertain reader: resolve it against pinned source or include it
+  conservatively and document the uncertainty in `README.md`.
+- Keep source groups, function names, positional indexes, and named selectors
+  sorted and deduplicated. Update the pinned sources, inventory table,
+  exclusions, limitations, and count in `README.md` with every change.
+- Separately audit replacement scans and non-function read surfaces on every
+  DuckDB upgrade. Document them in `README.md`; do not add them to this
+  function-argument API.
+- Run `go test ./pkg/functionset/remoteread` from
+  `packages/server/duckdb-server-go`. The invariant tests must cover every
+  inventoried name and selector.

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/AGENTS.md
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/AGENTS.md
@@ -14,6 +14,11 @@ directory.
 - Include every positional and named selector that can carry a path across all
   overloads. Positional indexes are zero-based among unnamed SQL arguments;
   named selectors use DuckDB's lowercase serialized names.
+- Trace bind-time and helper I/O, including in autoloadable functions, that
+  derive a path from a larger argument, not only arguments passed directly to
+  `OpenFile`. In DuckDB 1.5.5, `sql_auto_complete` can derive a
+  filename-suggestion directory from SQL text and pass it to
+  `FileSystem::ListFiles`.
 - This is a deny-oriented sink inventory. Do not silently omit a credible but
   uncertain reader: resolve it against pinned source or include it
   conservatively and document the uncertainty in `README.md`.
@@ -23,9 +28,11 @@ directory.
 - Separately audit replacement scans and non-function read surfaces on every
   DuckDB upgrade. Document them in `README.md`; do not add them to this
   function-argument API.
-- Re-audit core nested-SQL table functions on every DuckDB upgrade. Keep the
-  query policy's rejection list and tests synchronized; do not add SQL-string
-  arguments to this path inventory.
+- Re-audit stock and autoloadable functions that bind or execute nested SQL on
+  every DuckDB upgrade, including scalar functions. Keep the query policy's
+  rejection list and tests synchronized. Keep bind/execute-only SQL-string
+  arguments out of this path inventory; include SQL text when a helper derives
+  a caller-controlled filesystem path from it.
 - Re-audit the query policy's remote prefixes against every bundled or loaded
   filesystem's `CanHandleFile` implementation, its helper predicates, and its
   scheme constants at the exact pinned extension revisions. Review HTTPFS's

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/README.md
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/README.md
@@ -1,0 +1,49 @@
+# Remote-read function inventory
+
+This package identifies reviewed DuckDB functions whose arguments can cause a
+caller-controlled URI or path to be read. It is intentionally only an
+inventory: the query package decides which expressions to inspect and which URI
+prefixes to reject.
+
+The inventory contains 58 normalized function names reviewed against DuckDB
+1.5.5 at
+[`d8cdaa33`](https://github.com/duckdb/duckdb/tree/d8cdaa33fda8df955cc76ef58a280f68f4cd43fa).
+Positional indexes are zero-based among unnamed SQL arguments. Named selectors
+are lowercase DuckDB argument names. Each entry unions the path-bearing
+selectors of all reviewed overloads.
+
+| Source | Selectors | Functions |
+| --- | --- | --- |
+| [DuckDB core](https://github.com/duckdb/duckdb/tree/d8cdaa33fda8df955cc76ef58a280f68f4cd43fa/src/function/table) | `0`; `histogram` and `histogram_values` also `source` | `glob`, `histogram`, `histogram_values`, `query_table`, `read_blob`, `read_csv`, `read_csv_auto`, `read_duckdb`, `read_text`, `sniff_csv` |
+| [Parquet](https://github.com/duckdb/duckdb/tree/d8cdaa33fda8df955cc76ef58a280f68f4cd43fa/extension/parquet) | `0` | `parquet_bloom_probe`, `parquet_file_metadata`, `parquet_full_metadata`, `parquet_kv_metadata`, `parquet_metadata`, `parquet_scan`, `parquet_schema`, `read_parquet` |
+| [JSON](https://github.com/duckdb/duckdb/tree/d8cdaa33fda8df955cc76ef58a280f68f4cd43fa/extension/json) | `0` | `read_json`, `read_json_auto`, `read_json_objects`, `read_json_objects_auto`, `read_ndjson`, `read_ndjson_auto`, `read_ndjson_objects` |
+| [Delta](https://github.com/duckdb/duckdb-delta/tree/45c40878601b54b4188b09e08732fe0d576ad222) | `0`; `copy_dir` also `src_dir`; `delta_scan` also `log_tail` | `copy_dir`, `delta_domain_metadata`, `delta_list_files`, `delta_scan` |
+| [Iceberg](https://github.com/duckdb/duckdb-iceberg/tree/45163a28e0ed6a2071a82a1bf1dd432d0216cf9c) | `0` | `iceberg_column_stats`, `iceberg_metadata`, `iceberg_partition_stats`, `iceberg_scan`, `iceberg_snapshots` |
+| [Spatial](https://github.com/duckdb/duckdb-spatial/tree/eb1e57c9d92c0f3f76eb03eaa52c315090f328cc) | `0`; `st_read` also `sibling_files` | `shapefile_meta`, `st_read`, `st_read_meta`, `st_readosm`, `st_readshp` |
+| [Lance](https://github.com/lance-format/lance-duckdb/tree/2f167ea1aa8b1201c89d53740b84deb00aff680e) | `0` | `__lance_cleanup_old_versions`, `__lance_compact_files`, `__lance_exec`, `__lance_namespace_scan`, `__lance_optimize_index`, `__lance_scan`, `__lance_set_auto_cleanup`, `__lance_show_auto_cleanup`, `lance_fts`, `lance_hybrid_search`, `lance_vector_search` |
+| [DuckLake](https://github.com/duckdb/ducklake/tree/d8a1881e22516ea3d186d73e83c65fe5bd1a1dc4) | `2` | `ducklake_add_data_files` |
+| [SQLite](https://github.com/duckdb/duckdb-sqlite/tree/f79b1db7d7730b18d0f8400d3650ffa6b45168d8) | `0` | `sqlite_attach`, `sqlite_scan` |
+| [Avro](https://github.com/duckdb/duckdb-avro/tree/f9d590297485f0318f480372c70bdd852826e258) | `0` | `read_avro` |
+| [Excel](https://github.com/duckdb/duckdb-excel/tree/f4c72b5ef04a03b3a78a95b5a2ee94ba93e3178d) | `0` | `read_xlsx` |
+| [Postgres](https://github.com/duckdb/duckdb-postgres/tree/41223e51559cd581f1c06e170b71c71df25bbaac) | `0` | `read_postgres_binary` |
+| [Vortex](https://github.com/vortex-data/duckdb-vortex/tree/2a008b1734d563f46a1ff0af3a758f4fd844ea91) | `0` | `read_vortex`, `vortex_scan` |
+
+`copy_dir` is included because it reads its source before writing. DuckLake's
+add-files function reads metadata from its third argument. Lance maintenance
+functions open the dataset identified by their first argument, and
+`__lance_namespace_scan` reads an HTTP endpoint. `sqlite_attach` is the legacy
+table function, not the SQL `ATTACH` statement.
+
+The review deliberately excludes nested SQL functions; attached-catalog
+functions whose arguments are catalog or table identifiers; Postgres, MySQL,
+and ODBC connection-string functions; pure write destinations; Lance functions
+whose arguments are only catalog identifiers; and proprietary or unpinned
+extension behavior. `ducklake_scan` is excluded because its catalog-visible
+argument is not used as a caller-provided path during normal binding.
+
+Replacement scans are a separate query AST surface. DuckDB 1.5.5 rewrites
+recognized CSV/TSV, DuckDB database, Parquet, JSON, XLSX, Spatial, and Lance
+paths to reader functions. A caller can also evade literal inspection through
+macros, views, nested SQL, extension-defined schemes, metadata that references
+remote files, or filesystem conventions such as GDAL `/vsi*` paths. This
+inventory is best-effort hardening, not a sandbox.

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/README.md
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/README.md
@@ -13,7 +13,7 @@ filesystem sources. DuckDB's generated extension-prefix map is only an
 autoloading cross-check and omits `abfs://`, which the pinned Azure DFS
 filesystem accepts.
 
-The inventory contains 58 normalized function names reviewed against DuckDB
+The inventory contains 59 normalized function names reviewed against DuckDB
 1.5.5 at
 [`d8cdaa33`](https://github.com/duckdb/duckdb/tree/d8cdaa33fda8df955cc76ef58a280f68f4cd43fa).
 Positional indexes are zero-based among unnamed SQL arguments. Named selectors
@@ -22,6 +22,7 @@ selectors of all reviewed overloads.
 
 | Source | Selectors | Functions |
 | --- | --- | --- |
+| [Autocomplete](https://github.com/duckdb/duckdb/blob/v1.5.5/extension/autocomplete/autocomplete_extension.cpp#L389-L411) | `0` | `sql_auto_complete` |
 | [DuckDB core](https://github.com/duckdb/duckdb/tree/d8cdaa33fda8df955cc76ef58a280f68f4cd43fa/src/function/table) | `0`; `histogram` and `histogram_values` also `source` | `glob`, `histogram`, `histogram_values`, `query_table`, `read_blob`, `read_csv`, `read_csv_auto`, `read_duckdb`, `read_text`, `sniff_csv` |
 | [Parquet](https://github.com/duckdb/duckdb/tree/d8cdaa33fda8df955cc76ef58a280f68f4cd43fa/extension/parquet) | `0` | `parquet_bloom_probe`, `parquet_file_metadata`, `parquet_full_metadata`, `parquet_kv_metadata`, `parquet_metadata`, `parquet_scan`, `parquet_schema`, `read_parquet` |
 | [JSON](https://github.com/duckdb/duckdb/tree/d8cdaa33fda8df955cc76ef58a280f68f4cd43fa/extension/json) | `0` | `read_json`, `read_json_auto`, `read_json_objects`, `read_json_objects_auto`, `read_ndjson`, `read_ndjson_auto`, `read_ndjson_objects` |
@@ -40,15 +41,20 @@ selectors of all reviewed overloads.
 add-files function reads metadata from its third argument. Lance maintenance
 functions open the dataset identified by their first argument, and
 `__lance_namespace_scan` reads an HTTP endpoint. `sqlite_attach` is the legacy
-table function, not the SQL `ATTACH` statement.
+table function, not the SQL `ATTACH` statement. The autoloadable
+[`sql_auto_complete`](https://github.com/duckdb/duckdb/blob/v1.5.5/src/include/duckdb/main/extension_entries.hpp#L605)
+[registers one positional SQL-text argument and only suggestion-count named arguments](https://github.com/duckdb/duckdb/blob/v1.5.5/extension/autocomplete/autocomplete_extension.cpp#L900-L906),
+then can pass an unterminated quoted path from that text to
+[`FileSystem::ListFiles`](https://github.com/duckdb/duckdb/blob/v1.5.5/extension/autocomplete/autocomplete_extension.cpp#L389-L411).
 
 The path-selector review deliberately excludes nested-SQL functions; the query
-policy separately rejects the known core nested-SQL table functions. It also
-excludes attached-catalog functions whose arguments are catalog or table
-identifiers; Postgres, MySQL, and ODBC connection-string functions; pure write
-destinations; Lance functions whose arguments are only catalog identifiers; and
-proprietary or unpinned extension behavior. `ducklake_scan` is excluded because
-its catalog-visible argument is not used as a caller-provided path during normal
+policy separately rejects the known stock and autoloadable binders and
+executors `query`, `json_execute_serialized_sql`, and `json_serialize_plan`.
+It also excludes attached-catalog functions whose arguments are catalog or table identifiers;
+Postgres, MySQL, and ODBC connection-string functions; pure write destinations;
+Lance functions whose arguments are only catalog identifiers; and proprietary
+or unpinned extension behavior. `ducklake_scan` is excluded because its
+catalog-visible argument is not used as a caller-provided path during normal
 binding.
 
 Replacement scans are a separate query AST surface. DuckDB 1.5.5 rewrites

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/README.md
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/README.md
@@ -5,6 +5,14 @@ caller-controlled URI or path to be read. It is intentionally only an
 inventory: the query package decides which expressions to inspect and which URI
 prefixes to reject.
 
+The query-layer prefix inventory is reviewed separately against the actual
+`CanHandleFile` routing and scheme helpers in the pinned
+[HTTPFS](https://github.com/duckdb/duckdb-httpfs/tree/827222fb45a043a7a852d1f7aae46901492a3cda/src) and
+[Azure](https://github.com/duckdb/duckdb-azure/tree/003214c96d0caa39d5c3e27a9e1976a0692c7d37/src)
+filesystem sources. DuckDB's generated extension-prefix map is only an
+autoloading cross-check and omits `abfs://`, which the pinned Azure DFS
+filesystem accepts.
+
 The inventory contains 58 normalized function names reviewed against DuckDB
 1.5.5 at
 [`d8cdaa33`](https://github.com/duckdb/duckdb/tree/d8cdaa33fda8df955cc76ef58a280f68f4cd43fa).
@@ -34,16 +42,20 @@ functions open the dataset identified by their first argument, and
 `__lance_namespace_scan` reads an HTTP endpoint. `sqlite_attach` is the legacy
 table function, not the SQL `ATTACH` statement.
 
-The review deliberately excludes nested SQL functions; attached-catalog
-functions whose arguments are catalog or table identifiers; Postgres, MySQL,
-and ODBC connection-string functions; pure write destinations; Lance functions
-whose arguments are only catalog identifiers; and proprietary or unpinned
-extension behavior. `ducklake_scan` is excluded because its catalog-visible
-argument is not used as a caller-provided path during normal binding.
+The path-selector review deliberately excludes nested-SQL functions; the query
+policy separately rejects the known core nested-SQL table functions. It also
+excludes attached-catalog functions whose arguments are catalog or table
+identifiers; Postgres, MySQL, and ODBC connection-string functions; pure write
+destinations; Lance functions whose arguments are only catalog identifiers; and
+proprietary or unpinned extension behavior. `ducklake_scan` is excluded because
+its catalog-visible argument is not used as a caller-provided path during normal
+binding.
 
 Replacement scans are a separate query AST surface. DuckDB 1.5.5 rewrites
 recognized CSV/TSV, DuckDB database, Parquet, JSON, XLSX, Spatial, and Lance
 paths to reader functions. A caller can also evade literal inspection through
-macros, views, nested SQL, extension-defined schemes, metadata that references
-remote files, or filesystem conventions such as GDAL `/vsi*` paths. This
-inventory is best-effort hardening, not a sandbox.
+constructed path expressions, macros, views, unreviewed nested-SQL executors,
+extension-defined schemes, metadata that references remote files, or filesystem
+conventions such as GDAL `/vsi*` paths. This inventory supports best-effort
+hardening against common accidental or opportunistic remote scans, not a
+sandbox.

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/autocomplete.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/autocomplete.go
@@ -1,0 +1,5 @@
+package remoteread
+
+var autocompleteFunctions = map[string]PathArguments{
+	"sql_auto_complete": positionalPath(0),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/avro.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/avro.go
@@ -1,0 +1,5 @@
+package remoteread
+
+var avroFunctions = map[string]PathArguments{
+	"read_avro": positionalPath(0),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/core.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/core.go
@@ -1,0 +1,14 @@
+package remoteread
+
+var coreFunctions = map[string]PathArguments{
+	"glob":             positionalPath(0),
+	"histogram":        positionalPath(0, "source"),
+	"histogram_values": positionalPath(0, "source"),
+	"query_table":      positionalPath(0),
+	"read_blob":        positionalPath(0),
+	"read_csv":         positionalPath(0),
+	"read_csv_auto":    positionalPath(0),
+	"read_duckdb":      positionalPath(0),
+	"read_text":        positionalPath(0),
+	"sniff_csv":        positionalPath(0),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/delta.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/delta.go
@@ -1,0 +1,8 @@
+package remoteread
+
+var deltaFunctions = map[string]PathArguments{
+	"copy_dir":              positionalPath(0, "src_dir"),
+	"delta_domain_metadata": positionalPath(0),
+	"delta_list_files":      positionalPath(0),
+	"delta_scan":            positionalPath(0, "log_tail"),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/doc.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/doc.go
@@ -1,0 +1,2 @@
+// Package remoteread provides reviewed DuckDB function path-argument inventories.
+package remoteread

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/ducklake.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/ducklake.go
@@ -1,0 +1,5 @@
+package remoteread
+
+var duckLakeFunctions = map[string]PathArguments{
+	"ducklake_add_data_files": positionalPath(2),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/excel.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/excel.go
@@ -1,0 +1,5 @@
+package remoteread
+
+var excelFunctions = map[string]PathArguments{
+	"read_xlsx": positionalPath(0),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/iceberg.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/iceberg.go
@@ -1,0 +1,9 @@
+package remoteread
+
+var icebergFunctions = map[string]PathArguments{
+	"iceberg_column_stats":    positionalPath(0),
+	"iceberg_metadata":        positionalPath(0),
+	"iceberg_partition_stats": positionalPath(0),
+	"iceberg_scan":            positionalPath(0),
+	"iceberg_snapshots":       positionalPath(0),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/inventory.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/inventory.go
@@ -38,12 +38,13 @@ var inventoryGroups = [...]inventoryGroup{
 var inventory = mergeInventories(inventoryGroups[:])
 
 // Lookup returns the reviewed path arguments for a function name.
+// The returned slices alias package state and must not be mutated.
 func Lookup(name string) (PathArguments, bool) {
 	arguments, ok := inventory[strings.ToLower(strings.TrimSpace(name))]
 	if !ok {
 		return PathArguments{}, false
 	}
-	return cloneArguments(arguments), true
+	return arguments, true
 }
 
 // FunctionNames returns the sorted reviewed function names.
@@ -70,15 +71,8 @@ func mergeInventories(groups []inventoryGroup) map[string]PathArguments {
 			if _, ok := functions[name]; ok {
 				panic("duplicate remote-read function: " + name)
 			}
-			functions[name] = cloneArguments(arguments)
+			functions[name] = arguments
 		}
 	}
 	return functions
-}
-
-func cloneArguments(arguments PathArguments) PathArguments {
-	return PathArguments{
-		Positional: slices.Clone(arguments.Positional),
-		Named:      slices.Clone(arguments.Named),
-	}
 }

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/inventory.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/inventory.go
@@ -1,0 +1,83 @@
+package remoteread
+
+import (
+	"slices"
+	"strings"
+)
+
+// PathArguments identifies arguments that can carry a URI or path.
+type PathArguments struct {
+	// Positional contains zero-based indexes among unnamed SQL arguments.
+	Positional []int
+	// Named contains lowercase DuckDB argument names.
+	Named []string
+}
+
+type inventoryGroup struct {
+	name      string
+	functions map[string]PathArguments
+}
+
+var inventoryGroups = [...]inventoryGroup{
+	{name: "avro", functions: avroFunctions},
+	{name: "core", functions: coreFunctions},
+	{name: "delta", functions: deltaFunctions},
+	{name: "ducklake", functions: duckLakeFunctions},
+	{name: "excel", functions: excelFunctions},
+	{name: "iceberg", functions: icebergFunctions},
+	{name: "json", functions: jsonFunctions},
+	{name: "lance", functions: lanceFunctions},
+	{name: "parquet", functions: parquetFunctions},
+	{name: "postgres", functions: postgresFunctions},
+	{name: "spatial", functions: spatialFunctions},
+	{name: "sqlite", functions: sqliteFunctions},
+	{name: "vortex", functions: vortexFunctions},
+}
+
+var inventory = mergeInventories(inventoryGroups[:])
+
+// Lookup returns the reviewed path arguments for a function name.
+func Lookup(name string) (PathArguments, bool) {
+	arguments, ok := inventory[strings.ToLower(strings.TrimSpace(name))]
+	if !ok {
+		return PathArguments{}, false
+	}
+	return cloneArguments(arguments), true
+}
+
+// FunctionNames returns the sorted reviewed function names.
+func FunctionNames() []string {
+	names := make([]string, 0, len(inventory))
+	for name := range inventory {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func positionalPath(index int, named ...string) PathArguments {
+	return PathArguments{
+		Positional: []int{index},
+		Named:      named,
+	}
+}
+
+func mergeInventories(groups []inventoryGroup) map[string]PathArguments {
+	functions := make(map[string]PathArguments)
+	for _, group := range groups {
+		for name, arguments := range group.functions {
+			if _, ok := functions[name]; ok {
+				panic("duplicate remote-read function: " + name)
+			}
+			functions[name] = cloneArguments(arguments)
+		}
+	}
+	return functions
+}
+
+func cloneArguments(arguments PathArguments) PathArguments {
+	return PathArguments{
+		Positional: slices.Clone(arguments.Positional),
+		Named:      slices.Clone(arguments.Named),
+	}
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/inventory.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/inventory.go
@@ -19,6 +19,7 @@ type inventoryGroup struct {
 }
 
 var inventoryGroups = [...]inventoryGroup{
+	{name: "autocomplete", functions: autocompleteFunctions},
 	{name: "avro", functions: avroFunctions},
 	{name: "core", functions: coreFunctions},
 	{name: "delta", functions: deltaFunctions},

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/inventory_test.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/inventory_test.go
@@ -59,6 +59,7 @@ var expectedFunctionNames = []string{
 	"read_xlsx",
 	"shapefile_meta",
 	"sniff_csv",
+	"sql_auto_complete",
 	"sqlite_attach",
 	"sqlite_scan",
 	"st_read",

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/inventory_test.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/inventory_test.go
@@ -1,0 +1,173 @@
+package remoteread
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+var expectedFunctionNames = []string{
+	"__lance_cleanup_old_versions",
+	"__lance_compact_files",
+	"__lance_exec",
+	"__lance_namespace_scan",
+	"__lance_optimize_index",
+	"__lance_scan",
+	"__lance_set_auto_cleanup",
+	"__lance_show_auto_cleanup",
+	"copy_dir",
+	"delta_domain_metadata",
+	"delta_list_files",
+	"delta_scan",
+	"ducklake_add_data_files",
+	"glob",
+	"histogram",
+	"histogram_values",
+	"iceberg_column_stats",
+	"iceberg_metadata",
+	"iceberg_partition_stats",
+	"iceberg_scan",
+	"iceberg_snapshots",
+	"lance_fts",
+	"lance_hybrid_search",
+	"lance_vector_search",
+	"parquet_bloom_probe",
+	"parquet_file_metadata",
+	"parquet_full_metadata",
+	"parquet_kv_metadata",
+	"parquet_metadata",
+	"parquet_scan",
+	"parquet_schema",
+	"query_table",
+	"read_avro",
+	"read_blob",
+	"read_csv",
+	"read_csv_auto",
+	"read_duckdb",
+	"read_json",
+	"read_json_auto",
+	"read_json_objects",
+	"read_json_objects_auto",
+	"read_ndjson",
+	"read_ndjson_auto",
+	"read_ndjson_objects",
+	"read_parquet",
+	"read_postgres_binary",
+	"read_text",
+	"read_vortex",
+	"read_xlsx",
+	"shapefile_meta",
+	"sniff_csv",
+	"sqlite_attach",
+	"sqlite_scan",
+	"st_read",
+	"st_read_meta",
+	"st_readosm",
+	"st_readshp",
+	"vortex_scan",
+}
+
+func TestInventory(t *testing.T) {
+	if got := FunctionNames(); !reflect.DeepEqual(got, expectedFunctionNames) {
+		t.Fatalf("FunctionNames() = %v, want %v", got, expectedFunctionNames)
+	}
+
+	for _, group := range inventoryGroups {
+		t.Run(group.name, func(t *testing.T) {
+			for name, arguments := range group.functions {
+				if name != strings.TrimSpace(name) || name != strings.ToLower(name) {
+					t.Errorf("invalid function name %q", name)
+				}
+				assertArguments(t, name, arguments)
+			}
+		})
+	}
+}
+
+func TestPathArguments(t *testing.T) {
+	for _, name := range expectedFunctionNames {
+		want := positionalPath(0)
+		switch name {
+		case "copy_dir":
+			want = positionalPath(0, "src_dir")
+		case "delta_scan":
+			want = positionalPath(0, "log_tail")
+		case "ducklake_add_data_files":
+			want = positionalPath(2)
+		case "histogram", "histogram_values":
+			want = positionalPath(0, "source")
+		case "st_read":
+			want = positionalPath(0, "sibling_files")
+		}
+
+		got, ok := Lookup(name)
+		if !ok {
+			t.Fatalf("Lookup(%q) not found", name)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("Lookup(%q) = %#v, want %#v", name, got, want)
+		}
+	}
+}
+
+func TestLookupNormalizesName(t *testing.T) {
+	arguments, ok := Lookup(" READ_PARQUET ")
+	if !ok || !reflect.DeepEqual(arguments, positionalPath(0)) {
+		t.Fatalf("Lookup() = %#v, %v", arguments, ok)
+	}
+
+	arguments, ok = Lookup("missing")
+	if ok || !reflect.DeepEqual(arguments, PathArguments{}) {
+		t.Fatalf("Lookup() = %#v, %v", arguments, ok)
+	}
+}
+
+func TestResultsAreDefensiveCopies(t *testing.T) {
+	arguments, ok := Lookup("st_read")
+	if !ok {
+		t.Fatal("Lookup(st_read) not found")
+	}
+	arguments.Positional[0] = 9
+	arguments.Named[0] = "mutated"
+
+	got, ok := Lookup("st_read")
+	if !ok || !reflect.DeepEqual(got, positionalPath(0, "sibling_files")) {
+		t.Fatalf("Lookup(st_read) = %#v, %v", got, ok)
+	}
+
+	names := FunctionNames()
+	names[0] = "mutated"
+	if got := FunctionNames(); !reflect.DeepEqual(got, expectedFunctionNames) {
+		t.Fatalf("FunctionNames() = %v, want %v", got, expectedFunctionNames)
+	}
+}
+
+func assertArguments(t *testing.T, name string, arguments PathArguments) {
+	t.Helper()
+	if len(arguments.Positional) == 0 && len(arguments.Named) == 0 {
+		t.Errorf("%q has no path arguments", name)
+	}
+	if !slices.IsSorted(arguments.Positional) {
+		t.Errorf("%q positional arguments are not sorted", name)
+	}
+	if len(arguments.Positional) != len(slices.Compact(slices.Clone(arguments.Positional))) {
+		t.Errorf("%q has duplicate positional arguments", name)
+	}
+	for _, index := range arguments.Positional {
+		if index < 0 {
+			t.Errorf("%q has negative positional argument %d", name, index)
+		}
+	}
+	if !slices.IsSorted(arguments.Named) {
+		t.Errorf("%q named arguments are not sorted", name)
+	}
+	if len(arguments.Named) != len(slices.Compact(slices.Clone(arguments.Named))) {
+		t.Errorf("%q has duplicate named arguments", name)
+	}
+	for _, named := range arguments.Named {
+		if named == "" || named != strings.TrimSpace(named) || named != strings.ToLower(named) {
+			t.Errorf("%q has invalid named argument %q", name, named)
+		}
+	}
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/inventory_test.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/inventory_test.go
@@ -124,19 +124,7 @@ func TestLookupNormalizesName(t *testing.T) {
 	}
 }
 
-func TestResultsAreDefensiveCopies(t *testing.T) {
-	arguments, ok := Lookup("st_read")
-	if !ok {
-		t.Fatal("Lookup(st_read) not found")
-	}
-	arguments.Positional[0] = 9
-	arguments.Named[0] = "mutated"
-
-	got, ok := Lookup("st_read")
-	if !ok || !reflect.DeepEqual(got, positionalPath(0, "sibling_files")) {
-		t.Fatalf("Lookup(st_read) = %#v, %v", got, ok)
-	}
-
+func TestFunctionNamesReturnsCopy(t *testing.T) {
 	names := FunctionNames()
 	names[0] = "mutated"
 	if got := FunctionNames(); !reflect.DeepEqual(got, expectedFunctionNames) {

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/json.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/json.go
@@ -1,0 +1,11 @@
+package remoteread
+
+var jsonFunctions = map[string]PathArguments{
+	"read_json":              positionalPath(0),
+	"read_json_auto":         positionalPath(0),
+	"read_json_objects":      positionalPath(0),
+	"read_json_objects_auto": positionalPath(0),
+	"read_ndjson":            positionalPath(0),
+	"read_ndjson_auto":       positionalPath(0),
+	"read_ndjson_objects":    positionalPath(0),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/lance.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/lance.go
@@ -1,0 +1,15 @@
+package remoteread
+
+var lanceFunctions = map[string]PathArguments{
+	"__lance_cleanup_old_versions": positionalPath(0),
+	"__lance_compact_files":        positionalPath(0),
+	"__lance_exec":                 positionalPath(0),
+	"__lance_namespace_scan":       positionalPath(0),
+	"__lance_optimize_index":       positionalPath(0),
+	"__lance_scan":                 positionalPath(0),
+	"__lance_set_auto_cleanup":     positionalPath(0),
+	"__lance_show_auto_cleanup":    positionalPath(0),
+	"lance_fts":                    positionalPath(0),
+	"lance_hybrid_search":          positionalPath(0),
+	"lance_vector_search":          positionalPath(0),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/parquet.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/parquet.go
@@ -1,0 +1,12 @@
+package remoteread
+
+var parquetFunctions = map[string]PathArguments{
+	"parquet_bloom_probe":   positionalPath(0),
+	"parquet_file_metadata": positionalPath(0),
+	"parquet_full_metadata": positionalPath(0),
+	"parquet_kv_metadata":   positionalPath(0),
+	"parquet_metadata":      positionalPath(0),
+	"parquet_scan":          positionalPath(0),
+	"parquet_schema":        positionalPath(0),
+	"read_parquet":          positionalPath(0),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/postgres.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/postgres.go
@@ -1,0 +1,5 @@
+package remoteread
+
+var postgresFunctions = map[string]PathArguments{
+	"read_postgres_binary": positionalPath(0),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/spatial.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/spatial.go
@@ -1,0 +1,9 @@
+package remoteread
+
+var spatialFunctions = map[string]PathArguments{
+	"shapefile_meta": positionalPath(0),
+	"st_read":        positionalPath(0, "sibling_files"),
+	"st_read_meta":   positionalPath(0),
+	"st_readosm":     positionalPath(0),
+	"st_readshp":     positionalPath(0),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/sqlite.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/sqlite.go
@@ -1,0 +1,6 @@
+package remoteread
+
+var sqliteFunctions = map[string]PathArguments{
+	"sqlite_attach": positionalPath(0),
+	"sqlite_scan":   positionalPath(0),
+}

--- a/packages/server/duckdb-server-go/pkg/functionset/remoteread/vortex.go
+++ b/packages/server/duckdb-server-go/pkg/functionset/remoteread/vortex.go
@@ -1,0 +1,6 @@
+package remoteread
+
+var vortexFunctions = map[string]PathArguments{
+	"read_vortex": positionalPath(0),
+	"vortex_scan": positionalPath(0),
+}

--- a/packages/server/duckdb-server-go/pkg/query/options.go
+++ b/packages/server/duckdb-server-go/pkg/query/options.go
@@ -111,7 +111,8 @@ func WithFunctionAllowlist(options FunctionAllowlistOptions) OptionFunc {
 	}
 }
 
-// WithRemoteURILiteralRejection rejects recognized remote URI literals in reviewed path arguments and replacement scans.
+// WithRemoteURILiteralRejection enables best-effort rejection of recognized remote URI literals in reviewed path
+// arguments and replacement scans. Constructed or computed strings may evade detection.
 func WithRemoteURILiteralRejection() OptionFunc {
 	return func(opts *Options) error {
 		opts.RejectRemoteURILiterals = true

--- a/packages/server/duckdb-server-go/pkg/query/options.go
+++ b/packages/server/duckdb-server-go/pkg/query/options.go
@@ -31,6 +31,9 @@ type Options struct {
 	// FunctionAllowlist configures the function names that are allowed in queries.
 	// A nil value leaves function calls unrestricted.
 	FunctionAllowlist *FunctionAllowlistOptions
+
+	// RejectRemoteURILiterals rejects recognized remote URI literals in reviewed path arguments and replacement scans.
+	RejectRemoteURILiterals bool
 }
 
 // FunctionAllowlistOptions configures an allowlist from reviewed defaults and exact function names.
@@ -104,6 +107,14 @@ func WithFunctionAllowlist(options FunctionAllowlistOptions) OptionFunc {
 			DisableDefaults: configured.DisableDefaults,
 		}
 		opts.FunctionAllowlist = &value
+		return nil
+	}
+}
+
+// WithRemoteURILiteralRejection rejects recognized remote URI literals in reviewed path arguments and replacement scans.
+func WithRemoteURILiteralRejection() OptionFunc {
+	return func(opts *Options) error {
+		opts.RejectRemoteURILiterals = true
 		return nil
 	}
 }

--- a/packages/server/duckdb-server-go/pkg/query/query.go
+++ b/packages/server/duckdb-server-go/pkg/query/query.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-var ErrExecWithValidation = errors.New("query: exec command is disabled when schema or function validation is active")
+var ErrExecWithValidation = errors.New("query: exec command is disabled when query validation is active")
 
 type DB struct {
 	db *sql.DB
@@ -36,6 +36,7 @@ type DB struct {
 	functionBlocklist           []string
 	functionAllowlist           []string
 	functionAllowlistConfigured bool
+	rejectRemoteURILiterals     bool
 	logger                      *slog.Logger
 }
 
@@ -104,6 +105,7 @@ func New(ctx context.Context, connector *duckdb.Connector, opts ...OptionFunc) (
 		functionBlocklist:           append([]string(nil), o.FunctionBlocklist...),
 		functionAllowlist:           append([]string(nil), functionAllowlist...),
 		functionAllowlistConfigured: functionAllowlistConfigured,
+		rejectRemoteURILiterals:     o.RejectRemoteURILiterals,
 		logger:                      o.Logger,
 	}, nil
 }
@@ -202,7 +204,7 @@ func (db *DB) Close() {
 }
 
 func (db *DB) Exec(ctx context.Context, query string) error {
-	if len(db.functionBlocklist) > 0 || db.functionAllowlistConfigured {
+	if len(db.functionBlocklist) > 0 || db.functionAllowlistConfigured || db.rejectRemoteURILiterals {
 		return ErrExecWithValidation
 	}
 
@@ -215,7 +217,7 @@ func (db *DB) Exec(ctx context.Context, query string) error {
 }
 
 func (db *DB) validateQuery(ctx context.Context, query string, allowedSchemas []string) error {
-	validators := make([]Validator, 0, 3)
+	validators := make([]Validator, 0, 4)
 	if len(allowedSchemas) > 0 {
 		validators = append(validators, newBaseTableValidator(allowedSchemas))
 	}
@@ -224,6 +226,9 @@ func (db *DB) validateQuery(ctx context.Context, query string, allowedSchemas []
 	}
 	if db.functionAllowlistConfigured {
 		validators = append(validators, newFunctionAllowlistValidator(db.functionAllowlist))
+	}
+	if db.rejectRemoteURILiterals {
+		validators = append(validators, newRemoteURILiteralValidator())
 	}
 	if len(validators) == 0 {
 		return nil

--- a/packages/server/duckdb-server-go/pkg/query/query_test.go
+++ b/packages/server/duckdb-server-go/pkg/query/query_test.go
@@ -423,7 +423,7 @@ func TestDB_Exec(t *testing.T) {
 
 		err := db.Exec(ctx, "SELECT 1")
 		require.ErrorIs(t, err, ErrExecWithValidation)
-		assert.EqualError(t, err, "query: exec command is disabled when schema or function validation is active")
+		assert.EqualError(t, err, "query: exec command is disabled when query validation is active")
 	})
 
 	t.Run("function allowlist rejects exec", func(t *testing.T) {
@@ -431,7 +431,7 @@ func TestDB_Exec(t *testing.T) {
 
 		err := db.Exec(ctx, "SELECT 1")
 		require.ErrorIs(t, err, ErrExecWithValidation)
-		assert.EqualError(t, err, "query: exec command is disabled when schema or function validation is active")
+		assert.EqualError(t, err, "query: exec command is disabled when query validation is active")
 	})
 }
 

--- a/packages/server/duckdb-server-go/pkg/query/remote_uri.go
+++ b/packages/server/duckdb-server-go/pkg/query/remote_uri.go
@@ -9,7 +9,7 @@ import (
 	"github.com/uwdata/mosaic/packages/server/duckdb-server-go/pkg/functionset/remoteread"
 )
 
-// Source: https://github.com/duckdb/duckdb/blob/v1.5.5/src/include/duckdb/main/extension_entries.hpp#L1275-L1280
+// Sources are the DuckDB 1.5.5-pinned filesystem handlers listed in ../functionset/remoteread/README.md.
 var remoteURIPrefixes = [...]string{
 	"http://",
 	"https://",
@@ -22,7 +22,13 @@ var remoteURIPrefixes = [...]string{
 	"hf://",
 	"azure://",
 	"az://",
+	"abfs://",
 	"abfss://",
+}
+
+var nestedSQLExecutors = [...]string{
+	"json_execute_serialized_sql",
+	"query",
 }
 
 type remoteURILiteralValidator struct {
@@ -65,8 +71,13 @@ func (v *remoteURILiteralValidator) checkTableFunction(node map[string]any) {
 		v.errs = append(v.errs, fmt.Errorf("query: invalid remote URI table function node: expected string function_name: %v", function["function_name"]))
 		return
 	}
+	functionName = strings.ToLower(functionName)
+	if slices.Contains(nestedSQLExecutors[:], functionName) {
+		v.errs = append(v.errs, fmt.Errorf("%w: nested SQL executor '%s' is not allowed", ErrAccessDenied, functionName))
+		return
+	}
 
-	pathArguments, ok := remoteread.Lookup(strings.ToLower(functionName))
+	pathArguments, ok := remoteread.Lookup(functionName)
 	if !ok {
 		return
 	}

--- a/packages/server/duckdb-server-go/pkg/query/remote_uri.go
+++ b/packages/server/duckdb-server-go/pkg/query/remote_uri.go
@@ -26,10 +26,12 @@ var remoteURIPrefixes = [...]string{
 	"abfss://",
 }
 
-var nestedSQLExecutors = [...]string{
+var nestedSQLTableExecutors = [...]string{
 	"json_execute_serialized_sql",
 	"query",
 }
+
+const nestedSQLScalarExecutor = "json_serialize_plan"
 
 type remoteURILiteralValidator struct {
 	errs []error
@@ -39,13 +41,32 @@ func newRemoteURILiteralValidator() Validator {
 	return &remoteURILiteralValidator{}
 }
 
-func (v *remoteURILiteralValidator) CheckNode(node map[string]any, _ []string) {
+func (v *remoteURILiteralValidator) CheckNode(node map[string]any, keyStack []string) {
+	if node["class"] == "FUNCTION" && (len(keyStack) == 0 || keyStack[len(keyStack)-1] != "function") {
+		v.checkScalarNestedSQLExecutor(node)
+	}
+
 	switch node["type"] {
 	case "BASE_TABLE":
 		v.checkBaseTable(node)
 	case "TABLE_FUNCTION":
 		v.checkTableFunction(node)
 	}
+}
+
+func (v *remoteURILiteralValidator) checkScalarNestedSQLExecutor(node map[string]any) {
+	functionName, ok := node["function_name"].(string)
+	if !ok || !strings.EqualFold(functionName, nestedSQLScalarExecutor) {
+		return
+	}
+	if catalog := stringField(node, "catalog"); catalog != "" && !strings.EqualFold(catalog, "system") {
+		return
+	}
+	if schema := stringField(node, "schema"); schema != "" &&
+		!strings.EqualFold(schema, "main") && !strings.EqualFold(schema, "system") {
+		return
+	}
+	v.errs = append(v.errs, fmt.Errorf("%w: nested SQL executor '%s' is not allowed", ErrAccessDenied, nestedSQLScalarExecutor))
 }
 
 func (v *remoteURILiteralValidator) checkBaseTable(node map[string]any) {
@@ -72,7 +93,7 @@ func (v *remoteURILiteralValidator) checkTableFunction(node map[string]any) {
 		return
 	}
 	functionName = strings.ToLower(functionName)
-	if slices.Contains(nestedSQLExecutors[:], functionName) {
+	if slices.Contains(nestedSQLTableExecutors[:], functionName) {
 		v.errs = append(v.errs, fmt.Errorf("%w: nested SQL executor '%s' is not allowed", ErrAccessDenied, functionName))
 		return
 	}

--- a/packages/server/duckdb-server-go/pkg/query/remote_uri.go
+++ b/packages/server/duckdb-server-go/pkg/query/remote_uri.go
@@ -9,7 +9,7 @@ import (
 	"github.com/uwdata/mosaic/packages/server/duckdb-server-go/pkg/functionset/remoteread"
 )
 
-// Source: https://github.com/duckdb/duckdb/blob/v1.5.5/src/include/duckdb/main/extension_entries.hpp#L1264-L1269
+// Source: https://github.com/duckdb/duckdb/blob/v1.5.5/src/include/duckdb/main/extension_entries.hpp#L1275-L1280
 var remoteURIPrefixes = [...]string{
 	"http://",
 	"https://",
@@ -125,6 +125,7 @@ func (v *remoteURILiteralValidator) Validate() []error {
 }
 
 func findRemoteURIPrefix(value string) (string, bool) {
+	value = strings.ToLower(value)
 	for _, prefix := range remoteURIPrefixes {
 		if strings.Contains(value, prefix) {
 			return prefix, true

--- a/packages/server/duckdb-server-go/pkg/query/remote_uri.go
+++ b/packages/server/duckdb-server-go/pkg/query/remote_uri.go
@@ -1,0 +1,148 @@
+package query
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/uwdata/mosaic/packages/server/duckdb-server-go/pkg/functionset/remoteread"
+)
+
+// Source: https://github.com/duckdb/duckdb/blob/v1.5.5/src/include/duckdb/main/extension_entries.hpp#L1264-L1269
+var remoteURIPrefixes = [...]string{
+	"http://",
+	"https://",
+	"s3://",
+	"s3a://",
+	"s3n://",
+	"gcs://",
+	"gs://",
+	"r2://",
+	"hf://",
+	"azure://",
+	"az://",
+	"abfss://",
+}
+
+type remoteURILiteralValidator struct {
+	errs []error
+}
+
+func newRemoteURILiteralValidator() Validator {
+	return &remoteURILiteralValidator{}
+}
+
+func (v *remoteURILiteralValidator) CheckNode(node map[string]any, _ []string) {
+	switch node["type"] {
+	case "BASE_TABLE":
+		v.checkBaseTable(node)
+	case "TABLE_FUNCTION":
+		v.checkTableFunction(node)
+	}
+}
+
+func (v *remoteURILiteralValidator) checkBaseTable(node map[string]any) {
+	tableName, ok := node["table_name"].(string)
+	if !ok {
+		v.errs = append(v.errs, fmt.Errorf("query: invalid remote URI base table node: expected string table_name: %v", node["table_name"]))
+		return
+	}
+	if prefix, ok := findRemoteURIPrefix(tableName); ok {
+		v.reject(prefix, "replacement scan")
+	}
+}
+
+func (v *remoteURILiteralValidator) checkTableFunction(node map[string]any) {
+	function, ok := node["function"].(map[string]any)
+	if !ok {
+		v.errs = append(v.errs, errors.New("query: invalid remote URI table function node: missing function"))
+		return
+	}
+
+	functionName, ok := function["function_name"].(string)
+	if !ok {
+		v.errs = append(v.errs, fmt.Errorf("query: invalid remote URI table function node: expected string function_name: %v", function["function_name"]))
+		return
+	}
+
+	pathArguments, ok := remoteread.Lookup(strings.ToLower(functionName))
+	if !ok {
+		return
+	}
+
+	children, ok := function["children"].([]any)
+	if !ok {
+		return
+	}
+
+	positional := 0
+	for _, child := range children {
+		argument, ok := child.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if name, named := argument["alias"].(string); named && name != "" {
+			if slices.Contains(pathArguments.Named, strings.ToLower(name)) {
+				v.checkPathExpression(argument, functionName)
+			}
+			continue
+		}
+
+		if slices.Contains(pathArguments.Positional, positional) {
+			v.checkPathExpression(argument, functionName)
+		}
+		positional++
+	}
+}
+
+func (v *remoteURILiteralValidator) checkPathExpression(expression map[string]any, functionName string) {
+	walkValues(expression, func(node map[string]any) {
+		if node["class"] != "CONSTANT" {
+			return
+		}
+		value, ok := node["value"].(map[string]any)
+		if !ok {
+			return
+		}
+		literal, ok := value["value"].(string)
+		if !ok {
+			return
+		}
+		if prefix, ok := findRemoteURIPrefix(literal); ok {
+			v.reject(prefix, fmt.Sprintf("path argument to function '%s'", strings.ToLower(functionName)))
+		}
+	})
+}
+
+func (v *remoteURILiteralValidator) reject(prefix, location string) {
+	v.errs = append(v.errs, fmt.Errorf("%w: remote URI prefix '%s' is not allowed in %s", ErrAccessDenied, prefix, location))
+}
+
+func (v *remoteURILiteralValidator) Validate() []error {
+	return append([]error(nil), v.errs...)
+}
+
+func findRemoteURIPrefix(value string) (string, bool) {
+	for _, prefix := range remoteURIPrefixes {
+		if strings.Contains(value, prefix) {
+			return prefix, true
+		}
+	}
+	return "", false
+}
+
+func walkValues(value any, visit func(map[string]any)) {
+	switch value := value.(type) {
+	case map[string]any:
+		visit(value)
+		for _, child := range value {
+			walkValues(child, visit)
+		}
+	case []any:
+		for _, child := range value {
+			walkValues(child, visit)
+		}
+	}
+}

--- a/packages/server/duckdb-server-go/pkg/query/remote_uri_test.go
+++ b/packages/server/duckdb-server-go/pkg/query/remote_uri_test.go
@@ -1,0 +1,225 @@
+package query
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithRemoteURILiteralRejection(t *testing.T) {
+	opts := &Options{}
+	require.NoError(t, WithRemoteURILiteralRejection()(opts))
+	assert.True(t, opts.RejectRemoteURILiterals)
+}
+
+func TestRemoteURILiteralValidatorRecognizesPinnedPrefixes(t *testing.T) {
+	db := setupTestDB(t)
+
+	for _, prefix := range remoteURIPrefixes {
+		t.Run(prefix, func(t *testing.T) {
+			sql := fmt.Sprintf("SELECT * FROM read_parquet('%sbucket/file.parquet')", prefix)
+			err := db.ValidateSQL(t.Context(), sql, newRemoteURILiteralValidator())
+			require.ErrorIs(t, err, ErrAccessDenied)
+			assert.EqualError(t, err, fmt.Sprintf(
+				"query: access denied: remote URI prefix '%s' is not allowed in path argument to function 'read_parquet'",
+				prefix,
+			))
+		})
+	}
+}
+
+func TestRemoteURILiteralValidatorPathArguments(t *testing.T) {
+	db := setupTestDB(t)
+
+	tests := []struct {
+		name       string
+		sql        string
+		wantPrefix string
+	}{
+		{
+			name:       "direct positional literal",
+			sql:        "SELECT * FROM read_parquet('gcs://bucket/file.parquet')",
+			wantPrefix: "gcs://",
+		},
+		{
+			name:       "prefix within literal",
+			sql:        "SELECT * FROM read_parquet('mirror=https://example.com/file.parquet')",
+			wantPrefix: "https://",
+		},
+		{
+			name:       "constructed expression",
+			sql:        "SELECT * FROM read_parquet('gcs://' || 'bucket/file.parquet')",
+			wantPrefix: "gcs://",
+		},
+		{
+			name:       "cast expression",
+			sql:        "SELECT * FROM read_parquet(CAST('s3://bucket/file.parquet' AS VARCHAR))",
+			wantPrefix: "s3://",
+		},
+		{
+			name:       "literal list",
+			sql:        "SELECT * FROM read_parquet(['local.parquet', 'r2://bucket/file.parquet'])",
+			wantPrefix: "r2://",
+		},
+		{
+			name:       "array constructor",
+			sql:        "SELECT * FROM read_parquet(ARRAY['local.parquet', 'gs://bucket/file.parquet'])",
+			wantPrefix: "gs://",
+		},
+		{
+			name:       "named literal list",
+			sql:        "SELECT * FROM st_read('local.shp', sibling_files := ['local.dbf', 's3://bucket/file.shx'])",
+			wantPrefix: "s3://",
+		},
+		{
+			name:       "third positional argument",
+			sql:        "SELECT * FROM ducklake_add_data_files('catalog', 'table', 'azure://container/file.parquet')",
+			wantPrefix: "azure://",
+		},
+		{
+			name:       "table macro path",
+			sql:        "SELECT * FROM histogram('https://example.com/file.parquet', 'value')",
+			wantPrefix: "https://",
+		},
+		{
+			name: "local path",
+			sql:  "SELECT * FROM read_parquet('/var/data/file.parquet')",
+		},
+		{
+			name: "remote literal in non-path argument",
+			sql:  "SELECT * FROM parquet_bloom_probe('local.parquet', 'https://example.com', 'value')",
+		},
+		{
+			name: "remote literal in unrelated function",
+			sql:  "SELECT parse_path('https://example.com/file.parquet')",
+		},
+		{
+			name: "remote literal in unreviewed table function",
+			sql:  "SELECT * FROM unreviewed_reader('https://example.com/file.parquet')",
+		},
+		{
+			name: "remote literal in where predicate",
+			sql:  "SELECT 1 WHERE 'https://example.com' = 'https://example.com'",
+		},
+		{
+			name: "aggregate sharing table macro name",
+			sql:  "SELECT histogram('https://example.com')",
+		},
+		{
+			name: "case-sensitive prefix",
+			sql:  "SELECT * FROM read_parquet('HTTPS://example.com/file.parquet')",
+		},
+		{
+			name: "prefix split between literals",
+			sql:  "SELECT * FROM read_parquet('gcs:/' || '/bucket/file.parquet')",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := db.ValidateSQL(t.Context(), tt.sql, newRemoteURILiteralValidator())
+			if tt.wantPrefix == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, ErrAccessDenied)
+			assert.ErrorContains(t, err, fmt.Sprintf("remote URI prefix '%s'", tt.wantPrefix))
+		})
+	}
+}
+
+func TestRemoteURILiteralValidatorCountsOnlyUnnamedPositions(t *testing.T) {
+	validator := newRemoteURILiteralValidator()
+	validator.CheckNode(map[string]any{
+		"type": "TABLE_FUNCTION",
+		"function": map[string]any{
+			"function_name": "read_parquet",
+			"children": []any{
+				map[string]any{
+					"alias": "unreviewed_option",
+					"class": "CONSTANT",
+					"value": map[string]any{"value": "https://example.com/ignored"},
+				},
+				map[string]any{
+					"class": "CONSTANT",
+					"value": map[string]any{"value": "local.parquet"},
+				},
+			},
+		},
+	}, nil)
+
+	assert.Empty(t, validator.Validate())
+}
+
+func TestRemoteURILiteralValidatorReplacementScans(t *testing.T) {
+	db := setupTestDB(t)
+
+	tests := []struct {
+		name    string
+		sql     string
+		wantErr bool
+	}{
+		{
+			name:    "remote path",
+			sql:     "SELECT * FROM 'gcs://bucket/file.parquet'",
+			wantErr: true,
+		},
+		{
+			name:    "prefix within base table literal",
+			sql:     "SELECT * FROM 'mirror-https://example.com/file.parquet'",
+			wantErr: true,
+		},
+		{
+			name: "local replacement scan",
+			sql:  "SELECT * FROM '/var/data/file.parquet'",
+		},
+		{
+			name:    "quoted cte with URI-like name fails closed",
+			sql:     `WITH "https://example.com/file.parquet" AS (SELECT 1 AS value) SELECT * FROM "https://example.com/file.parquet"`,
+			wantErr: true,
+		},
+		{
+			name:    "cte body cannot hide a replacement scan",
+			sql:     `WITH "https://example.com/file.parquet" AS (SELECT * FROM "https://example.com/file.parquet") SELECT * FROM "https://example.com/file.parquet"`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := db.ValidateSQL(t.Context(), tt.sql, newRemoteURILiteralValidator())
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, ErrAccessDenied)
+			assert.ErrorContains(t, err, "is not allowed in replacement scan")
+		})
+	}
+}
+
+func TestDBRemoteURILiteralRejection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "local.csv")
+	require.NoError(t, os.WriteFile(path, []byte("value\n42\n"), 0o600))
+
+	db := setupTestDB(t, WithRemoteURILiteralRejection())
+
+	data, _, err := db.QueryJSON(t.Context(), "SELECT * FROM read_csv("+quoteLiteral(path)+")", nil, false)
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{"value": 42}]`, string(data))
+
+	data, _, err = db.QueryJSON(t.Context(), "SELECT 'https://example.com' AS url WHERE url = 'https://example.com'", nil, false)
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{"url": "https://example.com"}]`, string(data))
+
+	_, _, err = db.QueryJSON(t.Context(), "SELECT * FROM read_csv('https://example.com/file.csv')", nil, false)
+	require.ErrorIs(t, err, ErrAccessDenied)
+	assert.ErrorContains(t, err, "remote URI prefix 'https://' is not allowed in path argument to function 'read_csv'")
+
+	err = db.Exec(t.Context(), "SELECT 1")
+	require.ErrorIs(t, err, ErrExecWithValidation)
+}

--- a/packages/server/duckdb-server-go/pkg/query/remote_uri_test.go
+++ b/packages/server/duckdb-server-go/pkg/query/remote_uri_test.go
@@ -90,6 +90,11 @@ func TestRemoteURILiteralValidatorPathArguments(t *testing.T) {
 			wantPrefix: "https://",
 		},
 		{
+			name:       "autocomplete filename suggestion",
+			sql:        "SELECT * FROM sql_auto_complete('SELECT * FROM ''GCS://bucket/file', max_file_suggestion_count := 10)",
+			wantPrefix: "gcs://",
+		},
+		{
 			name: "local path",
 			sql:  "SELECT * FROM read_parquet('/var/data/file.parquet')",
 		},
@@ -100,6 +105,10 @@ func TestRemoteURILiteralValidatorPathArguments(t *testing.T) {
 		{
 			name: "local array constructor",
 			sql:  "SELECT * FROM read_parquet(ARRAY['/var/data/a.parquet', '/var/data/b.parquet'])",
+		},
+		{
+			name: "local autocomplete filename suggestion",
+			sql:  "SELECT * FROM sql_auto_complete('SELECT * FROM ''/var/data/file', max_file_suggestion_count := 10)",
 		},
 		{
 			name: "remote literal in non-path argument",
@@ -164,6 +173,11 @@ func TestRemoteURILiteralValidatorRejectsNestedSQLExecutors(t *testing.T) {
 			sql:      "SELECT * FROM query('SELECT * FROM read_parquet(''https://example.com/file.parquet'')')",
 		},
 		{
+			name:     "qualified mixed-case query",
+			function: "query",
+			sql:      "SELECT * FROM MAIN.QUERY('SELECT 42')",
+		},
+		{
 			name:     "serialized SQL with literal JSON",
 			function: "json_execute_serialized_sql",
 			sql:      "SELECT * FROM json_execute_serialized_sql('{}')",
@@ -172,6 +186,11 @@ func TestRemoteURILiteralValidatorRejectsNestedSQLExecutors(t *testing.T) {
 			name:     "serialized SQL produced from remote reader",
 			function: "json_execute_serialized_sql",
 			sql:      "SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT * FROM read_parquet(''https://example.com/file.parquet'')'))",
+		},
+		{
+			name:     "qualified serialized SQL",
+			function: "json_execute_serialized_sql",
+			sql:      "SELECT * FROM system.json_execute_serialized_sql('{}')",
 		},
 	}
 
@@ -193,6 +212,47 @@ func TestRemoteURILiteralValidatorAllowsScalarExecutorNames(t *testing.T) {
 	for _, sql := range []string{
 		"SELECT query('local')",
 		"SELECT json_execute_serialized_sql('local')",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			assert.NoError(t, db.ValidateSQL(t.Context(), sql, newRemoteURILiteralValidator()))
+		})
+	}
+}
+
+func TestRemoteURILiteralValidatorRejectsJSONSerializePlan(t *testing.T) {
+	db := setupTestDB(t)
+
+	for _, sql := range []string{
+		"SELECT json_serialize_plan('SELECT 42')",
+		"SELECT json_serialize_plan('SELECT * FROM read_csv(''https://example.com/file.csv'')')",
+		"SELECT MaIn.JsOn_SeRiAlIzE_PlAn('SELECT 42')",
+		"SELECT system.json_serialize_plan('SELECT * FROM read_csv(''https://example.com/file.csv'')')",
+		"SELECT system.main.json_serialize_plan('SELECT 42')",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			err := db.ValidateSQL(t.Context(), sql, newRemoteURILiteralValidator())
+			require.ErrorIs(t, err, ErrAccessDenied)
+			assert.EqualError(t, err, "query: access denied: nested SQL executor 'json_serialize_plan' is not allowed")
+		})
+	}
+}
+
+func TestRemoteURILiteralValidatorAllowsTableMacroNamedJSONSerializePlan(t *testing.T) {
+	db := setupTestDB(t)
+
+	assert.NoError(t, db.ValidateSQL(
+		t.Context(),
+		"SELECT * FROM json_serialize_plan('local')",
+		newRemoteURILiteralValidator(),
+	))
+}
+
+func TestRemoteURILiteralValidatorAllowsQualifiedJSONSerializePlanUDF(t *testing.T) {
+	db := setupTestDB(t)
+
+	for _, sql := range []string{
+		"SELECT tenant.json_serialize_plan('local')",
+		"SELECT other.main.json_serialize_plan('local')",
 	} {
 		t.Run(sql, func(t *testing.T) {
 			assert.NoError(t, db.ValidateSQL(t.Context(), sql, newRemoteURILiteralValidator()))
@@ -308,6 +368,45 @@ func TestDBRemoteURILiteralRejection(t *testing.T) {
 	_, _, err = db.QueryJSON(t.Context(), "SELECT * FROM query('SELECT 42')", nil, false)
 	require.ErrorIs(t, err, ErrAccessDenied)
 	assert.ErrorContains(t, err, "nested SQL executor 'query' is not allowed")
+
+	_, _, err = db.QueryJSON(
+		t.Context(),
+		"SELECT json_serialize_plan('SELECT * FROM read_csv(''https://example.com/file.csv'')')",
+		nil,
+		false,
+	)
+	require.ErrorIs(t, err, ErrAccessDenied)
+	assert.ErrorContains(t, err, "nested SQL executor 'json_serialize_plan' is not allowed")
+
+	_, _, err = db.QueryJSON(
+		t.Context(),
+		"SELECT system.json_serialize_plan('SELECT * FROM read_csv(''https://example.com/file.csv'')')",
+		nil,
+		false,
+	)
+	require.ErrorIs(t, err, ErrAccessDenied)
+	assert.ErrorContains(t, err, "nested SQL executor 'json_serialize_plan' is not allowed")
+
+	autocompleteSQL := "SELECT * FROM '" + filepath.Join(filepath.Dir(path), "loc")
+	_, _, err = db.QueryJSON(
+		t.Context(),
+		"SELECT * FROM sql_auto_complete("+quoteLiteral(autocompleteSQL)+", max_file_suggestion_count := 10)",
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+
+	_, _, err = db.QueryJSON(
+		t.Context(),
+		"SELECT * FROM sql_auto_complete('SELECT * FROM ''S3://no-such-bucket/file', max_file_suggestion_count := 10)",
+		nil,
+		false,
+	)
+	require.ErrorIs(t, err, ErrAccessDenied)
+	assert.ErrorContains(t, err, "remote URI prefix 's3://' is not allowed in path argument to function 'sql_auto_complete'")
+
+	_, _, err = db.QueryJSON(t.Context(), "PRAGMA import_database('s3://bucket/export')", nil, false)
+	require.ErrorIs(t, err, ErrUnsupportedStatement)
 
 	err = db.Exec(t.Context(), "SELECT 1")
 	require.ErrorIs(t, err, ErrExecWithValidation)

--- a/packages/server/duckdb-server-go/pkg/query/remote_uri_test.go
+++ b/packages/server/duckdb-server-go/pkg/query/remote_uri_test.go
@@ -19,6 +19,7 @@ func TestWithRemoteURILiteralRejection(t *testing.T) {
 
 func TestRemoteURILiteralValidatorRecognizesPinnedPrefixes(t *testing.T) {
 	db := setupTestDB(t)
+	assert.Contains(t, remoteURIPrefixes, "abfs://")
 
 	for _, prefix := range remoteURIPrefixes {
 		t.Run(prefix, func(t *testing.T) {
@@ -93,6 +94,14 @@ func TestRemoteURILiteralValidatorPathArguments(t *testing.T) {
 			sql:  "SELECT * FROM read_parquet('/var/data/file.parquet')",
 		},
 		{
+			name: "local literal list",
+			sql:  "SELECT * FROM read_parquet(['/var/data/a.parquet', '/var/data/b.parquet'])",
+		},
+		{
+			name: "local array constructor",
+			sql:  "SELECT * FROM read_parquet(ARRAY['/var/data/a.parquet', '/var/data/b.parquet'])",
+		},
+		{
 			name: "remote literal in non-path argument",
 			sql:  "SELECT * FROM parquet_bloom_probe('local.parquet', 'https://example.com', 'value')",
 		},
@@ -132,6 +141,61 @@ func TestRemoteURILiteralValidatorPathArguments(t *testing.T) {
 			}
 			require.ErrorIs(t, err, ErrAccessDenied)
 			assert.ErrorContains(t, err, fmt.Sprintf("remote URI prefix '%s'", tt.wantPrefix))
+		})
+	}
+}
+
+func TestRemoteURILiteralValidatorRejectsNestedSQLExecutors(t *testing.T) {
+	db := setupTestDB(t)
+
+	tests := []struct {
+		name     string
+		function string
+		sql      string
+	}{
+		{
+			name:     "query with local SQL",
+			function: "query",
+			sql:      "SELECT * FROM query('SELECT 42')",
+		},
+		{
+			name:     "query with remote reader",
+			function: "query",
+			sql:      "SELECT * FROM query('SELECT * FROM read_parquet(''https://example.com/file.parquet'')')",
+		},
+		{
+			name:     "serialized SQL with literal JSON",
+			function: "json_execute_serialized_sql",
+			sql:      "SELECT * FROM json_execute_serialized_sql('{}')",
+		},
+		{
+			name:     "serialized SQL produced from remote reader",
+			function: "json_execute_serialized_sql",
+			sql:      "SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT * FROM read_parquet(''https://example.com/file.parquet'')'))",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := db.ValidateSQL(t.Context(), tt.sql, newRemoteURILiteralValidator())
+			require.ErrorIs(t, err, ErrAccessDenied)
+			assert.EqualError(t, err, fmt.Sprintf(
+				"query: access denied: nested SQL executor '%s' is not allowed",
+				tt.function,
+			))
+		})
+	}
+}
+
+func TestRemoteURILiteralValidatorAllowsScalarExecutorNames(t *testing.T) {
+	db := setupTestDB(t)
+
+	for _, sql := range []string{
+		"SELECT query('local')",
+		"SELECT json_execute_serialized_sql('local')",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			assert.NoError(t, db.ValidateSQL(t.Context(), sql, newRemoteURILiteralValidator()))
 		})
 	}
 }
@@ -183,6 +247,11 @@ func TestRemoteURILiteralValidatorReplacementScans(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "azure dfs remote path",
+			sql:     "SELECT * FROM 'AbFs://container/file.parquet'",
+			wantErr: true,
+		},
+		{
 			name: "local replacement scan",
 			sql:  "SELECT * FROM '/var/data/file.parquet'",
 		},
@@ -214,12 +283,19 @@ func TestRemoteURILiteralValidatorReplacementScans(t *testing.T) {
 func TestDBRemoteURILiteralRejection(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "local.csv")
 	require.NoError(t, os.WriteFile(path, []byte("value\n42\n"), 0o600))
+	secondPath := filepath.Join(t.TempDir(), "second.csv")
+	require.NoError(t, os.WriteFile(secondPath, []byte("value\n43\n"), 0o600))
 
 	db := setupTestDB(t, WithRemoteURILiteralRejection())
 
 	data, _, err := db.QueryJSON(t.Context(), "SELECT * FROM read_csv("+quoteLiteral(path)+")", nil, false)
 	require.NoError(t, err)
 	assert.JSONEq(t, `[{"value": 42}]`, string(data))
+
+	list := fmt.Sprintf("[%s, %s]", quoteLiteral(path), quoteLiteral(secondPath))
+	data, _, err = db.QueryJSON(t.Context(), "SELECT * FROM read_csv("+list+") ORDER BY value", nil, false)
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{"value": 42}, {"value": 43}]`, string(data))
 
 	data, _, err = db.QueryJSON(t.Context(), "SELECT 'https://example.com' AS url WHERE url = 'https://example.com'", nil, false)
 	require.NoError(t, err)
@@ -228,6 +304,10 @@ func TestDBRemoteURILiteralRejection(t *testing.T) {
 	_, _, err = db.QueryJSON(t.Context(), "SELECT * FROM read_csv('https://example.com/file.csv')", nil, false)
 	require.ErrorIs(t, err, ErrAccessDenied)
 	assert.ErrorContains(t, err, "remote URI prefix 'https://' is not allowed in path argument to function 'read_csv'")
+
+	_, _, err = db.QueryJSON(t.Context(), "SELECT * FROM query('SELECT 42')", nil, false)
+	require.ErrorIs(t, err, ErrAccessDenied)
+	assert.ErrorContains(t, err, "nested SQL executor 'query' is not allowed")
 
 	err = db.Exec(t.Context(), "SELECT 1")
 	require.ErrorIs(t, err, ErrExecWithValidation)

--- a/packages/server/duckdb-server-go/pkg/query/remote_uri_test.go
+++ b/packages/server/duckdb-server-go/pkg/query/remote_uri_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,13 +22,15 @@ func TestRemoteURILiteralValidatorRecognizesPinnedPrefixes(t *testing.T) {
 
 	for _, prefix := range remoteURIPrefixes {
 		t.Run(prefix, func(t *testing.T) {
-			sql := fmt.Sprintf("SELECT * FROM read_parquet('%sbucket/file.parquet')", prefix)
-			err := db.ValidateSQL(t.Context(), sql, newRemoteURILiteralValidator())
-			require.ErrorIs(t, err, ErrAccessDenied)
-			assert.EqualError(t, err, fmt.Sprintf(
-				"query: access denied: remote URI prefix '%s' is not allowed in path argument to function 'read_parquet'",
-				prefix,
-			))
+			for _, literalPrefix := range []string{prefix, strings.ToUpper(prefix)} {
+				sql := fmt.Sprintf("SELECT * FROM read_parquet('%sbucket/file.parquet')", literalPrefix)
+				err := db.ValidateSQL(t.Context(), sql, newRemoteURILiteralValidator())
+				require.ErrorIs(t, err, ErrAccessDenied)
+				assert.EqualError(t, err, fmt.Sprintf(
+					"query: access denied: remote URI prefix '%s' is not allowed in path argument to function 'read_parquet'",
+					prefix,
+				))
+			}
 		})
 	}
 }
@@ -110,8 +113,9 @@ func TestRemoteURILiteralValidatorPathArguments(t *testing.T) {
 			sql:  "SELECT histogram('https://example.com')",
 		},
 		{
-			name: "case-sensitive prefix",
-			sql:  "SELECT * FROM read_parquet('HTTPS://example.com/file.parquet')",
+			name:       "mixed-case prefix",
+			sql:        "SELECT * FROM read_parquet('HtTpS://example.com/file.parquet')",
+			wantPrefix: "https://",
 		},
 		{
 			name: "prefix split between literals",
@@ -171,6 +175,11 @@ func TestRemoteURILiteralValidatorReplacementScans(t *testing.T) {
 		{
 			name:    "prefix within base table literal",
 			sql:     "SELECT * FROM 'mirror-https://example.com/file.parquet'",
+			wantErr: true,
+		},
+		{
+			name:    "mixed-case remote path",
+			sql:     "SELECT * FROM 'GCS://bucket/file.parquet'",
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
Similar to #1150 AI did a deep dive to find all the functions in core + core extensions that are eligible to be fed into httpfs for remote reads. This then does a case insensitive comparison looking for `gcs://`, `https://`, etc., in those specific parameters. There are ways around it, some mentioned here, so this isn't a perfect way around remote reads, but as a best-effort I think it's decent.

This is orthogonal to the allowlist, so if you truly want to stop remote reads while still querying remote filesystems, you can attach a db/table and disallow all the file read functions.

## Summary

- add a source-audited, DuckDB 1.5.5-pinned inventory of 58 functions whose reviewed arguments can open caller-controlled paths
- add `query.WithRemoteURILiteralRejection()` to reject recognized remote URI literals case-insensitively in replacement scans and decoded literals within those path arguments
- preserve local paths, unrelated literals, and trusted pre-attached catalogs while documenting the best-effort boundary and disabling unvalidated `exec` commands