### PR TITLE
refactor(widget): Consistently use `warnings` for warnings

### DIFF
--- a/packages/vgplot/widget/mosaic_widget/__init__.py
+++ b/packages/vgplot/widget/mosaic_widget/__init__.py
@@ -4,7 +4,6 @@ import inspect
 import logging
 import pathlib
 import time
-import warnings
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict
 
 import anywidget
@@ -12,6 +11,7 @@ import duckdb
 import pyarrow as pa
 import traitlets
 
+from mosaic_widget._exceptions import warn
 from mosaic_widget.frame_interop import (
     frame_to_duckdb_registrable,
     is_registrable_frame,
@@ -167,7 +167,7 @@ class MosaicWidget(anywidget.AnyWidget):
 
         total = round((time.time() - start) * 1_000)
         if total > SLOW_QUERY_THRESHOLD:
-            logger.warning(f"DONE. Slow query {uuid} took {total} ms.\n{sql}")
+            warn(f"DONE. Slow query {uuid} took {total} ms.\n{sql}")
         else:
             logger.info(f"DONE. Query {uuid} took {total} ms.\n{sql}")
 
@@ -184,7 +184,7 @@ class MosaicWidget(anywidget.AnyWidget):
         try:
             table = self._resolve_table(None)
         except ValueError as err:
-            warnings.warn(f"{err} widget.sql is None.", stacklevel=2)
+            warn(f"{err} widget.sql is None.")
             return None
         return self._build_sql(table, filter_by=None)
 

--- a/packages/vgplot/widget/mosaic_widget/_exceptions.py
+++ b/packages/vgplot/widget/mosaic_widget/_exceptions.py
@@ -12,7 +12,7 @@ class PerformanceWarning(MosaicWidgetWarning):
 
 
 def warn(
-    message: str, category: type[Warning] = MosaicWidgetWarning, *, stacklevel: int = 2
+    message: str, category: type[Warning] = MosaicWidgetWarning, stacklevel: int = 3
 ) -> None:
     """Issue a warning.
 
@@ -20,6 +20,6 @@ def warn(
         message: The text of the warning message.
         category: The Warning category subclass.
         stacklevel: How far up the call stack to make this warning appear.
-            A value of 2 for example attributes the warning to the caller of the code calling warn().
+            A value of 3 for example attributes the warning to the caller of the code calling warn().
     """
-    warnings.warn(message, category, stacklevel)
+    warnings.warn(message, category, max(stacklevel, 3))

--- a/packages/vgplot/widget/mosaic_widget/_exceptions.py
+++ b/packages/vgplot/widget/mosaic_widget/_exceptions.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import warnings
+
+
+class MosaicWidgetWarning(UserWarning):
+    """Any kind of warning issued by `mosaic_widget`."""
+
+
+class PerformanceWarning(MosaicWidgetWarning):
+    """Warning issued for data sources that require conversion/materialization."""
+
+
+def warn(
+    message: str, category: type[Warning] = MosaicWidgetWarning, *, stacklevel: int = 2
+) -> None:
+    """Issue a warning.
+
+    Args:
+        message: The text of the warning message.
+        category: The Warning category subclass.
+        stacklevel: How far up the call stack to make this warning appear.
+            A value of 2 for example attributes the warning to the caller of the code calling warn().
+    """
+    warnings.warn(message, category, stacklevel)

--- a/packages/vgplot/widget/mosaic_widget/frame_interop.py
+++ b/packages/vgplot/widget/mosaic_widget/frame_interop.py
@@ -39,11 +39,9 @@ def frame_to_duckdb_registrable(frame: IntoFrame) -> object:
     nw_frame = nw.from_native(frame)
     if nw_frame.implementation in _DUCKDB_NATIVE:
         return nw_frame.to_native()
-    tp = type(frame)
-    msg = f"Converting '{tp.__module__}.{tp.__name__}' to Arrow table for DuckDB registration. This may not be a zero-copy operation."
-    warn(msg, PerformanceWarning)
-
+    msg = f"'{type(frame).__module__}.{type(frame).__name__}' to Arrow table for DuckDB registration."
     if isinstance(nw_frame, nw.LazyFrame):
-        warn("Materializing lazy frame", PerformanceWarning)
+        warn(f"Materializing {msg}", PerformanceWarning)
         return nw_frame.collect(Impl.PYARROW)
+    warn(f"Converting {msg}", PerformanceWarning)
     return nw_frame.to_arrow()

--- a/packages/vgplot/widget/mosaic_widget/frame_interop.py
+++ b/packages/vgplot/widget/mosaic_widget/frame_interop.py
@@ -40,8 +40,9 @@ def frame_to_duckdb_registrable(frame: IntoFrame) -> object:
     if nw_frame.implementation in _DUCKDB_NATIVE:
         return nw_frame.to_native()
     msg = f"'{type(frame).__module__}.{type(frame).__name__}' to Arrow table for DuckDB registration."
+    category, stacklevel = PerformanceWarning, 4
     if isinstance(nw_frame, nw.LazyFrame):
-        warn(f"Materializing {msg}", PerformanceWarning)
+        warn(f"Materializing {msg}", category, stacklevel)
         return nw_frame.collect(Impl.PYARROW)
-    warn(f"Converting {msg}", PerformanceWarning)
+    warn(f"Converting {msg}", category, stacklevel)
     return nw_frame.to_arrow()

--- a/packages/vgplot/widget/mosaic_widget/frame_interop.py
+++ b/packages/vgplot/widget/mosaic_widget/frame_interop.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, Final, TypeAlias
 
 import narwhals as nw
 from narwhals import Implementation as Impl
 from narwhals.dependencies import is_into_dataframe, is_into_lazyframe
 
+from mosaic_widget._exceptions import PerformanceWarning, warn
+
 if TYPE_CHECKING:
     from narwhals.typing import IntoDataFrame, IntoLazyFrame
     from typing_extensions import TypeIs
 
     IntoFrame: TypeAlias = IntoDataFrame | IntoLazyFrame
-
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 _NON_FRAME_TYPES = (str, bytes, int, float, bool, dict, list, tuple, type(None))
@@ -41,14 +39,11 @@ def frame_to_duckdb_registrable(frame: IntoFrame) -> object:
     nw_frame = nw.from_native(frame)
     if nw_frame.implementation in _DUCKDB_NATIVE:
         return nw_frame.to_native()
-    # If frame is not natively registrable to DuckDB, we convert it to an Arrow table via Narwhals.
-    # Based on the backend-specific implementation, this may or may not be zero-copy.
-    logger.warning(
-        f"Converting {type(frame)} to Arrow table for DuckDB registration. This may not be a zero-copy operation."
-    )
+    tp = type(frame)
+    msg = f"Converting '{tp.__module__}.{tp.__name__}' to Arrow table for DuckDB registration. This may not be a zero-copy operation."
+    warn(msg, PerformanceWarning)
 
-    # Some backends like Ibis, PySpark, etc. have lazy-only Narwhals support, so we must materialize them
     if isinstance(nw_frame, nw.LazyFrame):
-        logger.warning("Materializing lazy frame")
+        warn("Materializing lazy frame", PerformanceWarning)
         return nw_frame.collect(Impl.PYARROW)
     return nw_frame.to_arrow()

--- a/packages/vgplot/widget/mosaic_widget/tests/conftest.py
+++ b/packages/vgplot/widget/mosaic_widget/tests/conftest.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import enum
 from collections.abc import Callable, Mapping, Sequence
+from contextlib import AbstractContextManager as ContextManager
+from contextlib import nullcontext
 from functools import partial
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, Final, Generic, TypeAlias, TypeVar
@@ -11,6 +13,8 @@ import pytest
 from narwhals import Implementation as Impl
 from narwhals.typing import EagerAllowed, LazyAllowed
 from pytest import FixtureRequest as Request
+
+from mosaic_widget._exceptions import PerformanceWarning
 
 if TYPE_CHECKING:
     import dask.dataframe as dd
@@ -37,10 +41,15 @@ DataFrameConstructor: TypeAlias = Callable[[Data], NwDataFrame]
 """A constructor for a [`narwhals.DataFrame`][]."""
 
 
-class Warn(enum.Flag):
-    COPY = enum.auto()
-    MATERIALIZE = enum.auto()
-    ALL = COPY | MATERIALIZE
+class Warn(enum.Enum):
+    CONVERT = "Converting"
+    MATERIALIZE = "Materializing"
+    NONE = "null"
+
+    def context(self) -> ContextManager[Any]:
+        if self is Warn.NONE:
+            return nullcontext()
+        return pytest.warns(PerformanceWarning, match=rf"^{self.value}")
 
 
 _LAZY: Final = frozenset[LazyAllowed]().union(
@@ -49,8 +58,6 @@ _LAZY: Final = frozenset[LazyAllowed]().union(
 
 _BackendT = TypeVar("_BackendT", bound=EagerAllowed | LazyAllowed, covariant=True)
 
-_NO_WARNING = Warn(0)
-
 
 class Backend(Generic[_BackendT]):
     """Wrapper around a Narwhals [`backend`][narwhals.typing.IntoBackend]."""
@@ -58,7 +65,7 @@ class Backend(Generic[_BackendT]):
     __slots__ = ("requires", "value", "warn")
 
     def __init__(
-        self, value: _BackendT, requires: str = "", warn: Warn = _NO_WARNING
+        self, value: _BackendT, requires: str = "", warn: Warn = Warn.NONE
     ) -> None:
         self.value: _BackendT = value
         """Argument for `backend` in Narwhals constructors."""
@@ -84,10 +91,10 @@ _BACKENDS: Final = (
     Backend("polars"),
     Backend("pyarrow"),
     Backend("pandas"),
-    Backend("modin", "modin.pandas", Warn.COPY),
-    Backend("ibis", warn=Warn.ALL),
+    Backend("modin", "modin.pandas", Warn.CONVERT),
+    Backend("ibis", warn=Warn.MATERIALIZE),
     Backend("duckdb"),
-    Backend("dask", "dask.dataframe", Warn.ALL),
+    Backend("dask", "dask.dataframe", Warn.MATERIALIZE),
 )
 
 

--- a/packages/vgplot/widget/mosaic_widget/tests/test_frame_interop.py
+++ b/packages/vgplot/widget/mosaic_widget/tests/test_frame_interop.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,11 +8,8 @@ import pytest
 
 from mosaic_widget.frame_interop import frame_to_duckdb_registrable
 
-from .conftest import Warn
-
 if TYPE_CHECKING:
     import pyarrow as pa
-    from pytest import LogCaptureFixture as LogCapture
 
     from .conftest import Backend, EagerAllowed, LazyAllowed, NativeLazyFrame
 
@@ -32,43 +28,17 @@ def pyarrow_frame() -> nw.DataFrame[pa.Table]:
     return nw.read_csv(CSV_PATH, backend="pyarrow")
 
 
-@pytest.fixture
-def caplog(caplog: LogCapture) -> LogCapture:
-    caplog.set_level(logging.WARNING)
-    return caplog
-
-
-def check_warns(caplog: LogCapture, warn: Warn) -> None:
-    copy = "This may not be a zero-copy operation"
-    materialize = "Materializing lazy frame"
-    warn_copy = any(copy in msg for msg in caplog.messages)
-    warn_materialize = any(materialize in msg for msg in caplog.messages)
-    match warn:
-        case Warn.ALL:
-            assert warn_copy and warn_materialize
-        case Warn.COPY:
-            assert warn_copy and not warn_materialize
-        case Warn.MATERIALIZE:
-            assert not warn_copy and warn_materialize
-        case _:
-            assert not (warn_copy or warn_materialize)
-
-
 def test_frame_to_duckdb_registrable_eager(
-    pyarrow_frame: nw.DataFrame[pa.Table],
-    eager: Backend[EagerAllowed],
-    caplog: LogCapture,
+    pyarrow_frame: nw.DataFrame[pa.Table], eager: Backend[EagerAllowed]
 ) -> None:
     frame = nw.from_arrow(pyarrow_frame, backend=eager.value).to_native()
-    assert frame_to_duckdb_registrable(frame) is not None
-    check_warns(caplog, eager.warn)
+    with eager.warn.context():
+        assert frame_to_duckdb_registrable(frame) is not None
 
 
 def test_frame_to_duckdb_registrable_lazy(
-    pyarrow_frame: nw.DataFrame[pa.Table],
-    lazy: Backend[LazyAllowed],
-    caplog: LogCapture,
+    pyarrow_frame: nw.DataFrame[pa.Table], lazy: Backend[LazyAllowed]
 ) -> None:
     frame: NativeLazyFrame = pyarrow_frame.lazy(lazy.value).to_native()
-    assert frame_to_duckdb_registrable(frame) is not None
-    check_warns(caplog, lazy.warn)
+    with lazy.warn.context():
+        assert frame_to_duckdb_registrable(frame) is not None


### PR DESCRIPTION
Closes #1093

## Description
Replaces the mixed usage of `logger.warning` and `warnings.warn` - making warnings easier to test and silence.

Adds a new `_exceptions.py` module to make it harder to get this wrong in the future.

As an example of *what not to do*, consider that `modin` emits warnings like this, when running our tests [^1]:

[^1]: Which I need to resolve in #1088

```py
packages/vgplot/widget/mosaic_widget/tests/test_sql_data.py::test_data_multiple_tables_requires_table_argument[modin]
  .venv/Lib/site-packages/modin/error_message.py:80: UserWarning: `from_dict` is not currently supported by PandasOnPython, defaulting to pandas implementation.
    warnings.warn(message)
```

Whereas our new warnings show you what caused it:

```py
packages/vgplot/widget/mosaic_widget/tests/test_spec_input.py::test_frame_in_data_section_is_registered[modin]
  mosaic/packages/vgplot/widget/mosaic_widget/tests/test_spec_input.py:86: PerformanceWarning: Converting 'modin.pandas.dataframe.DataFrame' to Arrow table for DuckDB registration.
    widget = MosaicWidget(FrameDataSpec({"weather": frame.to_native()}))
```


