### PR TITLE
feat!: size-based client query cache

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -94,6 +94,7 @@
         <div>
           Cache Queries:
           <input id="cache" type="checkbox" checked />
+          <span id="cache-bytes"></span>
         </div>
         <div>
           Consolidate Queries:
@@ -121,6 +122,7 @@
   const sourceMenu = document.querySelector('#source');
   const qlogToggle = document.querySelector('#query-log');
   const cacheToggle = document.querySelector('#cache');
+  const cacheBytes = document.querySelector('#cache-bytes');
   const consolidateToggle = document.querySelector('#consolidate');
   const preaggToggle = document.querySelector('#preagg');
   const preaggState = document.querySelector('#preagg-state');
@@ -143,6 +145,11 @@
       console.warn('No Pre-aggregate Entries');
     }
   });
+
+  setInterval(() => {
+    const bytes = vg.coordinator().manager.cache().bytes();
+    cacheBytes.textContent = `${(bytes / 1048576).toFixed(1)} MiB`;
+  }, 500);
 
   setQueryLog();
   setCache();

--- a/dev/parse.html
+++ b/dev/parse.html
@@ -7,17 +7,18 @@
 <body>
 <script type="module">
   import yaml from '../node_modules/yaml/browser/index.js';
+  import { decodeIPC } from '@uwdata/mosaic-core';
   import { coordinator, setDatabaseConnector } from './setup.js';
   setDatabaseConnector('wasm');
   const db = coordinator.databaseConnector();
 
   self.parse = async function(query) {
     const t0 = Date.now();
-    const table = await db.query({
+    const bytes = await db.query({
       type: 'arrow',
       sql: `SELECT json_serialize_sql($$${query}$$, skip_empty:=true, skip_null:=true) AS ast`
     });
-    const result = table.toArray();
+    const result = decodeIPC(bytes).toArray();
     const ast = JSON.parse(result[0].ast);
     ast._time = Date.now() - t0;
     return ast;

--- a/dev/setup.ts
+++ b/dev/setup.ts
@@ -4,47 +4,6 @@ import { createAPIContext } from '@uwdata/vgplot';
 export { parseSpec, astToDOM, astToESM } from '@uwdata/mosaic-spec';
 export const vg = createAPIContext();
 
-// ---- BEGIN CACHE-SIZE INSTRUMENTATION (via connector wrap) -----------------
-const sizes: number[] = [];
-
-function wrapConnectorForSizing<T extends { query: (req: any) => Promise<any> }>(conn: T): T {
-  const orig = conn.query.bind(conn);
-  conn.query = async (req: any) => {
-    const result = await orig(req);
-    const size = (result as { byteLength?: number })?.byteLength ?? 0;
-    console.log('[sizingCache] query', {
-      type: req.type,
-      size,
-      shape: result?.constructor?.name ?? typeof result
-    });
-    if (size > 0) sizes.push(size);
-    return result;
-  };
-  return conn;
-}
-
-(self as any).__stats = () => {
-  const sorted = [...sizes].sort((a, b) => a - b);
-  const pick = (q: number) => sorted[Math.floor(sorted.length * q)];
-  const total = sizes.reduce((a, b) => a + b, 0);
-  return {
-    count: sizes.length,
-    total_bytes: total,
-    mean: sizes.length ? Math.round(total / sizes.length) : 0,
-    median: pick(0.5),
-    p75: pick(0.75),
-    p95: pick(0.95),
-    min: sorted[0],
-    max: sorted[sorted.length - 1],
-    raw: sizes.slice()
-  };
-};
-
-(self as any).__resetStats = () => {
-  sizes.length = 0;
-};
-// ---- END CACHE-SIZE INSTRUMENTATION ----------------------------------------
-
 // make API accessible for console debugging
 Object.assign(self, { vg });
 
@@ -89,6 +48,5 @@ export async function setDatabaseConnector(type) {
       throw new Error(`Unrecognized connector type: ${type}`);
   }
   console.log('Database Connector', type);
-  wrapConnectorForSizing(connector);
   coordinator.databaseConnector(connector);
 }

--- a/dev/setup.ts
+++ b/dev/setup.ts
@@ -4,6 +4,47 @@ import { createAPIContext } from '@uwdata/vgplot';
 export { parseSpec, astToDOM, astToESM } from '@uwdata/mosaic-spec';
 export const vg = createAPIContext();
 
+// ---- BEGIN CACHE-SIZE INSTRUMENTATION (via connector wrap) -----------------
+const sizes: number[] = [];
+
+function wrapConnectorForSizing<T extends { query: (req: any) => Promise<any> }>(conn: T): T {
+  const orig = conn.query.bind(conn);
+  conn.query = async (req: any) => {
+    const result = await orig(req);
+    const size = (result as { byteLength?: number })?.byteLength ?? 0;
+    console.log('[sizingCache] query', {
+      type: req.type,
+      size,
+      shape: result?.constructor?.name ?? typeof result
+    });
+    if (size > 0) sizes.push(size);
+    return result;
+  };
+  return conn;
+}
+
+(self as any).__stats = () => {
+  const sorted = [...sizes].sort((a, b) => a - b);
+  const pick = (q: number) => sorted[Math.floor(sorted.length * q)];
+  const total = sizes.reduce((a, b) => a + b, 0);
+  return {
+    count: sizes.length,
+    total_bytes: total,
+    mean: sizes.length ? Math.round(total / sizes.length) : 0,
+    median: pick(0.5),
+    p75: pick(0.75),
+    p95: pick(0.95),
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    raw: sizes.slice()
+  };
+};
+
+(self as any).__resetStats = () => {
+  sizes.length = 0;
+};
+// ---- END CACHE-SIZE INSTRUMENTATION ----------------------------------------
+
 // make API accessible for console debugging
 Object.assign(self, { vg });
 
@@ -48,5 +89,6 @@ export async function setDatabaseConnector(type) {
       throw new Error(`Unrecognized connector type: ${type}`);
   }
   console.log('Database Connector', type);
+  wrapConnectorForSizing(connector);
   coordinator.databaseConnector(connector);
 }

--- a/dev/setup.ts
+++ b/dev/setup.ts
@@ -1,4 +1,4 @@
-import { DuckDBWASMConnector, RestConnector, SocketConnector } from '@uwdata/mosaic-core';
+import { decodeIPC, DuckDBWASMConnector, RestConnector, SocketConnector } from '@uwdata/mosaic-core';
 import { createAPIContext } from '@uwdata/vgplot';
 
 export { parseSpec, astToDOM, astToESM } from '@uwdata/mosaic-spec';
@@ -10,11 +10,11 @@ Object.assign(self, { vg });
 // enable query interface on global this (window)
 Object.assign(self, {
   query: async (sql) => {
-    const r = await vg.coordinator().databaseConnector().query({
+    const bytes = await vg.coordinator().databaseConnector().query({
       type: 'arrow',
       sql
     });
-    return r.toArray();
+    return decodeIPC(bytes).toArray();
   }
 });
 

--- a/docs/api/core/connectors.md
+++ b/docs/api/core/connectors.md
@@ -9,6 +9,8 @@ The _query_ argument is an object that may include the following properties:
 - _type_: The query format type, either `"exec"` (no return value) or `"arrow"`.
 - Any additional connector-specific options.
 
+For the `"arrow"` type, a connector returns the raw Arrow IPC bytes as an `ArrayBuffer`, a `Uint8Array`, or an array of `Uint8Array` chunks; the coordinator decodes them to an Arrow table.
+
 Once instantiated, register a connector with the coordinator using the [`coordinator.databaseConnector()`](coordinator#databaseconnector) method.
 
 ## socketConnector

--- a/docs/api/core/connectors.md
+++ b/docs/api/core/connectors.md
@@ -9,7 +9,7 @@ The _query_ argument is an object that may include the following properties:
 - _type_: The query format type, either `"exec"` (no return value) or `"arrow"`.
 - Any additional connector-specific options.
 
-For the `"arrow"` type, a connector returns the raw Arrow IPC bytes as an `ArrayBuffer`, a `Uint8Array`, or an array of `Uint8Array` chunks; the coordinator decodes them to an Arrow table.
+For the `"arrow"` type, a connector returns the raw Arrow IPC bytes as an `ArrowIPCBytes` value, which is an `ArrayBuffer`, a `Uint8Array`, or an array of `Uint8Array` chunks; the coordinator decodes them to an Arrow table.
 
 Once instantiated, register a connector with the coordinator using the [`coordinator.databaseConnector()`](coordinator#databaseconnector) method.
 

--- a/docs/api/core/connectors.md
+++ b/docs/api/core/connectors.md
@@ -13,6 +13,12 @@ For the `"arrow"` type, a connector returns the raw Arrow IPC bytes as an `Arrow
 
 Once instantiated, register a connector with the coordinator using the [`coordinator.databaseConnector()`](coordinator#databaseconnector) method.
 
+## decodeIPC
+
+`decodeIPC(data, options)`
+
+Decode Arrow IPC bytes to an Arrow table. The _data_ argument is an `ArrowIPCBytes` value. The optional _options_ argument gives Arrow IPC extraction options; if unspecified, date and timestamp values are extracted as JavaScript `Date` objects. Use this to read query results directly from a connector, outside the coordinator.
+
 ## socketConnector
 
 `socketConnector(uri)`

--- a/docs/api/core/coordinator.md
+++ b/docs/api/core/coordinator.md
@@ -18,9 +18,27 @@ Get the default global coordinator instance.
 Create a new Mosaic Coordinator to manage all database communication for clients and handle selection updates. Accepts a database _connector_ and an _options_ object:
 
 * _logger_: The logger to use, defaults to `console`.
-* _cache_: Boolean flag to enable/disable query caching (default `true`).
+* _cache_: Boolean flag to enable/disable query caching, or a custom cache object with `get`, `set`, and `clear` methods (default `true`, which uses `lruCache()`). A custom cache is called as `set(key, value, bytes, owner)`, where _bytes_ is the measured size of the result (`0` if the size could not be measured) and _owner_, when present, is a source object shared by multiple entries: entries passing the same _owner_ must be charged against a size budget only once.
+* _ipc_: Arrow IPC extraction options used when decoding `"arrow"` query results. If unspecified, date and timestamp values are extracted as JavaScript `Date` objects.
 * _consolidate_ Boolean flag to enable/disable query consolidation (default `true`).
 * _preagg_: Pre-aggregation options object. The _enabled_ flag (default `true`) determines if pre-aggregation optimizations should be used when possible. The _schema_ option (default `'mosaic'`) indicates the database schema in which materialized view tables should be created for pre-aggregated data.
+
+## Query cache
+
+`lruCache(options)`
+
+Create a least-recently-used query cache with a byte budget. This is the cache the coordinator uses when the _cache_ option is `true`. Supports the following _options_:
+
+- _maxBytes_: The maximum number of bytes of query results to retain (default `33554432`, or 32 MiB). Once the budget is exceeded, the least recently used entries are evicted.
+- _ttl_: The time in milliseconds that an unused entry is retained (default `10800000`, or 3 hours). An entry older than its _ttl_ is discarded upon lookup.
+
+For `"arrow"` results the budget counts the Arrow IPC bytes returned by the connector, not the size of the decoded table; `"json"` results are measured by the length of their JSON serialization. A result larger than _maxBytes_ is passed through without being cached. Arrow results extracted from the same consolidated query share one decoded table, and so are charged against the budget only once.
+
+`voidCache()`
+
+Create a cache that retains nothing. This is the cache used when the coordinator _cache_ option is `false`.
+
+Both `lruCache` and `voidCache` are exported from `@uwdata/mosaic-core`. To use a budget other than the default, pass a cache instance as the _cache_ option: `new Coordinator(connector, { cache: lruCache({ maxBytes: 64 * 1024 * 1024 }) })`.
 
 ## databaseConnector
 

--- a/docs/api/core/coordinator.md
+++ b/docs/api/core/coordinator.md
@@ -32,7 +32,7 @@ Create the least-recently-used query cache the coordinator uses by default. The 
 - _maxBytes_: The maximum number of bytes to retain (default 32 MiB).
 - _ttl_: The time in milliseconds after which an unused entry is discarded (default 3 hours).
 
-A custom cache object must implement `get(key)`, `set(key, value, bytes, owner)`, and `clear()`, where entries that share an _owner_ object hold the same underlying data.
+A custom cache object must implement `get(key)`, `set(key, value, bytes, owner)`, `clear()`, and `bytes()`, where entries that share an _owner_ object hold the same underlying data and `bytes()` returns the total bytes currently charged to the cache.
 
 ## databaseConnector
 

--- a/docs/api/core/coordinator.md
+++ b/docs/api/core/coordinator.md
@@ -18,7 +18,7 @@ Get the default global coordinator instance.
 Create a new Mosaic Coordinator to manage all database communication for clients and handle selection updates. Accepts a database _connector_ and an _options_ object:
 
 * _logger_: The logger to use, defaults to `console`.
-* _cache_: Boolean flag to enable/disable query caching, or a custom cache object with `get`, `set`, and `clear` methods (default `true`, which uses `lruCache()`). A custom cache is called as `set(key, value, bytes, owner)`, where _bytes_ is the measured size of the result (`0` if the size could not be measured) and _owner_, when present, is a source object shared by multiple entries: entries passing the same _owner_ must be charged against a size budget only once.
+* _cache_: Boolean flag to enable/disable query caching (default `true`), or a cache object such as `lruCache({ maxBytes })` to use a custom budget. See [Query cache](#query-cache).
 * _ipc_: Arrow IPC extraction options used when decoding `"arrow"` query results. If unspecified, date and timestamp values are extracted as JavaScript `Date` objects.
 * _consolidate_ Boolean flag to enable/disable query consolidation (default `true`).
 * _preagg_: Pre-aggregation options object. The _enabled_ flag (default `true`) determines if pre-aggregation optimizations should be used when possible. The _schema_ option (default `'mosaic'`) indicates the database schema in which materialized view tables should be created for pre-aggregated data.
@@ -27,18 +27,12 @@ Create a new Mosaic Coordinator to manage all database communication for clients
 
 `lruCache(options)`
 
-Create a least-recently-used query cache with a byte budget. This is the cache the coordinator uses when the _cache_ option is `true`. Supports the following _options_:
+Create the least-recently-used query cache the coordinator uses by default. The budget counts the Arrow IPC bytes returned by the connector; results of one consolidated query share a single charge, and a result larger than the budget is not cached. Supports the following _options_:
 
-- _maxBytes_: The maximum number of bytes of query results to retain (default `33554432`, or 32 MiB). Once the budget is exceeded, the least recently used entries are evicted.
-- _ttl_: The time in milliseconds that an unused entry is retained (default `10800000`, or 3 hours). An entry older than its _ttl_ is discarded upon lookup.
+- _maxBytes_: The maximum number of bytes to retain (default 32 MiB).
+- _ttl_: The time in milliseconds after which an unused entry is discarded (default 3 hours).
 
-For `"arrow"` results the budget counts the Arrow IPC bytes returned by the connector, not the size of the decoded table; `"json"` results are measured by the length of their JSON serialization. A result larger than _maxBytes_ is passed through without being cached. Arrow results extracted from the same consolidated query share one decoded table, and so are charged against the budget only once.
-
-`voidCache()`
-
-Create a cache that retains nothing. This is the cache used when the coordinator _cache_ option is `false`.
-
-Both `lruCache` and `voidCache` are exported from `@uwdata/mosaic-core`. To use a budget other than the default, pass a cache instance as the _cache_ option: `new Coordinator(connector, { cache: lruCache({ maxBytes: 64 * 1024 * 1024 }) })`.
+A custom cache object must implement `get(key)`, `set(key, value, bytes, owner)`, and `clear()`, where entries that share an _owner_ object hold the same underlying data.
 
 ## databaseConnector
 

--- a/docs/api/core/coordinator.md
+++ b/docs/api/core/coordinator.md
@@ -19,7 +19,7 @@ Create a new Mosaic Coordinator to manage all database communication for clients
 
 * _logger_: The logger to use, defaults to `console`.
 * _cache_: Boolean flag to enable/disable query caching (default `true`), or a cache object such as `lruCache({ maxBytes })` to use a custom budget. See [Query cache](#query-cache).
-* _ipc_: Arrow IPC extraction options used when decoding `"arrow"` query results. If unspecified, date and timestamp values are extracted as JavaScript `Date` objects. Setting new options on the query manager clears the query cache, as cached tables were decoded under the previous options.
+* _ipc_: Arrow IPC extraction options used when decoding `"arrow"` query results. If unspecified, date and timestamp values are extracted as JavaScript `Date` objects. Setting new options on the query manager clears the query cache.
 * _consolidate_ Boolean flag to enable/disable query consolidation (default `true`).
 * _preagg_: Pre-aggregation options object. The _enabled_ flag (default `true`) determines if pre-aggregation optimizations should be used when possible. The _schema_ option (default `'mosaic'`) indicates the database schema in which materialized view tables should be created for pre-aggregated data.
 

--- a/docs/api/core/coordinator.md
+++ b/docs/api/core/coordinator.md
@@ -19,7 +19,7 @@ Create a new Mosaic Coordinator to manage all database communication for clients
 
 * _logger_: The logger to use, defaults to `console`.
 * _cache_: Boolean flag to enable/disable query caching (default `true`), or a cache object such as `lruCache({ maxBytes })` to use a custom budget. See [Query cache](#query-cache).
-* _ipc_: Arrow IPC extraction options used when decoding `"arrow"` query results. If unspecified, date and timestamp values are extracted as JavaScript `Date` objects.
+* _ipc_: Arrow IPC extraction options used when decoding `"arrow"` query results. If unspecified, date and timestamp values are extracted as JavaScript `Date` objects. Setting new options clears the query cache, as cached tables were decoded under the previous options.
 * _consolidate_ Boolean flag to enable/disable query consolidation (default `true`).
 * _preagg_: Pre-aggregation options object. The _enabled_ flag (default `true`) determines if pre-aggregation optimizations should be used when possible. The _schema_ option (default `'mosaic'`) indicates the database schema in which materialized view tables should be created for pre-aggregated data.
 

--- a/docs/api/core/coordinator.md
+++ b/docs/api/core/coordinator.md
@@ -19,7 +19,7 @@ Create a new Mosaic Coordinator to manage all database communication for clients
 
 * _logger_: The logger to use, defaults to `console`.
 * _cache_: Boolean flag to enable/disable query caching (default `true`), or a cache object such as `lruCache({ maxBytes })` to use a custom budget. See [Query cache](#query-cache).
-* _ipc_: Arrow IPC extraction options used when decoding `"arrow"` query results. If unspecified, date and timestamp values are extracted as JavaScript `Date` objects. Setting new options clears the query cache, as cached tables were decoded under the previous options.
+* _ipc_: Arrow IPC extraction options used when decoding `"arrow"` query results. If unspecified, date and timestamp values are extracted as JavaScript `Date` objects. Setting new options on the query manager clears the query cache, as cached tables were decoded under the previous options.
 * _consolidate_ Boolean flag to enable/disable query consolidation (default `true`).
 * _preagg_: Pre-aggregation options object. The _enabled_ flag (default `true`) determines if pre-aggregation optimizations should be used when possible. The _schema_ option (default `'mosaic'`) indicates the database schema in which materialized view tables should be created for pre-aggregated data.
 

--- a/docs/api/core/coordinator.md
+++ b/docs/api/core/coordinator.md
@@ -29,7 +29,7 @@ Create a new Mosaic Coordinator to manage all database communication for clients
 
 Create the least-recently-used query cache the coordinator uses by default. The budget counts the Arrow IPC bytes returned by the connector; results of one consolidated query share a single charge, and a result larger than the budget is not cached. Supports the following _options_:
 
-- _maxBytes_: The maximum number of bytes to retain (default 32 MiB).
+- _maxBytes_: The maximum number of bytes to retain (default 256 MiB).
 - _ttl_: The time in milliseconds after which an unused entry is discarded (default 3 hours).
 
 A custom cache object must implement `get(key)`, `set(key, value, bytes, owner)`, `clear()`, and `bytes()`, where entries that share an _owner_ object hold the same underlying data and `bytes()` returns the total bytes currently charged to the cache.

--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -77,7 +77,7 @@ export class Coordinator {
       logger = console,
       manager = new QueryManager(),
       cache = true,
-      ipc = undefined,
+      ipc,
       consolidate = true,
       preagg = {}
     } = options;
@@ -106,7 +106,7 @@ export class Coordinator {
       this.clients?.forEach(client => this.disconnect(client));
       this.clients = new Set;
     }
-    if (cache) this.manager.cache()!.clear();
+    if (cache) this.manager.cache().clear();
   }
 
   /**

--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -83,7 +83,7 @@ export class Coordinator {
     } = options;
     this.manager = manager;
     this.manager.cache(cache);
-    this.manager.ipc(ipc);
+    if (ipc) this.manager.ipc(ipc);
     this.manager.consolidate(consolidate);
     this.databaseConnector(db);
     this.logger(logger);

--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -4,12 +4,12 @@ import { PreAggregator, type PreAggregateOptions } from './preagg/PreAggregator.
 import { voidLogger } from './util/void-logger.js';
 import { QueryManager, Priority } from './QueryManager.js';
 import { type Selection } from './Selection.js';
-import { type Logger, type QueryType } from './types.js';
+import { type Cache, type Logger, type QueryType } from './types.js';
 import { type QueryResult } from './util/query-result.js';
 import { type MosaicClient } from './MosaicClient.js';
 import { type SelectionClause } from './SelectionClause.js';
 import { MaybeArray } from '@uwdata/mosaic-sql';
-import { Table } from '@uwdata/flechette';
+import { type ExtractionOptions, Table } from '@uwdata/flechette';
 import { QueryError } from './util/query-error.js';
 
 interface FilterGroupEntry {
@@ -56,7 +56,9 @@ export class Coordinator {
    * @param options Coordinator options.
    * @param options.logger The logger to use, defaults to `console`.
    * @param options.manager The query manager to use.
-   * @param options.cache Boolean flag to enable/disable query caching.
+   * @param options.cache Boolean flag to enable/disable query caching, or a
+   *  custom cache object.
+   * @param options.ipc Arrow IPC extraction options.
    * @param options.consolidate Boolean flag to enable/disable query consolidation.
    * @param options.preagg Options for the Pre-aggregator.
    */
@@ -65,7 +67,8 @@ export class Coordinator {
     options: {
       logger?: Logger | null;
       manager?: QueryManager;
-      cache?: boolean;
+      cache?: boolean | Cache;
+      ipc?: ExtractionOptions;
       consolidate?: boolean;
       preagg?: PreAggregateOptions;
     } = {}
@@ -74,11 +77,13 @@ export class Coordinator {
       logger = console,
       manager = new QueryManager(),
       cache = true,
+      ipc = undefined,
       consolidate = true,
       preagg = {}
     } = options;
     this.manager = manager;
     this.manager.cache(cache);
+    this.manager.ipc(ipc);
     this.manager.consolidate(consolidate);
     this.databaseConnector(db);
     this.logger(logger);

--- a/packages/mosaic/core/src/QueryConsolidator.ts
+++ b/packages/mosaic/core/src/QueryConsolidator.ts
@@ -2,6 +2,8 @@ import type { Table } from '@uwdata/flechette';
 import type { ExprNode, MaybeArray, Query, SelectQuery } from '@uwdata/mosaic-sql';
 import { isAggregateExpression, isColumnRef, isDescribeQuery, isSelectQuery } from '@uwdata/mosaic-sql';
 import type { Cache, QueryEntry, QueryType } from './types.js';
+import { jsonByteLength } from './util/cache.js';
+import { tableByteLength } from './util/decode-ipc.js';
 import { resolvePositional } from './util/positional.js';
 import { QueryResult } from './util/query-result.js';
 
@@ -279,6 +281,7 @@ async function processResults(group: QueryGroup, cache: Cache): Promise<void> {
   // extract result for each query in the consolidation group
   // update cache and pass extract to original issuer
   const describe = isDescribeQuery(query!);
+  const bytes = tableByteLength(data) ?? 0;
   group.forEach(({ entry }, index) => {
     const { request, result } = entry;
     const map = maps[index];
@@ -286,7 +289,12 @@ async function processResults(group: QueryGroup, cache: Cache): Promise<void> {
       : map ? projectResult(data, map)
       : data;
     if (request.cache) {
-      cache.set(String(request.query), extract);
+      const key = String(request.query);
+      if (describe && map) {
+        cache.set(key, extract, jsonByteLength(extract));
+      } else {
+        cache.set(key, extract, bytes, data);
+      }
     }
     result.fulfill(extract);
   });

--- a/packages/mosaic/core/src/QueryConsolidator.ts
+++ b/packages/mosaic/core/src/QueryConsolidator.ts
@@ -2,7 +2,6 @@ import type { Table } from '@uwdata/flechette';
 import type { ExprNode, MaybeArray, Query, SelectQuery } from '@uwdata/mosaic-sql';
 import { isAggregateExpression, isColumnRef, isDescribeQuery, isSelectQuery } from '@uwdata/mosaic-sql';
 import type { Cache, QueryEntry, QueryType } from './types.js';
-import { jsonByteLength } from './util/cache.js';
 import { tableByteLength } from './util/decode-ipc.js';
 import { resolvePositional } from './util/positional.js';
 import { QueryResult } from './util/query-result.js';
@@ -289,12 +288,7 @@ async function processResults(group: QueryGroup, cache: Cache): Promise<void> {
       : map ? projectResult(data, map)
       : data;
     if (request.cache) {
-      const key = String(request.query);
-      if (describe && map) {
-        cache.set(key, extract, jsonByteLength(extract));
-      } else {
-        cache.set(key, extract, bytes, data);
-      }
+      cache.set(String(request.query), extract, bytes, data);
     }
     result.fulfill(extract);
   });

--- a/packages/mosaic/core/src/QueryManager.ts
+++ b/packages/mosaic/core/src/QueryManager.ts
@@ -1,7 +1,7 @@
 import type { Connector } from './connectors/Connector.js';
 import type { Cache, Logger, QueryEntry, QueryRequest } from './types.js';
 import { consolidator } from './QueryConsolidator.js';
-import { lruCache, voidCache } from './util/cache.js';
+import { assertCacheable, lruCache, voidCache } from './util/cache.js';
 import { PriorityQueue } from './util/priority-queue.js';
 import { QueryResult, QueryState } from './util/query-result.js';
 import { voidLogger } from './util/void-logger.js';
@@ -102,7 +102,10 @@ export class QueryManager {
 
       const data = await promise;
 
-      if (cache) this.clientCache!.set(sql!, data);
+      if (cache) {
+        assertCacheable(data, `connector result (type=${type})`);
+        this.clientCache!.set(sql!, data);
+      }
 
       this._logger.debug(`Request: ${(performance.now() - t0).toFixed(1)}`);
       result.ready(type === 'exec' ? null : data);

--- a/packages/mosaic/core/src/QueryManager.ts
+++ b/packages/mosaic/core/src/QueryManager.ts
@@ -76,10 +76,9 @@ export class QueryManager {
    * @param result The query result.
    */
   async submit(request: QueryRequest, result: QueryResult): Promise<void> {
+    const { query, type, cache = false, options } = request;
+    const sql = Array.isArray(query) ? query.filter(x => x).join(';\n') : query ? String(query) : null;
     try {
-      const { query, type, cache = false, options } = request;
-      const sql = Array.isArray(query) ? query.filter(x => x).join(';\n') : query ? String(query) : null;
-
       // check query cache
       if (cache) {
         const cached = this.clientCache!.get(sql!);
@@ -108,6 +107,8 @@ export class QueryManager {
       this._logger.debug(`Request: ${(performance.now() - t0).toFixed(1)}`);
       result.ready(type === 'exec' ? null : data);
     } catch (err) {
+      // If we stored a pending promise for this key, remove it to prevent leaks
+      if (cache && sql) this.clientCache!.delete(sql);
       result.reject(err);
     }
   }

--- a/packages/mosaic/core/src/QueryManager.ts
+++ b/packages/mosaic/core/src/QueryManager.ts
@@ -1,6 +1,6 @@
-import type { ExtractionOptions, Table } from '@uwdata/flechette';
+import type { ExtractionOptions } from '@uwdata/flechette';
 import type { Connector } from './connectors/Connector.js';
-import type { ArrowIPCBytes, Cache, Logger, QueryEntry, QueryRequest } from './types.js';
+import type { Cache, Logger, QueryEntry, QueryRequest } from './types.js';
 import { consolidator } from './QueryConsolidator.js';
 import { lruCache, voidCache } from './util/cache.js';
 import { decodeIPC, tableByteLength } from './util/decode-ipc.js';
@@ -13,7 +13,7 @@ export const Priority = Object.freeze({ High: 0, Normal: 1, Low: 2 });
 export class QueryManager {
   private queue: PriorityQueue<QueryEntry>;
   private db: Connector | null;
-  private clientCache: Cache | null;
+  private clientCache: Cache;
   private _logger: Logger;
   private _logQueries: boolean;
   private _ipc?: ExtractionOptions;
@@ -27,7 +27,7 @@ export class QueryManager {
   constructor(maxConcurrentRequests: number = 32) {
     this.queue = new PriorityQueue(3);
     this.db = null;
-    this.clientCache = null;
+    this.clientCache = voidCache();
     this._logger = voidLogger();
     this._logQueries = false;
     this._consolidate = null;
@@ -83,10 +83,10 @@ export class QueryManager {
   async submit(request: QueryRequest, result: QueryResult): Promise<void> {
     try {
       const { query, type, cache = false, options } = request;
-      const sql = Array.isArray(query) ? query.filter(x => x).join(';\n') : query ? String(query) : null;
+      const sql = Array.isArray(query) ? query.filter(x => x).join(';\n') : String(query);
 
       if (cache) {
-        const cached = this.clientCache!.get(sql!) ?? this.inflight.get(sql!);
+        const cached = this.clientCache.get(sql) ?? this.inflight.get(sql);
         if (cached) {
           const data = await cached;
           this._logger.debug('Cache');
@@ -101,15 +101,15 @@ export class QueryManager {
       }
 
       // @ts-expect-error type may be exec | arrow
-      const response = this.db!.query({ ...options, type, sql: sql! });
+      const response = this.db!.query({ ...options, type, sql });
       const promise = type === 'arrow'
-        ? response.then(bytes => decodeIPC(bytes as ArrowIPCBytes, this._ipc))
+        ? response.then(bytes => decodeIPC(bytes, this._ipc))
         : response;
-      if (cache) this.inflight.set(sql!, promise);
+      if (cache) this.inflight.set(sql, promise);
 
-      const data = await promise.finally(() => this.inflight.delete(sql!));
+      const data = await promise.finally(() => { if (cache) this.inflight.delete(sql); });
 
-      if (cache) this.clientCache!.set(sql!, data, resultByteLength(type, data));
+      if (cache) this.clientCache.set(sql, data, tableByteLength(data) ?? 0);
 
       this._logger.debug(`Request: ${(performance.now() - t0).toFixed(1)}`);
       result.ready(type === 'exec' ? null : data);
@@ -123,9 +123,7 @@ export class QueryManager {
    * @param value Cache value to set
    * @returns Current cache
    */
-  cache(): Cache | null;
-  cache(value: Cache | boolean): Cache;
-  cache(value?: Cache | boolean): Cache | null {
+  cache(value?: Cache | boolean): Cache {
     return value !== undefined
       ? (this.clientCache = value === true ? lruCache() : (value || voidCache()))
       : this.clientCache;
@@ -147,11 +145,9 @@ export class QueryManager {
    * @param value Extraction options to set
    * @returns Current extraction options
    */
-  ipc(): ExtractionOptions | undefined;
-  ipc(value: ExtractionOptions): ExtractionOptions | undefined;
   ipc(value?: ExtractionOptions): ExtractionOptions | undefined {
     if (value === undefined) return this._ipc;
-    this.clientCache?.clear();
+    this.clientCache.clear();
     return this._ipc = value;
   }
 
@@ -183,7 +179,7 @@ export class QueryManager {
    */
   consolidate(flag: boolean): void {
     if (flag && !this._consolidate) {
-      this._consolidate = consolidator(this.enqueue.bind(this), this.clientCache!);
+      this._consolidate = consolidator(this.enqueue.bind(this), this.clientCache);
     } else if (!flag && this._consolidate) {
       this._consolidate = null;
     }
@@ -236,8 +232,4 @@ export class QueryManager {
     }
     this.pendingResults = [];
   }
-}
-
-function resultByteLength(type: QueryRequest['type'], data: unknown): number {
-  return type === 'arrow' ? tableByteLength(data as Table) ?? 0 : 0;
 }

--- a/packages/mosaic/core/src/QueryManager.ts
+++ b/packages/mosaic/core/src/QueryManager.ts
@@ -1,7 +1,9 @@
+import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import type { Connector } from './connectors/Connector.js';
 import type { Cache, Logger, QueryEntry, QueryRequest } from './types.js';
 import { consolidator } from './QueryConsolidator.js';
-import { assertCacheable, lruCache, voidCache } from './util/cache.js';
+import { lruCache, voidCache } from './util/cache.js';
+import { decodeIPC, tableByteLength } from './util/decode-ipc.js';
 import { PriorityQueue } from './util/priority-queue.js';
 import { QueryResult, QueryState } from './util/query-result.js';
 import { voidLogger } from './util/void-logger.js';
@@ -14,6 +16,7 @@ export class QueryManager {
   private clientCache: Cache | null;
   private _logger: Logger;
   private _logQueries: boolean;
+  private _ipc?: ExtractionOptions;
   private _consolidate: ReturnType<typeof consolidator> | null;
   /** Requests pending with the query manager. */
   public pendingResults: QueryResult[];
@@ -76,10 +79,10 @@ export class QueryManager {
    * @param result The query result.
    */
   async submit(request: QueryRequest, result: QueryResult): Promise<void> {
-    const { query, type, cache = false, options } = request;
-    const sql = Array.isArray(query) ? query.filter(x => x).join(';\n') : query ? String(query) : null;
     try {
-      // check query cache
+      const { query, type, cache = false, options } = request;
+      const sql = Array.isArray(query) ? query.filter(x => x).join(';\n') : query ? String(query) : null;
+
       if (cache) {
         const cached = this.clientCache!.get(sql!);
         if (cached) {
@@ -90,28 +93,25 @@ export class QueryManager {
         }
       }
 
-      // issue query, potentially cache result
       const t0 = performance.now();
       if (this._logQueries) {
         this._logger.debug('Query', { type, sql, ...options });
       }
 
       // @ts-expect-error type may be exec | arrow
-      const promise = this.db!.query({ ...options, type, sql: sql! });
+      const response = this.db!.query({ ...options, type, sql: sql! });
+      const promise = type === 'arrow'
+        ? response.then(bytes => decodeIPC(bytes as ArrayBuffer | Uint8Array | Uint8Array[], this._ipc))
+        : response;
       if (cache) this.clientCache!.set(sql!, promise);
 
       const data = await promise;
 
-      if (cache) {
-        assertCacheable(data, `connector result (type=${type})`);
-        this.clientCache!.set(sql!, data);
-      }
+      if (cache) this.clientCache!.set(sql!, data, resultByteLength(type, data));
 
       this._logger.debug(`Request: ${(performance.now() - t0).toFixed(1)}`);
       result.ready(type === 'exec' ? null : data);
     } catch (err) {
-      // If we stored a pending promise for this key, remove it to prevent leaks
-      if (cache && sql) this.clientCache!.delete(sql);
       result.reject(err);
     }
   }
@@ -138,6 +138,17 @@ export class QueryManager {
   logger(value: Logger): Logger;
   logger(value?: Logger): Logger {
     return value ? (this._logger = value) : this._logger;
+  }
+
+  /**
+   * Get or set the Arrow IPC extraction options.
+   * @param value Extraction options to set
+   * @returns Current extraction options
+   */
+  ipc(): ExtractionOptions | undefined;
+  ipc(value: ExtractionOptions | undefined): ExtractionOptions | undefined;
+  ipc(value?: ExtractionOptions): ExtractionOptions | undefined {
+    return value !== undefined ? (this._ipc = value) : this._ipc;
   }
 
   /**
@@ -221,4 +232,8 @@ export class QueryManager {
     }
     this.pendingResults = [];
   }
+}
+
+function resultByteLength(type: QueryRequest['type'], data: unknown): number {
+  return type === 'arrow' ? tableByteLength(data as Table) ?? 0 : 0;
 }

--- a/packages/mosaic/core/src/QueryManager.ts
+++ b/packages/mosaic/core/src/QueryManager.ts
@@ -18,6 +18,7 @@ export class QueryManager {
   private _logQueries: boolean;
   private _ipc?: ExtractionOptions;
   private _consolidate: ReturnType<typeof consolidator> | null;
+  private inflight: Map<string, Promise<unknown>>;
   /** Requests pending with the query manager. */
   public pendingResults: QueryResult[];
   private maxConcurrentRequests: number;
@@ -30,6 +31,7 @@ export class QueryManager {
     this._logger = voidLogger();
     this._logQueries = false;
     this._consolidate = null;
+    this.inflight = new Map();
     this.pendingResults = [];
     this.maxConcurrentRequests = maxConcurrentRequests;
     this.pendingExec = false;
@@ -84,7 +86,7 @@ export class QueryManager {
       const sql = Array.isArray(query) ? query.filter(x => x).join(';\n') : query ? String(query) : null;
 
       if (cache) {
-        const cached = this.clientCache!.get(sql!);
+        const cached = this.clientCache!.get(sql!) ?? this.inflight.get(sql!);
         if (cached) {
           const data = await cached;
           this._logger.debug('Cache');
@@ -103,9 +105,9 @@ export class QueryManager {
       const promise = type === 'arrow'
         ? response.then(bytes => decodeIPC(bytes as ArrowIPCBytes, this._ipc))
         : response;
-      if (cache) this.clientCache!.set(sql!, promise);
+      if (cache) this.inflight.set(sql!, promise);
 
-      const data = await promise;
+      const data = await promise.finally(() => this.inflight.delete(sql!));
 
       if (cache) this.clientCache!.set(sql!, data, resultByteLength(type, data));
 

--- a/packages/mosaic/core/src/QueryManager.ts
+++ b/packages/mosaic/core/src/QueryManager.ts
@@ -1,6 +1,6 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import type { Connector } from './connectors/Connector.js';
-import type { Cache, Logger, QueryEntry, QueryRequest } from './types.js';
+import type { ArrowIPCBytes, Cache, Logger, QueryEntry, QueryRequest } from './types.js';
 import { consolidator } from './QueryConsolidator.js';
 import { lruCache, voidCache } from './util/cache.js';
 import { decodeIPC, tableByteLength } from './util/decode-ipc.js';
@@ -101,7 +101,7 @@ export class QueryManager {
       // @ts-expect-error type may be exec | arrow
       const response = this.db!.query({ ...options, type, sql: sql! });
       const promise = type === 'arrow'
-        ? response.then(bytes => decodeIPC(bytes as ArrayBuffer | Uint8Array | Uint8Array[], this._ipc))
+        ? response.then(bytes => decodeIPC(bytes as ArrowIPCBytes, this._ipc))
         : response;
       if (cache) this.clientCache!.set(sql!, promise);
 
@@ -148,7 +148,9 @@ export class QueryManager {
   ipc(): ExtractionOptions | undefined;
   ipc(value: ExtractionOptions | undefined): ExtractionOptions | undefined;
   ipc(value?: ExtractionOptions): ExtractionOptions | undefined {
-    return value !== undefined ? (this._ipc = value) : this._ipc;
+    if (value === undefined) return this._ipc;
+    this.clientCache?.clear();
+    return this._ipc = value;
   }
 
   /**

--- a/packages/mosaic/core/src/QueryManager.ts
+++ b/packages/mosaic/core/src/QueryManager.ts
@@ -146,7 +146,7 @@ export class QueryManager {
    * @returns Current extraction options
    */
   ipc(): ExtractionOptions | undefined;
-  ipc(value: ExtractionOptions | undefined): ExtractionOptions | undefined;
+  ipc(value: ExtractionOptions): ExtractionOptions | undefined;
   ipc(value?: ExtractionOptions): ExtractionOptions | undefined {
     if (value === undefined) return this._ipc;
     this.clientCache?.clear();

--- a/packages/mosaic/core/src/connectors/Connector.ts
+++ b/packages/mosaic/core/src/connectors/Connector.ts
@@ -1,3 +1,5 @@
+import type { ArrowIPCBytes } from '../types.js';
+
 export interface ConnectorQueryRequest {
   /** The query type. */
   type?: string;
@@ -17,6 +19,6 @@ export interface ExecQueryRequest extends ConnectorQueryRequest {
 
 export interface Connector {
   /** Issue a query and return the result. */
-  query(query: ArrowQueryRequest): Promise<ArrayBuffer | Uint8Array | Uint8Array[]>;
+  query(query: ArrowQueryRequest): Promise<ArrowIPCBytes>;
   query(query: ExecQueryRequest): Promise<void>;
 }

--- a/packages/mosaic/core/src/connectors/Connector.ts
+++ b/packages/mosaic/core/src/connectors/Connector.ts
@@ -1,5 +1,3 @@
-import type { Table } from '@uwdata/flechette';
-
 export interface ConnectorQueryRequest {
   /** The query type. */
   type?: string;
@@ -19,6 +17,6 @@ export interface ExecQueryRequest extends ConnectorQueryRequest {
 
 export interface Connector {
   /** Issue a query and return the result. */
-  query(query: ArrowQueryRequest): Promise<Table>;
+  query(query: ArrowQueryRequest): Promise<ArrayBuffer | Uint8Array | Uint8Array[]>;
   query(query: ExecQueryRequest): Promise<void>;
 }

--- a/packages/mosaic/core/src/connectors/NodeConnector.ts
+++ b/packages/mosaic/core/src/connectors/NodeConnector.ts
@@ -1,6 +1,4 @@
-import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import { DuckDB } from '@uwdata/mosaic-duckdb';
-import { decodeIPC } from '../util/decode-ipc.js';
 import type {
   ArrowQueryRequest,
   Connector,
@@ -14,21 +12,16 @@ import type {
  */
 export class NodeConnector implements Connector {
   protected _db: DuckDB;
-  protected _ipc?: ExtractionOptions;
 
-  static async make(db?: DuckDB, ipc?: ExtractionOptions) {
-    const connector = new NodeConnector(db, ipc);
+  static async make(db?: DuckDB) {
+    const connector = new NodeConnector(db);
     // make sure initialization is complete
     await connector._db._init;
     return connector;
   }
 
-  constructor(
-    db: DuckDB = new DuckDB(),
-    ipc?: ExtractionOptions
-  ) {
+  constructor(db: DuckDB = new DuckDB()) {
     this._db = db;
-    this._ipc = ipc;
   }
 
   /**
@@ -36,12 +29,10 @@ export class NodeConnector implements Connector {
    * @param query Query object with type and SQL
    * @returns the query result
    */
-  async query(query: ArrowQueryRequest): Promise<Table>;
+  async query(query: ArrowQueryRequest): Promise<Uint8Array[]>;
   async query(query: ExecQueryRequest): Promise<void>;
   async query(query: ConnectorQueryRequest): Promise<unknown> {
     const { type, sql } = query;
-    return type === 'exec'
-      ? this._db.exec(sql)
-      : decodeIPC(await this._db.arrowBuffer(sql), this._ipc);
+    return type === 'exec' ? this._db.exec(sql) : this._db.arrowBuffer(sql);
   }
 }

--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -1,4 +1,3 @@
-
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 
 interface RestOptions {

--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -1,18 +1,14 @@
-import type { ExtractionOptions, Table } from '@uwdata/flechette';
+
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
-import { decodeIPC } from '../util/decode-ipc.js';
-import { annotateByteLength, assertCacheable } from '../util/cache.js';
 
 interface RestOptions {
   uri?: string;
-  ipc?: ExtractionOptions;
 }
 
 /**
  * Connect to a DuckDB server over an HTTP REST interface.
  * @param options Connector options.
  * @param options.uri The URI for the DuckDB REST server.
- * @param options.ipc Arrow IPC extraction options.
  * @returns A connector instance.
  */
 export function restConnector(options?: RestOptions) {
@@ -21,17 +17,14 @@ export function restConnector(options?: RestOptions) {
 
 export class RestConnector implements Connector {
   private _uri: string;
-  private _ipc?: ExtractionOptions;
 
   constructor({
-    uri = 'http://localhost:3000/',
-    ipc = undefined
+    uri = 'http://localhost:3000/'
   }: RestOptions = {}) {
     this._uri = uri;
-    this._ipc = ipc;
   }
 
-  async query(query: ArrowQueryRequest): Promise<Table>;
+  async query(query: ArrowQueryRequest): Promise<ArrayBuffer>;
   async query(query: ExecQueryRequest): Promise<void>;
   async query(query: ConnectorQueryRequest): Promise<unknown> {
     const req = fetch(this._uri, {
@@ -48,16 +41,8 @@ export class RestConnector implements Connector {
       throw new Error(`Query failed with HTTP status ${res.status}: ${await res.text()}`);
     }
 
-    if (query.type === 'exec') return req;
-    if (query.type === 'arrow') {
-      const table = decodeIPC(await res.arrayBuffer(), this._ipc);
-      assertCacheable(table, 'RestConnector arrow');
-      return table;
-    }
-
-    const text = await res.text();
-    const records = annotateByteLength(JSON.parse(text), text.length);
-    assertCacheable(records, 'RestConnector json');
-    return records;
+    return query.type === 'exec' ? req
+      : query.type === 'arrow' ? res.arrayBuffer()
+      : res.json();
   }
 }

--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -63,6 +63,5 @@ export class RestConnector implements Connector {
  * @returns The byte length of `s` when encoded as UTF-8.
  */
 function utf8Bytes(s: string): number {
-  const byteSize = new TextEncoder().encode(s).length;
-  return byteSize;
+  return new TextEncoder().encode(s).length;
 }

--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -1,7 +1,7 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import { decodeIPC } from '../util/decode-ipc.js';
-import { annotateByteLength } from '../util/cache.js';
+import { annotateByteLength, assertCacheable } from '../util/cache.js';
 
 interface RestOptions {
   uri?: string;
@@ -49,11 +49,17 @@ export class RestConnector implements Connector {
     }
 
     if (query.type === 'exec') return req;
-    if (query.type === 'arrow') return decodeIPC(await res.arrayBuffer(), this._ipc);
-    
+    if (query.type === 'arrow') {
+      const table = decodeIPC(await res.arrayBuffer(), this._ipc);
+      assertCacheable(table, 'RestConnector arrow');
+      return table;
+    }
+
     const text = await res.text();
     const size = Number(res.headers.get('content-length')) || utf8Bytes(text);
-    return annotateByteLength(JSON.parse(text), size);
+    const records = annotateByteLength(JSON.parse(text), size);
+    assertCacheable(records, 'RestConnector json');
+    return records;
   }
 }
 

--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -56,18 +56,8 @@ export class RestConnector implements Connector {
     }
 
     const text = await res.text();
-    const size = Number(res.headers.get('content-length')) || utf8Bytes(text);
-    const records = annotateByteLength(JSON.parse(text), size);
+    const records = annotateByteLength(JSON.parse(text), text.length);
     assertCacheable(records, 'RestConnector json');
     return records;
   }
-}
-
-/**
- * Helper function to find size of a stringified JSON response.
- * @param s The stringified response.
- * @returns The byte length of `s` when encoded as UTF-8.
- */
-function utf8Bytes(s: string): number {
-  return new TextEncoder().encode(s).length;
 }

--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -1,6 +1,6 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
-import { decodeIPC } from '../util/decode-ipc.js';
+import { annotateByteLength, decodeIPC } from '../util/decode-ipc.js';
 
 interface RestOptions {
   uri?: string;
@@ -47,8 +47,21 @@ export class RestConnector implements Connector {
       throw new Error(`Query failed with HTTP status ${res.status}: ${await res.text()}`);
     }
 
-    return query.type === 'exec'
-      ? undefined
-      : decodeIPC(await res.arrayBuffer(), this._ipc);
+    if (query.type === 'exec') return req;
+    if (query.type === 'arrow') return decodeIPC(await res.arrayBuffer(), this._ipc);
+    
+    const text = await res.text();
+    //This allows for an exact size measurement by using TextEncoder to read length
+    return annotateByteLength(JSON.parse(text), utf8Bytes(text));
   }
+}
+
+/**
+ * Helper function to find size of a stringified JSON response.
+ * @param s The stringified response.
+ * @returns The byte length of `s` when encoded as UTF-8.
+ */
+function utf8Bytes(s: string): number {
+  const byteSize = new TextEncoder().encode(s).length;
+  return byteSize;
 }

--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -41,8 +41,6 @@ export class RestConnector implements Connector {
       throw new Error(`Query failed with HTTP status ${res.status}: ${await res.text()}`);
     }
 
-    return query.type === 'exec' ? req
-      : query.type === 'arrow' ? res.arrayBuffer()
-      : res.json();
+    return query.type === 'exec' ? undefined : res.arrayBuffer();
   }
 }

--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -1,6 +1,7 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
-import { annotateByteLength, decodeIPC } from '../util/decode-ipc.js';
+import { decodeIPC } from '../util/decode-ipc.js';
+import { annotateByteLength } from '../util/cache.js';
 
 interface RestOptions {
   uri?: string;
@@ -51,8 +52,8 @@ export class RestConnector implements Connector {
     if (query.type === 'arrow') return decodeIPC(await res.arrayBuffer(), this._ipc);
     
     const text = await res.text();
-    //This allows for an exact size measurement by using TextEncoder to read length
-    return annotateByteLength(JSON.parse(text), utf8Bytes(text));
+    const size = Number(res.headers.get('content-length')) || utf8Bytes(text);
+    return annotateByteLength(JSON.parse(text), size);
   }
 }
 

--- a/packages/mosaic/core/src/connectors/socket.ts
+++ b/packages/mosaic/core/src/connectors/socket.ts
@@ -1,4 +1,3 @@
-
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 
 interface SocketOptions {

--- a/packages/mosaic/core/src/connectors/socket.ts
+++ b/packages/mosaic/core/src/connectors/socket.ts
@@ -1,11 +1,8 @@
-import type { ExtractionOptions, Table } from '@uwdata/flechette';
+
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
-import { decodeIPC } from '../util/decode-ipc.js';
-import { annotateByteLength, assertCacheable } from '../util/cache.js';
 
 interface SocketOptions {
   uri?: string;
-  ipc?: ExtractionOptions;
 }
 
 interface QueueItem<T = unknown> {
@@ -44,8 +41,7 @@ export class SocketConnector implements Connector {
    * @param options.ipc Options for Arrow IPC extraction.
    */
   constructor({
-    uri = 'ws://localhost:3000/',
-    ipc = undefined,
+    uri = 'ws://localhost:3000/'
   }: SocketOptions = {}) {
     this._uri = uri;
     this._queue = [];
@@ -93,9 +89,7 @@ export class SocketConnector implements Connector {
           } else if (query.type === 'exec') {
             resolve();
           } else if (query.type === 'arrow') {
-            const table = decodeIPC(data as Uint8Array, ipc);
-            assertCacheable(table, 'SocketConnector arrow');
-            resolve(table);
+            resolve(data);
           } else {
             reject(new Error(`Unexpected socket data: ${data}`));
           }
@@ -138,7 +132,7 @@ export class SocketConnector implements Connector {
     for (const { reject } of queue) reject(reason);
   }
 
-  query(query: ArrowQueryRequest): Promise<Table>;
+  query(query: ArrowQueryRequest): Promise<ArrayBuffer>;
   query(query: ExecQueryRequest): Promise<void>;
   query(query: ConnectorQueryRequest): Promise<unknown> {
     return new Promise(

--- a/packages/mosaic/core/src/connectors/socket.ts
+++ b/packages/mosaic/core/src/connectors/socket.ts
@@ -14,7 +14,6 @@ interface QueueItem<T = unknown> {
  * Connect to a DuckDB server over a WebSocket interface.
  * @param options Connector options.
  * @param options.uri The URI for the DuckDB server.
- * @param options.ipc Arrow IPC extraction options.
  * @returns A connector instance.
  */
 export function socketConnector(options?: SocketOptions) {
@@ -37,7 +36,6 @@ export class SocketConnector implements Connector {
   /**
    * @param options Connector options.
    * @param options.uri The URI for the DuckDB server, defaults to `ws://localhost:3000/`.
-   * @param options.ipc Options for Arrow IPC extraction.
    */
   constructor({
     uri = 'ws://localhost:3000/'

--- a/packages/mosaic/core/src/connectors/socket.ts
+++ b/packages/mosaic/core/src/connectors/socket.ts
@@ -1,7 +1,7 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import { decodeIPC } from '../util/decode-ipc.js';
-import { annotateByteLength } from '../util/cache.js';
+import { annotateByteLength, assertCacheable } from '../util/cache.js';
 
 interface SocketOptions {
   uri?: string;
@@ -93,7 +93,9 @@ export class SocketConnector implements Connector {
           } else if (query.type === 'exec') {
             resolve();
           } else if (query.type === 'arrow') {
-            resolve(decodeIPC(data as Uint8Array, ipc));
+            const table = decodeIPC(data as Uint8Array, ipc);
+            assertCacheable(table, 'SocketConnector arrow');
+            resolve(table);
           } else {
             reject(new Error(`Unexpected socket data: ${data}`));
           }

--- a/packages/mosaic/core/src/connectors/socket.ts
+++ b/packages/mosaic/core/src/connectors/socket.ts
@@ -1,6 +1,6 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
-import { decodeIPC } from '../util/decode-ipc.js';
+import { annotateByteLength, decodeIPC } from '../util/decode-ipc.js';
 
 interface SocketOptions {
   uri?: string;

--- a/packages/mosaic/core/src/connectors/socket.ts
+++ b/packages/mosaic/core/src/connectors/socket.ts
@@ -1,6 +1,7 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
-import { annotateByteLength, decodeIPC } from '../util/decode-ipc.js';
+import { decodeIPC } from '../util/decode-ipc.js';
+import { annotateByteLength } from '../util/cache.js';
 
 interface SocketOptions {
   uri?: string;

--- a/packages/mosaic/core/src/connectors/wasm.ts
+++ b/packages/mosaic/core/src/connectors/wasm.ts
@@ -1,7 +1,8 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import * as duckdb from '@duckdb/duckdb-wasm';
-import { annotateByteLength, decodeIPC } from '../util/decode-ipc.js';
+import { decodeIPC } from '../util/decode-ipc.js';
+import { annotateByteLength } from '../util/cache.js';
 
 interface DuckDBWASMOptions {
   /** Flag to enable logging. */

--- a/packages/mosaic/core/src/connectors/wasm.ts
+++ b/packages/mosaic/core/src/connectors/wasm.ts
@@ -2,7 +2,7 @@ import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import * as duckdb from '@duckdb/duckdb-wasm';
 import { decodeIPC } from '../util/decode-ipc.js';
-import { annotateByteLength } from '../util/cache.js';
+import { annotateByteLength, assertCacheable } from '../util/cache.js';
 
 interface DuckDBWASMOptions {
   /** Flag to enable logging. */
@@ -80,7 +80,13 @@ export class DuckDBWASMConnector implements Connector {
     const con = await this.getConnection();
     const result = await getArrowIPC(con, sql);
     if (type === 'exec') return undefined;
-    if (type === 'arrow') return decodeIPC(result, this._ipc);
+    if (type === 'arrow') {
+      const table = decodeIPC(result, this._ipc);
+      assertCacheable(table, 'DuckDBWASMConnector arrow');
+      return table;
+    }
+    const records = annotateByteLength(decodeIPC(result).toArray(), result.byteLength);
+    assertCacheable(records, 'DuckDBWASMConnector json');
     return type === 'exec' ? undefined : decodeIPC(result, this._ipc);
   }
 }

--- a/packages/mosaic/core/src/connectors/wasm.ts
+++ b/packages/mosaic/core/src/connectors/wasm.ts
@@ -1,4 +1,3 @@
-
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import * as duckdb from '@duckdb/duckdb-wasm';
 

--- a/packages/mosaic/core/src/connectors/wasm.ts
+++ b/packages/mosaic/core/src/connectors/wasm.ts
@@ -1,8 +1,7 @@
-import type { ExtractionOptions, Table } from '@uwdata/flechette';
+
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import * as duckdb from '@duckdb/duckdb-wasm';
 import { decodeIPC } from '../util/decode-ipc.js';
-import { annotateByteLength, assertCacheable } from '../util/cache.js';
 
 interface DuckDBWASMOptions {
   /** Flag to enable logging. */
@@ -10,8 +9,6 @@ interface DuckDBWASMOptions {
 }
 
 interface DuckDBWASMConnectorOptions extends DuckDBWASMOptions {
-  /** Arrow IPC extraction options. */
-  ipc?: ExtractionOptions;
   /** Optional pre-existing DuckDB-WASM instance. */
   duckdb?: duckdb.AsyncDuckDB;
   /** Optional pre-existing DuckDB-WASM connection. */
@@ -33,7 +30,6 @@ export function wasmConnector(options: DuckDBWASMConnectorOptions = {}): DuckDBW
  * DuckDB-WASM connector.
  */
 export class DuckDBWASMConnector implements Connector {
-  private _ipc?: ExtractionOptions;
   public _options: DuckDBWASMOptions;
   public _db?: duckdb.AsyncDuckDB;
   public _con?: duckdb.AsyncDuckDBConnection;
@@ -45,8 +41,7 @@ export class DuckDBWASMConnector implements Connector {
    * @param options Connector options.
    */
   constructor(options: DuckDBWASMConnectorOptions = {}) {
-    const { ipc, duckdb, connection, config, ...opts } = options;
-    this._ipc = ipc;
+    const { duckdb, connection, config, ...opts } = options;
     this._options = opts;
     this._db = duckdb;
     this._con = connection;
@@ -73,21 +68,13 @@ export class DuckDBWASMConnector implements Connector {
     return this._con!;
   }
 
-  async query(query: ArrowQueryRequest): Promise<Table>;
+  async query(query: ArrowQueryRequest): Promise<Uint8Array>;
   async query(query: ExecQueryRequest): Promise<void>;
   async query(query: ConnectorQueryRequest): Promise<unknown> {
     const { type, sql } = query;
     const con = await this.getConnection();
     const result = await getArrowIPC(con, sql);
-    if (type === 'exec') return undefined;
-    if (type === 'arrow') {
-      const table = decodeIPC(result, this._ipc);
-      assertCacheable(table, 'DuckDBWASMConnector arrow');
-      return table;
-    }
-    const records = annotateByteLength(decodeIPC(result).toArray(), result.byteLength);
-    assertCacheable(records, 'DuckDBWASMConnector json');
-    return type === 'exec' ? undefined : decodeIPC(result, this._ipc);
+    return type === 'exec' ? undefined : result;
   }
 }
 

--- a/packages/mosaic/core/src/connectors/wasm.ts
+++ b/packages/mosaic/core/src/connectors/wasm.ts
@@ -1,7 +1,7 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import * as duckdb from '@duckdb/duckdb-wasm';
-import { decodeIPC } from '../util/decode-ipc.js';
+import { annotateByteLength, decodeIPC } from '../util/decode-ipc.js';
 
 interface DuckDBWASMOptions {
   /** Flag to enable logging. */
@@ -78,6 +78,8 @@ export class DuckDBWASMConnector implements Connector {
     const { type, sql } = query;
     const con = await this.getConnection();
     const result = await getArrowIPC(con, sql);
+    if (type === 'exec') return undefined;
+    if (type === 'arrow') return decodeIPC(result, this._ipc);
     return type === 'exec' ? undefined : decodeIPC(result, this._ipc);
   }
 }

--- a/packages/mosaic/core/src/connectors/wasm.ts
+++ b/packages/mosaic/core/src/connectors/wasm.ts
@@ -1,7 +1,6 @@
 
 import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import * as duckdb from '@duckdb/duckdb-wasm';
-import { decodeIPC } from '../util/decode-ipc.js';
 
 interface DuckDBWASMOptions {
   /** Flag to enable logging. */

--- a/packages/mosaic/core/src/index.ts
+++ b/packages/mosaic/core/src/index.ts
@@ -25,6 +25,7 @@ export {
   clauseNone
 } from './SelectionClause.js';
 
+export { lruCache, voidCache } from './util/cache.js';
 export { decodeIPC } from './util/decode-ipc.js';
 export { distinct } from './util/distinct.js';
 export { isArrowTable } from './util/is-arrow-table.js';

--- a/packages/mosaic/core/src/types.ts
+++ b/packages/mosaic/core/src/types.ts
@@ -87,6 +87,7 @@ export interface Cache {
   get(key: string): unknown;
   set(key: string, value: unknown, bytes?: number, owner?: object): unknown;
   clear(): void;
+  bytes(): number;
 }
 
 /**

--- a/packages/mosaic/core/src/types.ts
+++ b/packages/mosaic/core/src/types.ts
@@ -85,8 +85,7 @@ export interface Activatable {
  */
 export interface Cache {
   get(key: string): unknown;
-  set(key: string, value: unknown): unknown;
-  delete(key: string): void;
+  set(key: string, value: unknown, bytes?: number, owner?: object): unknown;
   clear(): void;
 }
 

--- a/packages/mosaic/core/src/types.ts
+++ b/packages/mosaic/core/src/types.ts
@@ -86,6 +86,7 @@ export interface Activatable {
 export interface Cache {
   get(key: string): unknown;
   set(key: string, value: unknown): unknown;
+  delete(key: string): void;
   clear(): void;
 }
 

--- a/packages/mosaic/core/src/types.ts
+++ b/packages/mosaic/core/src/types.ts
@@ -1,6 +1,9 @@
 import type { CreateQuery, CreateSchemaQuery, DescribeQuery, ExprNode, MaybeArray, Query } from '@uwdata/mosaic-sql';
 import type { QueryResult } from './util/query-result.js';
 
+/** Arrow IPC bytes as returned by a connector. */
+export type ArrowIPCBytes = ArrayBuffer | Uint8Array | Uint8Array[];
+
 /** Query type accepted by a coordinator. */
 export type QueryType =
   | string

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -29,16 +29,25 @@ export function voidCache(): Cache {
  * `requestIdleCallback`. Each eviction pass drops any TTL-expired entries and
  * the single least-recently-used entry.
  *
+ * `maxEntries` is a backstop. Some results are legitimately zero bytes —
+ * an empty Arrow result, for instance — so they never move `totalBytes`
+ * and can't trigger the byte-based eviction on their own. Capping the
+ * entry count keeps a run of them from growing the cache without bound.
+ * The default is generous enough that healthy workloads never reach it.
+ *
  * @param options Cache options.
  * @param options.maxBytes Maximum total observed bytes across all entries.
+ * @param options.maxEntries Maximum number of cache entries.
  * @param options.ttl Time-to-live for cache entries.
  * @returns An LRU cache implementation.
  */
 export function lruCache({
   maxBytes = 32 * 1024 * 1024, // 32 MB of allocated default memory
+  maxEntries = 10_000, // backstop for entries that report zero bytes
   ttl = 3 * 60 * 60 * 1000 // 3 hours
 }: {
   maxBytes?: number;
+  maxEntries?: number;
   ttl?: number;
 } = {}): Cache {
   let cache = new Map<string, CacheEntry>();
@@ -93,7 +102,7 @@ export function lruCache({
 
       cache.set(key, { last: performance.now(), size, value });
       totalBytes += size;
-      if (totalBytes > maxBytes) requestIdle(evict);
+      if (totalBytes > maxBytes || cache.size > maxEntries) requestIdle(evict);
       return value;
     },
     delete(key: string): void {

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -1,5 +1,9 @@
 import type { Cache } from '../types.js';
 
+const requestIdle = typeof requestIdleCallback !== 'undefined'
+  ? requestIdleCallback
+  : setTimeout;
+
 interface CacheEntry<T = unknown> {
   last: number;
   size: number;
@@ -14,16 +18,16 @@ export function voidCache(): Cache {
   return {
     get: () => undefined,
     set: (key, value) => value,
+    delete: () => {},
     clear: () => {}
   };
 }
 
 /**
  * Create a new cache that uses an LRU eviction policy, capped by the
- * total memory usage. Eviction is synchronous: on every `set` that 
- * pushes the cache past `maxBytes`, the
- * evict pass runs immediately (dropping any TTL-expired entries and the single
- * LRU query) until the cache fits according to the memory requirement.
+ * total memory usage. Eviction is deferred to browser idle time via
+ * `requestIdleCallback`. Each eviction pass drops any TTL-expired entries and
+ * the single least-recently-used entry.
  *
  * @param options Cache options.
  * @param options.maxBytes Maximum total observed bytes across all entries.
@@ -41,8 +45,6 @@ export function lruCache({
   let totalBytes = 0;
   /**
    * Looks through our LRU cache and removes any expired queries and the current LRU query.
-   * Opts for a "naive" O(n) lookthrough to get and eliminate expired queries and the LRU.
-   * While this is computationally expensive, it makes the code less complex.
    */
   function evict(): void {
     const expire = performance.now() - ttl;
@@ -83,12 +85,23 @@ export function lruCache({
       const size = (value as { byteLength?: number } | null)?.byteLength ?? 0;
       const prior = cache.get(key);
       if (prior) totalBytes -= prior.size;
+
+      if (size > maxBytes) {
+        if (prior) cache.delete(key);
+        return value;
+      }
+
       cache.set(key, { last: performance.now(), size, value });
       totalBytes += size;
-      // The loop guard on cache.size prevents an
-      // infinite loop if a single entry is larger than maxBytes on its own.
-      while (totalBytes > maxBytes && cache.size > 0) evict();
+      if (totalBytes > maxBytes) requestIdle(evict);
       return value;
+    },
+    delete(key: string): void {
+      const entry = cache.get(key);
+      if (entry) {
+        totalBytes -= entry.size;
+        cache.delete(key);
+      }
     },
     clear(): void {
       cache = new Map();
@@ -120,4 +133,38 @@ export function annotateByteLength<T extends object>(value: T, bytes: number): T
     });
   }
   return value;
+}
+
+/**
+ * Enforce the cache-value contract.
+ *
+ * A value handed to the cache must be one of the following:
+ *   - a Promise,
+ *   - null/undefined,
+ *   - an object annotated with byteLength > 0.
+ *
+ * Any other shape will throw on violation.
+ *
+ * @param value The value about to be returned from a connector.
+ * @param context Short label identifying the call site (e.g.
+ *   `"DuckDBWASMConnector arrow"`) — included in the error message.
+ */
+export function assertCacheable(value: unknown, context: string): void {
+  if (value != null && typeof (value as { then?: unknown }).then === 'function') {
+    return;
+  }
+  if (value == null) return;
+  if (typeof value !== 'object') {
+    throw new Error(
+      `[${context}] cache contract violation: expected an annotated object, got ${typeof value}.`
+    );
+  }
+  const size = (value as { byteLength?: unknown }).byteLength;
+  if (typeof size !== 'number' || size <= 0) {
+    throw new Error(
+      `[${context}] cache contract violation: value must have byteLength > 0 ` +
+      `to be cacheable (got byteLength=${String(size)}). ` +
+      `Annotate with annotateByteLength before returning.`
+    );
+  }
 }

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -82,6 +82,7 @@ export function lruCache({
       }
     },
     set(key: string, value: unknown): unknown {
+      assertCacheable(value, 'lruCache.set');
       const size = (value as { byteLength?: number } | null)?.byteLength ?? 0;
       const prior = cache.get(key);
       if (prior) totalBytes -= prior.size;
@@ -139,26 +140,22 @@ export function annotateByteLength<T extends object>(value: T, bytes: number): T
  * Enforce the cache-value contract.
  *
  * A value handed to the cache must be one of the following:
- *   - a Promise,
- *   - null/undefined,
+ *   - a Promise (transient — will be replaced by resolved data),
+ *   - null/undefined (exec results, tiny by definition),
+ *   - a primitive,
  *   - an object annotated with byteLength > 0.
  *
- * Any other shape will throw on violation.
  *
- * @param value The value about to be returned from a connector.
- * @param context Short label identifying the call site (e.g.
- *   `"DuckDBWASMConnector arrow"`) — included in the error message.
+ * @param value The value about to be stored in the cache.
+ * @param context Short label identifying the call site included in the error message.
  */
 export function assertCacheable(value: unknown, context: string): void {
   if (value != null && typeof (value as { then?: unknown }).then === 'function') {
     return;
   }
   if (value == null) return;
-  if (typeof value !== 'object') {
-    throw new Error(
-      `[${context}] cache contract violation: expected an annotated object, got ${typeof value}.`
-    );
-  }
+
+  if (typeof value !== 'object') return;
   const size = (value as { byteLength?: unknown }).byteLength;
   if (typeof size !== 'number' || size <= 0) {
     throw new Error(

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -56,7 +56,8 @@ export function lruCache({
         lruKey = key;
         lruLast = last;
       }
-
+      
+      //Removing expired queries since they likely will not be used again.
       if (expire > last) {
         totalBytes -= entry.size;
         cache.delete(key);
@@ -79,7 +80,7 @@ export function lruCache({
       }
     },
     set(key: string, value: unknown): unknown {
-      const size = byteSize(value);
+      const size = (value as { byteLength?: number } | null)?.byteLength ?? 0;
       const prior = cache.get(key);
       if (prior) totalBytes -= prior.size;
       cache.set(key, { last: performance.now(), size, value });
@@ -97,18 +98,26 @@ export function lruCache({
 }
 
 /**
- * Byte size for a cached value. Mosaic connectors produce a bytesize to use reliably. Unannotated shapes return 0, treating them as
- * free. This should not be of concern since every query that is stored in the cache goes through the respective connectors that have an 
- * annotated bytesize.
+ * Attach a non-enumerable `byteLength` property to a cached value so that
+ * caches can estimate size.
+ * Called by the connectors on JSON payloads and by `decodeIPC` on Arrow
+ * Tables.
+ *
+ * The property is non-enumerable so it does not appear in iteration,
+ * spread, or JSON serialization of the value.
+ *
+ * @param value The value to annotate. Must be a non-null object.
+ * @param bytes The byte size to record. Ignored if not positive.
+ * @returns The annotated value.
  */
-function byteSize(value: unknown): number {
-  if (value == null) return 0;
-  if (typeof value === 'string') return value.length * 2; // UTF-16 in JS
-  if (value instanceof ArrayBuffer) return value.byteLength;
-  if (ArrayBuffer.isView(value)) return value.byteLength;
-  if (typeof value === 'object') {
-    const bl = (value as { byteLength?: unknown }).byteLength;
-    if (typeof bl === 'number') return bl;
+export function annotateByteLength<T extends object>(value: T, bytes: number): T {
+  if (bytes > 0) {
+    Object.defineProperty(value, 'byteLength', {
+      value: bytes,
+      enumerable: false,
+      writable: false,
+      configurable: true
+    });
   }
-  return 0;
+  return value;
 }

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -57,7 +57,7 @@ export function lruCache({
         lruLast = last;
       }
       
-      //Removing expired queries since they likely will not be used again.
+      // remove expired queries since they likely will not be used again
       if (expire > last) {
         totalBytes -= entry.size;
         cache.delete(key);

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -120,11 +120,13 @@ export function lruCache({
  * spread, or JSON serialization of the value.
  *
  * @param value The value to annotate. Must be a non-null object.
- * @param bytes The byte size to record. Ignored if not positive.
+ * @param bytes The byte size to record. Zero is valid — an empty query
+ *  result is still a cacheable value. Negative and non-finite values are
+ *  ignored.
  * @returns The annotated value.
  */
 export function annotateByteLength<T extends object>(value: T, bytes: number): T {
-  if (bytes > 0) {
+  if (Number.isFinite(bytes) && bytes >= 0) {
     Object.defineProperty(value, 'byteLength', {
       value: bytes,
       enumerable: false,
@@ -142,8 +144,11 @@ export function annotateByteLength<T extends object>(value: T, bytes: number): T
  *   - a Promise (transient — will be replaced by resolved data),
  *   - null/undefined (exec results, tiny by definition),
  *   - a primitive,
- *   - an object annotated with byteLength > 0.
+ *   - an object annotated with a non-negative `byteLength`.
  *
+ * Zero is a valid size: an empty query result is still a cacheable value.
+ * A missing annotation is the actual error case — it would leave the entry
+ * unaccounted for in the cache's byte budget.
  *
  * @param value The value about to be stored in the cache.
  * @param context Short label identifying the call site included in the error message.
@@ -156,10 +161,10 @@ export function assertCacheable(value: unknown, context: string): void {
 
   if (typeof value !== 'object') return;
   const size = (value as { byteLength?: unknown }).byteLength;
-  if (typeof size !== 'number' || size <= 0) {
+  if (typeof size !== 'number' || !Number.isFinite(size) || size < 0) {
     throw new Error(
-      `[${context}] cache contract violation: value must have byteLength > 0 ` +
-      `to be cacheable (got byteLength=${String(size)}). ` +
+      `[${context}] cache contract violation: value must have a non-negative ` +
+      `byteLength to be cacheable (got byteLength=${String(size)}). ` +
       `Annotate with annotateByteLength before returning.`
     );
   }

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -3,21 +3,12 @@ import type { Cache } from '../types.js';
 interface CacheEntry {
   last: number;
   value: unknown;
-  owner?: object;
+  owner: object;
 }
 
 interface OwnerCharge {
   bytes: number;
   refs: number;
-}
-
-export function jsonByteLength(value: unknown): number {
-  if (value == null) return 0;
-  try {
-    return JSON.stringify(value).length;
-  } catch {
-    return 0;
-  }
 }
 
 /**
@@ -51,30 +42,14 @@ export function lruCache({
   let ownerCharges = new Map<object, OwnerCharge>();
   let total = 0;
 
-  function charge(owner: object, bytes: number): void {
-    const record = ownerCharges.get(owner);
-    if (record) {
-      record.refs += 1;
-    } else {
-      ownerCharges.set(owner, { bytes, refs: 1 });
-      total += bytes;
-    }
-  }
-
-  function release(owner?: object): void {
-    if (!owner) return;
-    const record = ownerCharges.get(owner)!;
-    if (--record.refs === 0) {
-      ownerCharges.delete(owner);
-      total -= record.bytes;
-    }
-  }
-
   function remove(key: string): void {
     const entry = entries.get(key);
-    if (entry) {
-      entries.delete(key);
-      release(entry.owner);
+    if (!entry) return;
+    entries.delete(key);
+    const charge = ownerCharges.get(entry.owner)!;
+    if (--charge.refs === 0) {
+      ownerCharges.delete(entry.owner);
+      total -= charge.bytes;
     }
   }
 
@@ -94,22 +69,22 @@ export function lruCache({
       entries.set(key, entry);
       return entry.value;
     },
-    set(key: string, value: unknown, bytes = 0, owner?: object): unknown {
+    set(key: string, value: unknown, bytes = 0, owner: object = {}): unknown {
       remove(key);
       if (bytes > maxBytes) return value;
 
-      const entry: CacheEntry = { last: performance.now(), value };
-      if (bytes > 0) {
-        entry.owner = owner
-          ?? (typeof value === 'object' && value !== null ? value : entry);
-        charge(entry.owner, bytes);
+      entries.set(key, { last: performance.now(), value, owner });
+      const charge = ownerCharges.get(owner);
+      if (charge) {
+        charge.refs += 1;
+      } else {
+        ownerCharges.set(owner, { bytes, refs: 1 });
+        total += bytes;
       }
-      entries.set(key, entry);
 
-      while (total > maxBytes) {
-        const oldest = entries.keys().next();
-        if (oldest.done) break;
-        remove(oldest.value);
+      for (const oldest of entries.keys()) {
+        if (total <= maxBytes) break;
+        remove(oldest);
       }
 
       return value;

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -29,11 +29,7 @@ export function voidCache(): Cache {
  * `requestIdleCallback`. Each eviction pass drops any TTL-expired entries and
  * the single least-recently-used entry.
  *
- * `maxEntries` is a backstop. Some results are legitimately zero bytes —
- * an empty Arrow result, for instance — so they never move `totalBytes`
- * and can't trigger the byte-based eviction on their own. Capping the
- * entry count keeps a run of them from growing the cache without bound.
- * The default is generous enough that healthy workloads never reach it.
+ * `maxEntries` is implemented as a failsafe to cap entry count
  *
  * @param options Cache options.
  * @param options.maxBytes Maximum total observed bytes across all entries.

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -1,11 +1,8 @@
 import type { Cache } from '../types.js';
 
-const requestIdle = typeof requestIdleCallback !== 'undefined'
-  ? requestIdleCallback
-  : setTimeout;
-
 interface CacheEntry<T = unknown> {
   last: number;
+  size: number;
   value: T;
 }
 
@@ -22,28 +19,36 @@ export function voidCache(): Cache {
 }
 
 /**
- * Create a new cache that uses an LRU eviction policy.
+ * Create a new cache that uses an LRU eviction policy, capped by the total
+ * observed byte size of its entries rather than by entry count. Eviction is
+ * synchronous: on every `set` that pushes the cache past `maxBytes`, the
+ * evict pass runs inline (dropping any TTL-expired entries and the single
+ * least-recently-used entry) and repeats until the cache fits under budget.
+ * There is no deferral to `requestIdleCallback`, so `maxBytes` is enforced
+ * as a hard cap rather than a soft target.
+ *
  * @param options Cache options.
- * @param options.max Maximum number of cache entries.
+ * @param options.maxBytes Maximum total observed bytes across all entries.
  * @param options.ttl Time-to-live for cache entries.
  * @returns An LRU cache implementation.
  */
 export function lruCache({
-  max = 1000, // max entries
-  ttl = 3 * 60 * 60 * 1000 // time-to-live, default 3 hours
+  maxBytes = 32 * 1024 * 1024, // 32 MB
+  ttl = 3 * 60 * 60 * 1000 // 3 hours
 }: {
-  max?: number;
+  maxBytes?: number;
   ttl?: number;
 } = {}): Cache {
   let cache = new Map<string, CacheEntry>();
+  let totalBytes = 0;
 
   function evict(): void {
     const expire = performance.now() - ttl;
     let lruKey: string | null = null;
     let lruLast = Infinity;
 
-    for (const [key, value] of cache) {
-      const { last } = value;
+    for (const [key, entry] of cache) {
+      const { last } = entry;
 
       // least recently used entry seen so far
       if (last < lruLast) {
@@ -53,12 +58,15 @@ export function lruCache({
 
       // remove if time since last access exceeds ttl
       if (expire > last) {
+        totalBytes -= entry.size;
         cache.delete(key);
       }
     }
 
     // remove lru entry
     if (lruKey) {
+      const lru = cache.get(lruKey);
+      if (lru) totalBytes -= lru.size;
       cache.delete(lruKey);
     }
   }
@@ -72,12 +80,43 @@ export function lruCache({
       }
     },
     set(key: string, value: unknown): unknown {
-      cache.set(key, { last: performance.now(), value });
-      if (cache.size > max) requestIdle(evict);
+      const size = byteSize(value);
+      // Update in place — refund the prior entry's bytes before recounting.
+      const prior = cache.get(key);
+      if (prior) totalBytes -= prior.size;
+      cache.set(key, { last: performance.now(), size, value });
+      totalBytes += size;
+      // Enforce the budget inline. The loop guard on cache.size prevents an
+      // infinite loop if a single entry is larger than maxBytes on its own
+      // (evict() would remove it, cache goes empty, we stop).
+      while (totalBytes > maxBytes && cache.size > 0) evict();
       return value;
     },
     clear(): void {
       cache = new Map();
+      totalBytes = 0;
     }
   };
+}
+
+/**
+ * Best-effort byte size for a cached value. Exact for strings, ArrayBuffers,
+ * and typed arrays; approximated via JSON.stringify for plain objects; 0
+ * when nothing sensible can be measured.
+ */
+function byteSize(value: unknown): number {
+  if (value == null) return 0;
+  if (typeof value === 'string') return value.length * 2; // UTF-16 in JS
+  if (value instanceof ArrayBuffer) return value.byteLength;
+  if (ArrayBuffer.isView(value)) return value.byteLength;
+  if (typeof value === 'object') {
+    const bl = (value as { byteLength?: unknown }).byteLength;
+    if (typeof bl === 'number') return bl;
+    try {
+      return JSON.stringify(value).length * 2;
+    } catch {
+      return 0;
+    }
+  }
+  return 0;
 }

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -19,13 +19,11 @@ export function voidCache(): Cache {
 }
 
 /**
- * Create a new cache that uses an LRU eviction policy, capped by the total
- * observed byte size of its entries rather than by entry count. Eviction is
- * synchronous: on every `set` that pushes the cache past `maxBytes`, the
- * evict pass runs inline (dropping any TTL-expired entries and the single
- * least-recently-used entry) and repeats until the cache fits under budget.
- * There is no deferral to `requestIdleCallback`, so `maxBytes` is enforced
- * as a hard cap rather than a soft target.
+ * Create a new cache that uses an LRU eviction policy, capped by the
+ * total memory usage. Eviction is synchronous: on every `set` that 
+ * pushes the cache past `maxBytes`, the
+ * evict pass runs immediately (dropping any TTL-expired entries and the single
+ * LRU query) until the cache fits according to the memory requirement.
  *
  * @param options Cache options.
  * @param options.maxBytes Maximum total observed bytes across all entries.
@@ -33,7 +31,7 @@ export function voidCache(): Cache {
  * @returns An LRU cache implementation.
  */
 export function lruCache({
-  maxBytes = 32 * 1024 * 1024, // 32 MB
+  maxBytes = 32 * 1024 * 1024, // 32 MB of allocated default memory
   ttl = 3 * 60 * 60 * 1000 // 3 hours
 }: {
   maxBytes?: number;
@@ -41,7 +39,11 @@ export function lruCache({
 } = {}): Cache {
   let cache = new Map<string, CacheEntry>();
   let totalBytes = 0;
-
+  /**
+   * Looks through our LRU cache and removes any expired queries and the current LRU query.
+   * Opts for a "naive" O(n) lookthrough to get and eliminate expired queries and the LRU.
+   * While this is computationally expensive, it makes the code less complex.
+   */
   function evict(): void {
     const expire = performance.now() - ttl;
     let lruKey: string | null = null;
@@ -50,20 +52,17 @@ export function lruCache({
     for (const [key, entry] of cache) {
       const { last } = entry;
 
-      // least recently used entry seen so far
       if (last < lruLast) {
         lruKey = key;
         lruLast = last;
       }
 
-      // remove if time since last access exceeds ttl
       if (expire > last) {
         totalBytes -= entry.size;
         cache.delete(key);
       }
     }
 
-    // remove lru entry
     if (lruKey) {
       const lru = cache.get(lruKey);
       if (lru) totalBytes -= lru.size;
@@ -81,14 +80,12 @@ export function lruCache({
     },
     set(key: string, value: unknown): unknown {
       const size = byteSize(value);
-      // Update in place — refund the prior entry's bytes before recounting.
       const prior = cache.get(key);
       if (prior) totalBytes -= prior.size;
       cache.set(key, { last: performance.now(), size, value });
       totalBytes += size;
-      // Enforce the budget inline. The loop guard on cache.size prevents an
-      // infinite loop if a single entry is larger than maxBytes on its own
-      // (evict() would remove it, cache goes empty, we stop).
+      // The loop guard on cache.size prevents an
+      // infinite loop if a single entry is larger than maxBytes on its own.
       while (totalBytes > maxBytes && cache.size > 0) evict();
       return value;
     },
@@ -100,9 +97,9 @@ export function lruCache({
 }
 
 /**
- * Best-effort byte size for a cached value. Exact for strings, ArrayBuffers,
- * and typed arrays; approximated via JSON.stringify for plain objects; 0
- * when nothing sensible can be measured.
+ * Byte size for a cached value. Mosaic connectors produce a bytesize to use reliably. Unannotated shapes return 0, treating them as
+ * free. This should not be of concern since every query that is stored in the cache goes through the respective connectors that have an 
+ * annotated bytesize.
  */
 function byteSize(value: unknown): number {
   if (value == null) return 0;
@@ -112,11 +109,6 @@ function byteSize(value: unknown): number {
   if (typeof value === 'object') {
     const bl = (value as { byteLength?: unknown }).byteLength;
     if (typeof bl === 'number') return bl;
-    try {
-      return JSON.stringify(value).length * 2;
-    } catch {
-      return 0;
-    }
   }
   return 0;
 }

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -82,7 +82,6 @@ export function lruCache({
       }
     },
     set(key: string, value: unknown): unknown {
-      assertCacheable(value, 'lruCache.set');
       const size = (value as { byteLength?: number } | null)?.byteLength ?? 0;
       const prior = cache.get(key);
       if (prior) totalBytes -= prior.size;

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -19,7 +19,8 @@ export function voidCache(): Cache {
   return {
     get: () => undefined,
     set: (key, value) => value,
-    clear: () => {}
+    clear: () => {},
+    bytes: () => 0
   };
 }
 
@@ -93,6 +94,9 @@ export function lruCache({
       entries = new Map();
       ownerCharges = new Map();
       total = 0;
+    },
+    bytes(): number {
+      return total;
     }
   };
 }

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -1,13 +1,23 @@
 import type { Cache } from '../types.js';
 
-const requestIdle = typeof requestIdleCallback !== 'undefined'
-  ? requestIdleCallback
-  : setTimeout;
-
-interface CacheEntry<T = unknown> {
+interface CacheEntry {
   last: number;
-  size: number;
-  value: T;
+  value: unknown;
+  owner?: object;
+}
+
+interface OwnerCharge {
+  bytes: number;
+  refs: number;
+}
+
+export function jsonByteLength(value: unknown): number {
+  if (value == null) return 0;
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return 0;
+  }
 }
 
 /**
@@ -18,153 +28,96 @@ export function voidCache(): Cache {
   return {
     get: () => undefined,
     set: (key, value) => value,
-    delete: () => {},
     clear: () => {}
   };
 }
 
 /**
- * Create a new cache that uses an LRU eviction policy, capped by the
- * total memory usage. Eviction is deferred to browser idle time via
- * `requestIdleCallback`. Each eviction pass drops any TTL-expired entries and
- * the single least-recently-used entry.
- *
- * `maxEntries` is implemented as a failsafe to cap entry count
- *
+ * Create a new cache that evicts least recently used entries once cached bytes
+ * exceed a budget.
  * @param options Cache options.
- * @param options.maxBytes Maximum total observed bytes across all entries.
- * @param options.maxEntries Maximum number of cache entries.
+ * @param options.maxBytes Maximum number of bytes to retain.
  * @param options.ttl Time-to-live for cache entries.
  * @returns An LRU cache implementation.
  */
 export function lruCache({
-  maxBytes = 32 * 1024 * 1024, // 32 MB of allocated default memory
-  maxEntries = 10_000, // backstop for entries that report zero bytes
-  ttl = 3 * 60 * 60 * 1000 // 3 hours
+  maxBytes = 32 * 1024 * 1024,
+  ttl = 3 * 60 * 60 * 1000
 }: {
   maxBytes?: number;
-  maxEntries?: number;
   ttl?: number;
 } = {}): Cache {
-  let cache = new Map<string, CacheEntry>();
-  let totalBytes = 0;
-  /**
-   * Looks through our LRU cache and removes any expired queries and the current LRU query.
-   */
-  function evict(): void {
-    const expire = performance.now() - ttl;
-    let lruKey: string | null = null;
-    let lruLast = Infinity;
+  let entries = new Map<string, CacheEntry>();
+  let ownerCharges = new Map<object, OwnerCharge>();
+  let total = 0;
 
-    for (const [key, entry] of cache) {
-      const { last } = entry;
-
-      if (last < lruLast) {
-        lruKey = key;
-        lruLast = last;
-      }
-      
-      // remove expired queries since they likely will not be used again
-      if (expire > last) {
-        totalBytes -= entry.size;
-        cache.delete(key);
-      }
+  function charge(owner: object, bytes: number): void {
+    const record = ownerCharges.get(owner);
+    if (record) {
+      record.refs += 1;
+    } else {
+      ownerCharges.set(owner, { bytes, refs: 1 });
+      total += bytes;
     }
+  }
 
-    if (lruKey) {
-      const lru = cache.get(lruKey);
-      if (lru) totalBytes -= lru.size;
-      cache.delete(lruKey);
+  function release(owner?: object): void {
+    if (!owner) return;
+    const record = ownerCharges.get(owner)!;
+    if (--record.refs === 0) {
+      ownerCharges.delete(owner);
+      total -= record.bytes;
+    }
+  }
+
+  function remove(key: string): void {
+    const entry = entries.get(key);
+    if (entry) {
+      entries.delete(key);
+      release(entry.owner);
     }
   }
 
   return {
     get(key: string): unknown {
-      const entry = cache.get(key);
-      if (entry) {
-        entry.last = performance.now();
-        return entry.value;
+      const entry = entries.get(key);
+      if (!entry) return;
+
+      const now = performance.now();
+      if (now - entry.last > ttl) {
+        remove(key);
+        return;
       }
+
+      entry.last = now;
+      entries.delete(key);
+      entries.set(key, entry);
+      return entry.value;
     },
-    set(key: string, value: unknown): unknown {
-      const size = (value as { byteLength?: number } | null)?.byteLength ?? 0;
-      const prior = cache.get(key);
-      if (prior) totalBytes -= prior.size;
+    set(key: string, value: unknown, bytes = 0, owner?: object): unknown {
+      remove(key);
+      if (bytes > maxBytes) return value;
 
-      if (size > maxBytes) {
-        if (prior) cache.delete(key);
-        return value;
+      const entry: CacheEntry = { last: performance.now(), value };
+      if (bytes > 0) {
+        entry.owner = owner
+          ?? (typeof value === 'object' && value !== null ? value : entry);
+        charge(entry.owner, bytes);
+      }
+      entries.set(key, entry);
+
+      while (total > maxBytes) {
+        const oldest = entries.keys().next();
+        if (oldest.done) break;
+        remove(oldest.value);
       }
 
-      cache.set(key, { last: performance.now(), size, value });
-      totalBytes += size;
-      if (totalBytes > maxBytes || cache.size > maxEntries) requestIdle(evict);
       return value;
     },
-    delete(key: string): void {
-      const entry = cache.get(key);
-      if (entry) {
-        totalBytes -= entry.size;
-        cache.delete(key);
-      }
-    },
     clear(): void {
-      cache = new Map();
-      totalBytes = 0;
+      entries = new Map();
+      ownerCharges = new Map();
+      total = 0;
     }
   };
-}
-
-/**
- * Attach a non-enumerable `byteLength` property to a cached value so that
- * caches can estimate size.
- * Called by the connectors on JSON payloads and by `decodeIPC` on Arrow
- * Tables.
- *
- * The property is non-enumerable so it does not appear in iteration,
- * spread, or JSON serialization of the value.
- *
- * @param value The value to annotate. Must be a non-null object.
- * @param bytes The byte size to record. 
- * @returns The annotated value.
- */
-export function annotateByteLength<T extends object>(value: T, bytes: number): T {
-  if (Number.isFinite(bytes) && bytes >= 0) {
-    Object.defineProperty(value, 'byteLength', {
-      value: bytes,
-      enumerable: false,
-      writable: false,
-      configurable: true
-    });
-  }
-  return value;
-}
-
-/**
- * Enforce the cache-value contract.
- *
- * A value handed to the cache must be one of the following:
- *   - a Promise (transient — will be replaced by resolved data),
- *   - null/undefined (exec results, tiny by definition),
- *   - a primitive,
- *   - an object annotated with a non-negative `byteLength`.
- *
- * @param value The value about to be stored in the cache.
- * @param context Short label identifying the call site included in the error message.
- */
-export function assertCacheable(value: unknown, context: string): void {
-  if (value != null && typeof (value as { then?: unknown }).then === 'function') {
-    return;
-  }
-  if (value == null) return;
-
-  if (typeof value !== 'object') return;
-  const size = (value as { byteLength?: unknown }).byteLength;
-  if (typeof size !== 'number' || !Number.isFinite(size) || size < 0) {
-    throw new Error(
-      `[${context}] cache contract violation: value must have a non-negative ` +
-      `byteLength to be cacheable (got byteLength=${String(size)}). ` +
-      `Annotate with annotateByteLength before returning.`
-    );
-  }
 }

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -120,9 +120,7 @@ export function lruCache({
  * spread, or JSON serialization of the value.
  *
  * @param value The value to annotate. Must be a non-null object.
- * @param bytes The byte size to record. Zero is valid — an empty query
- *  result is still a cacheable value. Negative and non-finite values are
- *  ignored.
+ * @param bytes The byte size to record. 
  * @returns The annotated value.
  */
 export function annotateByteLength<T extends object>(value: T, bytes: number): T {
@@ -145,10 +143,6 @@ export function annotateByteLength<T extends object>(value: T, bytes: number): T
  *   - null/undefined (exec results, tiny by definition),
  *   - a primitive,
  *   - an object annotated with a non-negative `byteLength`.
- *
- * Zero is a valid size: an empty query result is still a cacheable value.
- * A missing annotation is the actual error case — it would leave the entry
- * unaccounted for in the cache's byte budget.
  *
  * @param value The value about to be stored in the cache.
  * @param context Short label identifying the call site included in the error message.

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -33,7 +33,7 @@ export function voidCache(): Cache {
  * @returns An LRU cache implementation.
  */
 export function lruCache({
-  maxBytes = 32 * 1024 * 1024,
+  maxBytes = 256 * 1024 * 1024,
   ttl = 3 * 60 * 60 * 1000
 }: {
   maxBytes?: number;

--- a/packages/mosaic/core/src/util/cache.ts
+++ b/packages/mosaic/core/src/util/cache.ts
@@ -66,6 +66,7 @@ export function lruCache({
       }
 
       entry.last = now;
+      // reinsert so Map iteration order stays least-recently-used first
       entries.delete(key);
       entries.set(key, entry);
       return entry.value;
@@ -83,8 +84,9 @@ export function lruCache({
         total += bytes;
       }
 
-      for (const oldest of entries.keys()) {
-        if (total <= maxBytes) break;
+      while (total > maxBytes) {
+        const oldest = entries.keys().next().value;
+        if (oldest === undefined) break;
         remove(oldest);
       }
 

--- a/packages/mosaic/core/src/util/decode-ipc.ts
+++ b/packages/mosaic/core/src/util/decode-ipc.ts
@@ -1,34 +1,32 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import { tableFromIPC } from '@uwdata/flechette';
-import { annotateByteLength } from './cache.js';
+
+const byteLengths = new WeakMap<Table, number>();
 
 /**
  * Decode Arrow IPC bytes to a table instance.
  * The default options map date and timestamp values to JS Date objects.
- *
- * The returned Table is annotated with a non-enumerable `byteLength`
- * property (via `annotateByteLength`) that reports the approximate size (in
- * bytes) of the input IPC data.
- *
  * @param data Arrow IPC bytes.
  * @param options Arrow IPC extraction options.
  *  If unspecified, the default options will extract date and timestamp
  *  values to JS Date objects.
- * @returns A table instance with an attached `byteLength` reflecting the
- *  size of the input IPC bytes.
+ * @returns A table instance.
  */
 export function decodeIPC(
   data: ArrayBufferLike | Uint8Array | Uint8Array[],
   options: ExtractionOptions = { useDate: true }
 ): Table {
-  return annotateByteLength(tableFromIPC(data, options), ipcByteSize(data));
+  const table = tableFromIPC(data, options);
+  byteLengths.set(table, ipcByteLength(data));
+  return table;
 }
 
-function ipcByteSize(data: ArrayBufferLike | Uint8Array | Uint8Array[]): number {
-  if (Array.isArray(data)) {
-    let total = 0;
-    for (const chunk of data) total += chunk.byteLength;
-    return total;
-  }
-  return (data as ArrayBufferLike | Uint8Array).byteLength ?? 0;
+export function tableByteLength(table: Table): number | undefined {
+  return byteLengths.get(table);
+}
+
+function ipcByteLength(data: ArrayBufferLike | Uint8Array | Uint8Array[]): number {
+  return Array.isArray(data)
+    ? data.reduce((sum, chunk) => sum + chunk.byteLength, 0)
+    : data.byteLength;
 }

--- a/packages/mosaic/core/src/util/decode-ipc.ts
+++ b/packages/mosaic/core/src/util/decode-ipc.ts
@@ -7,9 +7,6 @@ import { tableFromIPC } from '@uwdata/flechette';
  *
  * The returned Table is annotated with a non-enumerable `byteLength`
  * property that reports the exact size (in bytes) of the input IPC data.
- * This lets byte-budgeted caches (e.g. `lruCache({ maxBytes })`) size an
- * Arrow result precisely without estimating. The property is non-enumerable
- * so it does not appear in iteration, JSON serialization, or object spreads.
  *
  * @param data Arrow IPC bytes.
  * @param options Arrow IPC extraction options.
@@ -42,4 +39,23 @@ function ipcByteSize(data: ArrayBufferLike | Uint8Array | Uint8Array[]): number 
     return total;
   }
   return (data as ArrayBufferLike | Uint8Array).byteLength ?? 0;
+}
+
+/**
+ * Attach a `byteLength` property to a cached value. Used by the
+ * connectors to annotate JSON record arrays.
+ *
+ * @param value The value to annotate. Must be a non-null object.
+ * @param bytes The exact byte size to record. Ignored if not positive.
+ */
+export function annotateByteLength<T extends object>(value: T, bytes: number): T {
+  if (bytes > 0) {
+    Object.defineProperty(value, 'byteLength', {
+      value: bytes,
+      enumerable: false,
+      writable: false,
+      configurable: true
+    });
+  }
+  return value;
 }

--- a/packages/mosaic/core/src/util/decode-ipc.ts
+++ b/packages/mosaic/core/src/util/decode-ipc.ts
@@ -4,15 +4,42 @@ import { tableFromIPC } from '@uwdata/flechette';
 /**
  * Decode Arrow IPC bytes to a table instance.
  * The default options map date and timestamp values to JS Date objects.
+ *
+ * The returned Table is annotated with a non-enumerable `byteLength`
+ * property that reports the exact size (in bytes) of the input IPC data.
+ * This lets byte-budgeted caches (e.g. `lruCache({ maxBytes })`) size an
+ * Arrow result precisely without estimating. The property is non-enumerable
+ * so it does not appear in iteration, JSON serialization, or object spreads.
+ *
  * @param data Arrow IPC bytes.
  * @param options Arrow IPC extraction options.
  *  If unspecified, the default options will extract date and timestamp
  *  values to JS Date objects.
- * @returns A table instance.
+ * @returns A table instance with an attached `byteLength` reflecting the
+ *  size of the input IPC bytes.
  */
 export function decodeIPC(
   data: ArrayBufferLike | Uint8Array | Uint8Array[],
   options: ExtractionOptions = { useDate: true }
 ): Table {
-  return tableFromIPC(data, options);
+  const table = tableFromIPC(data, options);
+  const bytes = ipcByteSize(data);
+  if (bytes > 0) {
+    Object.defineProperty(table, 'byteLength', {
+      value: bytes,
+      enumerable: false,
+      writable: false,
+      configurable: true
+    });
+  }
+  return table;
+}
+
+function ipcByteSize(data: ArrayBufferLike | Uint8Array | Uint8Array[]): number {
+  if (Array.isArray(data)) {
+    let total = 0;
+    for (const chunk of data) total += chunk.byteLength;
+    return total;
+  }
+  return (data as ArrayBufferLike | Uint8Array).byteLength ?? 0;
 }

--- a/packages/mosaic/core/src/util/decode-ipc.ts
+++ b/packages/mosaic/core/src/util/decode-ipc.ts
@@ -7,7 +7,7 @@ import { annotateByteLength } from './cache.js';
  * The default options map date and timestamp values to JS Date objects.
  *
  * The returned Table is annotated with a non-enumerable `byteLength`
- * property (via `annotateByteLength`) that reports the exact size (in
+ * property (via `annotateByteLength`) that reports the approximate size (in
  * bytes) of the input IPC data.
  *
  * @param data Arrow IPC bytes.

--- a/packages/mosaic/core/src/util/decode-ipc.ts
+++ b/packages/mosaic/core/src/util/decode-ipc.ts
@@ -1,12 +1,14 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import { tableFromIPC } from '@uwdata/flechette';
+import { annotateByteLength } from './cache.js';
 
 /**
  * Decode Arrow IPC bytes to a table instance.
  * The default options map date and timestamp values to JS Date objects.
  *
  * The returned Table is annotated with a non-enumerable `byteLength`
- * property that reports the exact size (in bytes) of the input IPC data.
+ * property (via `annotateByteLength`) that reports the exact size (in
+ * bytes) of the input IPC data.
  *
  * @param data Arrow IPC bytes.
  * @param options Arrow IPC extraction options.
@@ -19,17 +21,7 @@ export function decodeIPC(
   data: ArrayBufferLike | Uint8Array | Uint8Array[],
   options: ExtractionOptions = { useDate: true }
 ): Table {
-  const table = tableFromIPC(data, options);
-  const bytes = ipcByteSize(data);
-  if (bytes > 0) {
-    Object.defineProperty(table, 'byteLength', {
-      value: bytes,
-      enumerable: false,
-      writable: false,
-      configurable: true
-    });
-  }
-  return table;
+  return annotateByteLength(tableFromIPC(data, options), ipcByteSize(data));
 }
 
 function ipcByteSize(data: ArrayBufferLike | Uint8Array | Uint8Array[]): number {
@@ -39,23 +31,4 @@ function ipcByteSize(data: ArrayBufferLike | Uint8Array | Uint8Array[]): number 
     return total;
   }
   return (data as ArrayBufferLike | Uint8Array).byteLength ?? 0;
-}
-
-/**
- * Attach a `byteLength` property to a cached value. Used by the
- * connectors to annotate JSON record arrays.
- *
- * @param value The value to annotate. Must be a non-null object.
- * @param bytes The exact byte size to record. Ignored if not positive.
- */
-export function annotateByteLength<T extends object>(value: T, bytes: number): T {
-  if (bytes > 0) {
-    Object.defineProperty(value, 'byteLength', {
-      value: bytes,
-      enumerable: false,
-      writable: false,
-      configurable: true
-    });
-  }
-  return value;
 }

--- a/packages/mosaic/core/src/util/decode-ipc.ts
+++ b/packages/mosaic/core/src/util/decode-ipc.ts
@@ -2,10 +2,6 @@ import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import { tableFromIPC } from '@uwdata/flechette';
 import type { ArrowIPCBytes } from '../types.js';
 
-interface SizedTable extends Table {
-  byteCount: number;
-}
-
 /**
  * Decode Arrow IPC bytes to a table instance.
  * The default options map date and timestamp values to JS Date objects.
@@ -23,8 +19,8 @@ export function decodeIPC(
   return Object.assign(table, { byteCount: ipcByteLength(data) });
 }
 
-export function tableByteLength(table: Table): number | undefined {
-  return (table as Partial<SizedTable>).byteCount;
+export function tableByteLength(table: unknown): number | undefined {
+  return (table as { byteCount?: number } | undefined)?.byteCount;
 }
 
 function ipcByteLength(data: ArrowIPCBytes): number {

--- a/packages/mosaic/core/src/util/decode-ipc.ts
+++ b/packages/mosaic/core/src/util/decode-ipc.ts
@@ -1,7 +1,10 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
 import { tableFromIPC } from '@uwdata/flechette';
+import type { ArrowIPCBytes } from '../types.js';
 
-const byteLengths = new WeakMap<Table, number>();
+interface SizedTable extends Table {
+  byteCount: number;
+}
 
 /**
  * Decode Arrow IPC bytes to a table instance.
@@ -13,19 +16,18 @@ const byteLengths = new WeakMap<Table, number>();
  * @returns A table instance.
  */
 export function decodeIPC(
-  data: ArrayBufferLike | Uint8Array | Uint8Array[],
+  data: ArrowIPCBytes,
   options: ExtractionOptions = { useDate: true }
 ): Table {
   const table = tableFromIPC(data, options);
-  byteLengths.set(table, ipcByteLength(data));
-  return table;
+  return Object.assign(table, { byteCount: ipcByteLength(data) });
 }
 
 export function tableByteLength(table: Table): number | undefined {
-  return byteLengths.get(table);
+  return (table as Partial<SizedTable>).byteCount;
 }
 
-function ipcByteLength(data: ArrayBufferLike | Uint8Array | Uint8Array[]): number {
+function ipcByteLength(data: ArrowIPCBytes): number {
   return Array.isArray(data)
     ? data.reduce((sum, chunk) => sum + chunk.byteLength, 0)
     : data.byteLength;

--- a/packages/mosaic/core/test/cache.test.ts
+++ b/packages/mosaic/core/test/cache.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { jsonByteLength, lruCache } from '../src/util/cache.js';
+
+function mockTime() {
+  let now = 0;
+  vi.spyOn(performance, 'now').mockImplementation(() => now);
+  return (ms: number) => { now += ms; };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('lruCache', () => {
+  it('evicts the least recently used entry when the budget is exceeded', () => {
+    const cache = lruCache({ maxBytes: 100 });
+    cache.set('a', { a: 1 }, 40);
+    cache.set('b', { b: 2 }, 40);
+    cache.set('c', { c: 3 }, 40);
+
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toEqual({ b: 2 });
+    expect(cache.get('c')).toEqual({ c: 3 });
+  });
+
+  it('refreshes recency on get', () => {
+    const cache = lruCache({ maxBytes: 100 });
+    cache.set('a', { a: 1 }, 40);
+    cache.set('b', { b: 2 }, 40);
+    cache.get('a');
+    cache.set('c', { c: 3 }, 40);
+
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('a')).toEqual({ a: 1 });
+    expect(cache.get('c')).toEqual({ c: 3 });
+  });
+
+  it('replaces the charge when an existing key is set again', () => {
+    const cache = lruCache({ maxBytes: 100 });
+    cache.set('a', { n: 1 }, 60);
+    cache.set('a', { n: 2 }, 60);
+    cache.set('b', { n: 3 }, 40);
+
+    expect(cache.get('a')).toEqual({ n: 2 });
+    expect(cache.get('b')).toEqual({ n: 3 });
+  });
+
+  it('charges once when a promise placeholder is replaced by data', () => {
+    const cache = lruCache({ maxBytes: 100 });
+    const promise = Promise.resolve('data');
+    cache.set('a', promise);
+    const data = { rows: 1 };
+    cache.set('a', data, 60);
+    cache.set('b', { b: 2 }, 40);
+
+    expect(cache.get('a')).toBe(data);
+    expect(cache.get('b')).toEqual({ b: 2 });
+  });
+
+  it('does not store a value larger than the budget and drops the placeholder', () => {
+    const cache = lruCache({ maxBytes: 100 });
+    const promise = Promise.resolve('data');
+    cache.set('a', promise);
+    expect(cache.get('a')).toBe(promise);
+
+    const big = { rows: 1 };
+    expect(cache.set('a', big, 101)).toBe(big);
+    expect(cache.get('a')).toBeUndefined();
+  });
+
+  it('charges a shared owner once and releases it with the last entry', () => {
+    const cache = lruCache({ maxBytes: 100 });
+    const owner = { buffer: true };
+    cache.set('a', { a: 1 }, 80, owner);
+    cache.set('b', { b: 2 }, 80, owner);
+    cache.set('c', { c: 3 }, 80, owner);
+    cache.set('d', { d: 4 }, 20);
+
+    expect(cache.get('a')).toEqual({ a: 1 });
+    expect(cache.get('b')).toEqual({ b: 2 });
+    expect(cache.get('c')).toEqual({ c: 3 });
+    expect(cache.get('d')).toEqual({ d: 4 });
+
+    cache.set('e', { e: 5 }, 1);
+
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBeUndefined();
+    expect(cache.get('d')).toEqual({ d: 4 });
+    expect(cache.get('e')).toEqual({ e: 5 });
+  });
+
+  it('shares a charge between keys holding the same object value', () => {
+    const cache = lruCache({ maxBytes: 100 });
+    const value = { shared: true };
+    cache.set('a', value, 60);
+    cache.set('b', value, 60);
+
+    expect(cache.get('a')).toBe(value);
+    expect(cache.get('b')).toBe(value);
+  });
+
+  it('charges a primitive value against the budget', () => {
+    const cache = lruCache({ maxBytes: 100 });
+    cache.set('a', 'a', 60);
+    cache.set('b', 'b', 60);
+
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe('b');
+  });
+
+  it('drops an entry older than the ttl on get', () => {
+    const advance = mockTime();
+    const cache = lruCache({ maxBytes: 100, ttl: 1000 });
+    cache.set('a', { a: 1 }, 10);
+    cache.set('b', { b: 2 }, 10);
+    advance(500);
+    expect(cache.get('b')).toEqual({ b: 2 });
+
+    advance(501);
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toEqual({ b: 2 });
+  });
+
+  it('empties the cache and restores the full budget on clear', () => {
+    const cache = lruCache({ maxBytes: 100 });
+    cache.set('a', { a: 1 }, 100);
+    cache.clear();
+
+    expect(cache.get('a')).toBeUndefined();
+    cache.set('b', { b: 2 }, 100);
+    expect(cache.get('b')).toEqual({ b: 2 });
+  });
+});
+
+describe('jsonByteLength', () => {
+  it('returns zero for nullish values', () => {
+    expect(jsonByteLength(undefined)).toBe(0);
+    expect(jsonByteLength(null)).toBe(0);
+  });
+
+  it('returns the stringified length for an array of objects', () => {
+    const rows = [{ a: 1, b: 'x' }, { a: 2, b: 'y' }];
+    expect(jsonByteLength(rows)).toBe(JSON.stringify(rows).length);
+  });
+
+  it('returns zero for values that can not be serialized', () => {
+    expect(jsonByteLength([{ n: 1n }])).toBe(0);
+  });
+});

--- a/packages/mosaic/core/test/cache.test.ts
+++ b/packages/mosaic/core/test/cache.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { jsonByteLength, lruCache } from '../src/util/cache.js';
-
-function mockTime() {
-  let now = 0;
-  vi.spyOn(performance, 'now').mockImplementation(() => now);
-  return (ms: number) => { now += ms; };
-}
+import { lruCache } from '../src/util/cache.js';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -16,28 +10,17 @@ describe('lruCache', () => {
     const cache = lruCache({ maxBytes: 100 });
     cache.set('a', { a: 1 }, 40);
     cache.set('b', { b: 2 }, 40);
-    cache.set('c', { c: 3 }, 40);
-
-    expect(cache.get('a')).toBeUndefined();
-    expect(cache.get('b')).toEqual({ b: 2 });
-    expect(cache.get('c')).toEqual({ c: 3 });
-  });
-
-  it('refreshes recency on get', () => {
-    const cache = lruCache({ maxBytes: 100 });
-    cache.set('a', { a: 1 }, 40);
-    cache.set('b', { b: 2 }, 40);
     cache.get('a');
     cache.set('c', { c: 3 }, 40);
 
-    expect(cache.get('b')).toBeUndefined();
     expect(cache.get('a')).toEqual({ a: 1 });
+    expect(cache.get('b')).toBeUndefined();
     expect(cache.get('c')).toEqual({ c: 3 });
   });
 
   it('replaces the charge when an existing key is set again', () => {
     const cache = lruCache({ maxBytes: 100 });
-    cache.set('a', { n: 1 }, 60);
+    cache.set('a', Promise.resolve());
     cache.set('a', { n: 2 }, 60);
     cache.set('b', { n: 3 }, 40);
 
@@ -45,24 +28,8 @@ describe('lruCache', () => {
     expect(cache.get('b')).toEqual({ n: 3 });
   });
 
-  it('charges once when a promise placeholder is replaced by data', () => {
+  it('does not store a value larger than the budget', () => {
     const cache = lruCache({ maxBytes: 100 });
-    const promise = Promise.resolve('data');
-    cache.set('a', promise);
-    const data = { rows: 1 };
-    cache.set('a', data, 60);
-    cache.set('b', { b: 2 }, 40);
-
-    expect(cache.get('a')).toBe(data);
-    expect(cache.get('b')).toEqual({ b: 2 });
-  });
-
-  it('does not store a value larger than the budget and drops the placeholder', () => {
-    const cache = lruCache({ maxBytes: 100 });
-    const promise = Promise.resolve('data');
-    cache.set('a', promise);
-    expect(cache.get('a')).toBe(promise);
-
     const big = { rows: 1 };
     expect(cache.set('a', big, 101)).toBe(big);
     expect(cache.get('a')).toBeUndefined();
@@ -70,7 +37,7 @@ describe('lruCache', () => {
 
   it('charges a shared owner once and releases it with the last entry', () => {
     const cache = lruCache({ maxBytes: 100 });
-    const owner = { buffer: true };
+    const owner = {};
     cache.set('a', { a: 1 }, 80, owner);
     cache.set('b', { b: 2 }, 80, owner);
     cache.set('c', { c: 3 }, 80, owner);
@@ -90,61 +57,15 @@ describe('lruCache', () => {
     expect(cache.get('e')).toEqual({ e: 5 });
   });
 
-  it('shares a charge between keys holding the same object value', () => {
-    const cache = lruCache({ maxBytes: 100 });
-    const value = { shared: true };
-    cache.set('a', value, 60);
-    cache.set('b', value, 60);
-
-    expect(cache.get('a')).toBe(value);
-    expect(cache.get('b')).toBe(value);
-  });
-
-  it('charges a primitive value against the budget', () => {
-    const cache = lruCache({ maxBytes: 100 });
-    cache.set('a', 'a', 60);
-    cache.set('b', 'b', 60);
-
-    expect(cache.get('a')).toBeUndefined();
-    expect(cache.get('b')).toBe('b');
-  });
-
   it('drops an entry older than the ttl on get', () => {
-    const advance = mockTime();
-    const cache = lruCache({ maxBytes: 100, ttl: 1000 });
+    let now = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => now);
+    const cache = lruCache({ ttl: 1000 });
     cache.set('a', { a: 1 }, 10);
-    cache.set('b', { b: 2 }, 10);
-    advance(500);
-    expect(cache.get('b')).toEqual({ b: 2 });
 
-    advance(501);
+    now = 1000;
+    expect(cache.get('a')).toEqual({ a: 1 });
+    now = 2001;
     expect(cache.get('a')).toBeUndefined();
-    expect(cache.get('b')).toEqual({ b: 2 });
-  });
-
-  it('empties the cache and restores the full budget on clear', () => {
-    const cache = lruCache({ maxBytes: 100 });
-    cache.set('a', { a: 1 }, 100);
-    cache.clear();
-
-    expect(cache.get('a')).toBeUndefined();
-    cache.set('b', { b: 2 }, 100);
-    expect(cache.get('b')).toEqual({ b: 2 });
-  });
-});
-
-describe('jsonByteLength', () => {
-  it('returns zero for nullish values', () => {
-    expect(jsonByteLength(undefined)).toBe(0);
-    expect(jsonByteLength(null)).toBe(0);
-  });
-
-  it('returns the stringified length for an array of objects', () => {
-    const rows = [{ a: 1, b: 'x' }, { a: 2, b: 'y' }];
-    expect(jsonByteLength(rows)).toBe(JSON.stringify(rows).length);
-  });
-
-  it('returns zero for values that can not be serialized', () => {
-    expect(jsonByteLength([{ n: 1n }])).toBe(0);
   });
 });

--- a/packages/mosaic/core/test/cache.test.ts
+++ b/packages/mosaic/core/test/cache.test.ts
@@ -20,7 +20,7 @@ describe('lruCache', () => {
 
   it('replaces the charge when an existing key is set again', () => {
     const cache = lruCache({ maxBytes: 100 });
-    cache.set('a', Promise.resolve());
+    cache.set('a', { n: 1 }, 30);
     cache.set('a', { n: 2 }, 60);
     cache.set('b', { n: 3 }, 40);
 

--- a/packages/mosaic/core/test/cache.test.ts
+++ b/packages/mosaic/core/test/cache.test.ts
@@ -41,6 +41,7 @@ describe('lruCache', () => {
     cache.set('a', { a: 1 }, 80, owner);
     cache.set('b', { b: 2 }, 80, owner);
     cache.set('c', { c: 3 }, 80, owner);
+    expect(cache.bytes()).toBe(80);
     cache.set('d', { d: 4 }, 20);
 
     expect(cache.get('a')).toEqual({ a: 1 });
@@ -55,6 +56,7 @@ describe('lruCache', () => {
     expect(cache.get('c')).toBeUndefined();
     expect(cache.get('d')).toEqual({ d: 4 });
     expect(cache.get('e')).toEqual({ e: 5 });
+    expect(cache.bytes()).toBe(21);
   });
 
   it('drops an entry older than the ttl on get', () => {

--- a/packages/mosaic/core/test/coordinator.test.ts
+++ b/packages/mosaic/core/test/coordinator.test.ts
@@ -1,7 +1,8 @@
 import { tableFromArrays } from '@uwdata/flechette';
+import { tableFromArrays, tableToIPC } from '@uwdata/flechette';
 import { Query } from '@uwdata/mosaic-sql';
 import { describe, it, expect } from 'vitest';
-import { type ArrowQueryRequest, clausePoint, type Connector, Coordinator, coordinator, makeClient, Selection } from '../src/index.js';
+import { type ArrowQueryRequest, type Cache, clausePoint, type Connector, Coordinator, coordinator, makeClient, Selection } from '../src/index.js';
 import { QueryResult, QueryState } from '../src/util/query-result.js';
 
 async function wait() {
@@ -27,6 +28,7 @@ describe('coordinator', () => {
   });
 
   it('query results returned in correct order', async () => {
+    const ipc = tableToIPC(tableFromArrays({ a: [1] }), {})!;
     const promises: QueryResult[] = [];
 
     // Mock the connector
@@ -56,7 +58,7 @@ describe('coordinator', () => {
 
     // resolve promises in reverse order
 
-    promises.at(3)!.fulfill(0);
+    promises.at(3)!.fulfill(ipc);
     await wait();
 
     expect(r0.state).toEqual(QueryState.pending);
@@ -64,7 +66,7 @@ describe('coordinator', () => {
     expect(r2.state).toEqual(QueryState.pending);
     expect(r3.state).toEqual(QueryState.ready);
 
-    promises.at(1)!.fulfill(0);
+    promises.at(1)!.fulfill(ipc);
     await wait();
 
     expect(r0.state).toEqual(QueryState.pending);
@@ -72,7 +74,7 @@ describe('coordinator', () => {
     expect(r2.state).toEqual(QueryState.pending);
     expect(r3.state).toEqual(QueryState.ready);
 
-    promises.at(0)!.fulfill(0);
+    promises.at(0)!.fulfill(ipc);
     await wait();
 
     expect(coord.manager.pendingResults).toHaveLength(2);
@@ -82,7 +84,7 @@ describe('coordinator', () => {
     expect(r2.state).toEqual(QueryState.pending);
     expect(r3.state).toEqual(QueryState.ready);
 
-    promises.at(2)!.fulfill(0);
+    promises.at(2)!.fulfill(ipc);
     await wait();
 
     expect(coord.manager.pendingResults).toHaveLength(0);
@@ -146,5 +148,56 @@ describe('coordinator', () => {
       "QUERY true",
       "CONNECT 1",
     ]);
+  });
+
+  it('applies the ipc extraction options to arrow results', async () => {
+    const ipc = tableToIPC(tableFromArrays({ t: [new Date(0)] }), {})!;
+    const connector = {
+      async query() {
+        return ipc;
+      },
+    } as unknown as Connector;
+
+    const coord = new Coordinator(connector, {
+      logger: null,
+      ipc: { useDate: false },
+      preagg: { enabled: false }
+    });
+
+    const table = await coord.query('SELECT t FROM foo', { type: 'arrow' });
+
+    expect(table.getChild('t').at(0)).toBe(0);
+  });
+
+  it('uses a custom cache object', async () => {
+    const connector = {
+      async query(req: JSONQueryRequest) {
+        return { sql: req.sql };
+      },
+    } as unknown as Connector;
+
+    const keys: string[] = [];
+    const entries = new Map<string, unknown>();
+    const cache: Cache = {
+      get: key => entries.get(key),
+      set: (key, value) => {
+        keys.push(key);
+        entries.set(key, value);
+        return value;
+      },
+      clear: () => entries.clear()
+    };
+
+    const coord = new Coordinator(connector, {
+      logger: null,
+      cache,
+      preagg: { enabled: false }
+    });
+
+    const result = await coord.query('SELECT 1', { type: 'json' });
+
+    expect(result).toStrictEqual({ sql: 'SELECT 1' });
+    expect(keys).toContain('SELECT 1');
+    expect(entries.get('SELECT 1')).toStrictEqual({ sql: 'SELECT 1' });
   });
 });

--- a/packages/mosaic/core/test/coordinator.test.ts
+++ b/packages/mosaic/core/test/coordinator.test.ts
@@ -1,4 +1,3 @@
-import { tableFromArrays } from '@uwdata/flechette';
 import { tableFromArrays, tableToIPC } from '@uwdata/flechette';
 import { Query } from '@uwdata/mosaic-sql';
 import { describe, it, expect } from 'vitest';
@@ -103,7 +102,7 @@ describe('coordinator', () => {
       async query(req: ArrowQueryRequest) {
         const index = req.sql.includes("WHERE") ? 1 : 0;
         events.push(`CONNECT ${index}`);
-        return tableFromArrays({ index: [index] });
+        return tableToIPC(tableFromArrays({ index: [index] }), {})!;
       },
     } as unknown as Connector;
 

--- a/packages/mosaic/core/test/coordinator.test.ts
+++ b/packages/mosaic/core/test/coordinator.test.ts
@@ -2,7 +2,7 @@ import { tableFromArrays } from '@uwdata/flechette';
 import { tableFromArrays, tableToIPC } from '@uwdata/flechette';
 import { Query } from '@uwdata/mosaic-sql';
 import { describe, it, expect } from 'vitest';
-import { type ArrowQueryRequest, type Cache, clausePoint, type Connector, Coordinator, coordinator, makeClient, Selection } from '../src/index.js';
+import { type ArrowQueryRequest, clausePoint, type Connector, Coordinator, coordinator, makeClient, Selection } from '../src/index.js';
 import { QueryResult, QueryState } from '../src/util/query-result.js';
 
 async function wait() {
@@ -167,37 +167,5 @@ describe('coordinator', () => {
     const table = await coord.query('SELECT t FROM foo', { type: 'arrow' });
 
     expect(table.getChild('t').at(0)).toBe(0);
-  });
-
-  it('uses a custom cache object', async () => {
-    const connector = {
-      async query(req: JSONQueryRequest) {
-        return { sql: req.sql };
-      },
-    } as unknown as Connector;
-
-    const keys: string[] = [];
-    const entries = new Map<string, unknown>();
-    const cache: Cache = {
-      get: key => entries.get(key),
-      set: (key, value) => {
-        keys.push(key);
-        entries.set(key, value);
-        return value;
-      },
-      clear: () => entries.clear()
-    };
-
-    const coord = new Coordinator(connector, {
-      logger: null,
-      cache,
-      preagg: { enabled: false }
-    });
-
-    const result = await coord.query('SELECT 1', { type: 'json' });
-
-    expect(result).toStrictEqual({ sql: 'SELECT 1' });
-    expect(keys).toContain('SELECT 1');
-    expect(entries.get('SELECT 1')).toStrictEqual({ sql: 'SELECT 1' });
   });
 });

--- a/packages/mosaic/core/test/decode-ipc.test.ts
+++ b/packages/mosaic/core/test/decode-ipc.test.ts
@@ -1,0 +1,26 @@
+import { tableFromArrays, tableToIPC } from '@uwdata/flechette';
+import { describe, expect, it } from 'vitest';
+import { decodeIPC, tableByteLength } from '../src/util/decode-ipc.js';
+
+describe('decodeIPC', () => {
+  it('records the byte length of a single buffer', () => {
+    const bytes = tableToIPC(tableFromArrays({ a: [1, 2, 3] }), {})!;
+    expect(tableByteLength(decodeIPC(bytes))).toBe(bytes.length);
+    expect(tableByteLength(decodeIPC(bytes.buffer))).toBe(bytes.length);
+  });
+
+  it('records the summed byte length of chunked buffers', () => {
+    const chunks = [
+      tableToIPC(tableFromArrays({ a: [1, 2, 3] }), {})!,
+      tableToIPC(tableFromArrays({ a: [4, 5] }), {})!
+    ];
+    const table = decodeIPC(chunks);
+
+    expect(table.numRows).toBe(5);
+    expect(tableByteLength(table)).toBe(chunks[0].length + chunks[1].length);
+  });
+
+  it('has no byte length for a table it did not decode', () => {
+    expect(tableByteLength(tableFromArrays({ a: [1] }))).toBeUndefined();
+  });
+});

--- a/packages/mosaic/core/test/decode-ipc.test.ts
+++ b/packages/mosaic/core/test/decode-ipc.test.ts
@@ -3,24 +3,13 @@ import { describe, expect, it } from 'vitest';
 import { decodeIPC, tableByteLength } from '../src/util/decode-ipc.js';
 
 describe('decodeIPC', () => {
-  it('records the byte length of a single buffer', () => {
-    const bytes = tableToIPC(tableFromArrays({ a: [1, 2, 3] }), {})!;
-    expect(tableByteLength(decodeIPC(bytes))).toBe(bytes.length);
-    expect(tableByteLength(decodeIPC(bytes.buffer))).toBe(bytes.length);
-  });
-
-  it('records the summed byte length of chunked buffers', () => {
+  it('records the IPC byte length of decoded tables', () => {
     const chunks = [
       tableToIPC(tableFromArrays({ a: [1, 2, 3] }), {})!,
       tableToIPC(tableFromArrays({ a: [4, 5] }), {})!
     ];
-    const table = decodeIPC(chunks);
-
-    expect(table.numRows).toBe(5);
-    expect(tableByteLength(table)).toBe(chunks[0].length + chunks[1].length);
-  });
-
-  it('has no byte length for a table it did not decode', () => {
+    expect(tableByteLength(decodeIPC(chunks[0]))).toBe(chunks[0].length);
+    expect(tableByteLength(decodeIPC(chunks))).toBe(chunks[0].length + chunks[1].length);
     expect(tableByteLength(tableFromArrays({ a: [1] }))).toBeUndefined();
   });
 });

--- a/packages/mosaic/core/test/query-consolidator.test.ts
+++ b/packages/mosaic/core/test/query-consolidator.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { type Table, tableFromArrays, tableToIPC } from '@uwdata/flechette';
-import { Query, SelectQuery, count, literal, sum } from '@uwdata/mosaic-sql';
+import { Query, count, literal, sum } from '@uwdata/mosaic-sql';
 import { consolidator } from '../src/QueryConsolidator.js';
 import { Priority } from '../src/QueryManager.js';
-import type { Cache, QueryEntry, QueryType } from '../src/types.js';
-import { jsonByteLength, lruCache, voidCache } from '../src/util/cache.js';
-import { decodeIPC, tableByteLength } from '../src/util/decode-ipc.js';
+import type { Cache, QueryEntry } from '../src/types.js';
+import { voidCache } from '../src/util/cache.js';
+import { decodeIPC } from '../src/util/decode-ipc.js';
 import { QueryResult } from '../src/util/query-result.js';
 
 describe('QueryConsolidation', () => {
@@ -109,115 +109,33 @@ describe('QueryConsolidation', () => {
 });
 
 describe('QueryConsolidationCaching', () => {
-  interface CacheCall {
-    key: string;
-    value: unknown;
-    bytes?: number;
-    owner?: object;
-  }
-
-  function recordingCache(): Cache & { calls: CacheCall[] } {
-    const calls: CacheCall[] = [];
-    return {
-      calls,
-      get: () => undefined,
-      set(key, value, bytes, owner) {
-        calls.push({ key, value, bytes, owner });
-        return value;
-      },
-      clear: () => {}
-    };
-  }
-
-  function decodedTable(columns: Record<string, unknown[]>): Table {
-    return decodeIPC(tableToIPC(tableFromArrays(columns), {})!);
-  }
-
-  // DescribeQuery is not a SelectQuery, so the consolidator never groups real
-  // describe queries; this shim makes the consolidated query a DescribeQuery.
-  function describeQuery(select: Record<string, string>): SelectQuery {
-    const query = Query.from({ source: 'table' }).select(select);
-    query.setSelect = function (...expr) {
-      SelectQuery.prototype.setSelect.apply(this, expr);
-      return Query.describe(this) as unknown as SelectQuery;
-    };
-    return query;
-  }
-
-  function selectQueries(...columns: string[]) {
-    return columns.map(c => Query.from({ source: 'table' }).select({ c }));
-  }
-
-  async function consolidate(
-    queries: unknown[],
-    data: Table,
-    cache: Cache
-  ): Promise<unknown[]> {
+  it('should charge projected extracts to the merged table', async () => {
+    const bytes = tableToIPC(tableFromArrays({ col0: [1, 2], col1: [3, 4] }), {})!;
+    const data = decodeIPC(bytes);
+    const queries = ['x', 'y'].map(c => Query.from({ source: 'table' }).select({ c }));
     const entries: QueryEntry[] = queries.map(query => ({
-      request: { type: 'arrow', cache: true, query: query as QueryType },
+      request: { type: 'arrow', cache: true, query },
       result: new QueryResult()
     }));
+
+    const calls: unknown[][] = [];
+    const cache: Cache = {
+      get: () => undefined,
+      set: (...args) => (calls.push(args), args[1]),
+      clear: () => {}
+    };
     const c = consolidator(entry => {
       if (entry.request.cache === false) entry.result.fulfill(data);
     }, cache);
     for (const entry of entries) {
       c.add(entry, Priority.Normal);
     }
-    return Promise.all(entries.map(entry => entry.result));
-  }
+    const extracts = await Promise.all(entries.map(entry => entry.result)) as Table[];
 
-  it('should charge projected extracts to the merged table', async () => {
-    const data = decodedTable({ col0: [1, 2], col1: [3, 4], col2: [5, 6] });
-    const queries = selectQueries('x', 'y', 'z');
-    const cache = recordingCache();
-    const extracts = await consolidate(queries, data, cache) as Table[];
-
-    expect(cache.calls.map(call => call.key))
-      .toEqual(queries.map(query => String(query)));
-    for (const [index, call] of cache.calls.entries()) {
-      expect(call.value).toBe(extracts[index]);
-      expect(call.bytes).toBe(tableByteLength(data));
-      expect(call.owner).toBe(data);
-    }
-
-    expect(new Set(extracts).size).toBe(3);
-    expect(extracts.some(extract => extract === data)).toBe(false);
     expect(Array.from(extracts[1])).toEqual([{ c: 3 }, { c: 4 }]);
-  });
-
-  it('should keep extracts of one merged buffer under a tight byte budget', async () => {
-    const data = decodedTable({ col0: [1, 2], col1: [3, 4], col2: [5, 6] });
-    const queries = selectQueries('x', 'y', 'z');
-    const bytes = tableByteLength(data)!;
-    const cache = lruCache({ maxBytes: bytes + 1 });
-    const extracts = await consolidate(queries, data, cache);
-
-    queries.forEach((query, index) => {
-      expect(cache.get(String(query))).toBe(extracts[index]);
-    });
-
-    cache.set('other', {}, bytes);
-    expect(queries.map(query => cache.get(String(query))))
-      .toEqual([undefined, undefined, undefined]);
-    expect(cache.get('other')).toEqual({});
-  });
-
-  it('should charge describe extracts by their JSON length', async () => {
-    const data = decodedTable({
-      column_name: ['col0', 'col1'],
-      column_type: ['DOUBLE', 'VARCHAR']
-    });
-    const queries = [describeQuery({ a: 'x' }), describeQuery({ b: 'y' })];
-    const cache = recordingCache();
-    const extracts = await consolidate(queries, data, cache);
-
-    expect(extracts).toEqual([
-      [{ column_name: 'a', column_type: 'DOUBLE' }],
-      [{ column_name: 'b', column_type: 'VARCHAR' }]
+    expect(calls).toEqual([
+      [String(queries[0]), extracts[0], bytes.length, data],
+      [String(queries[1]), extracts[1], bytes.length, data]
     ]);
-    for (const [index, call] of cache.calls.entries()) {
-      expect(call.bytes).toBe(jsonByteLength(extracts[index]));
-      expect(call.owner).toBeUndefined();
-    }
   });
 });

--- a/packages/mosaic/core/test/query-consolidator.test.ts
+++ b/packages/mosaic/core/test/query-consolidator.test.ts
@@ -122,7 +122,8 @@ describe('QueryConsolidationCaching', () => {
     const cache: Cache = {
       get: () => undefined,
       set: (...args) => (calls.push(args), args[1]),
-      clear: () => {}
+      clear: () => {},
+      bytes: () => 0
     };
     const c = consolidator(entry => {
       if (entry.request.cache === false) entry.result.fulfill(data);

--- a/packages/mosaic/core/test/query-consolidator.test.ts
+++ b/packages/mosaic/core/test/query-consolidator.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { Query, count, literal, sum } from '@uwdata/mosaic-sql';
+import { type Table, tableFromArrays, tableToIPC } from '@uwdata/flechette';
+import { Query, SelectQuery, count, literal, sum } from '@uwdata/mosaic-sql';
 import { consolidator } from '../src/QueryConsolidator.js';
 import { Priority } from '../src/QueryManager.js';
-import { voidCache } from '../src/util/cache.js';
+import type { Cache, QueryEntry, QueryType } from '../src/types.js';
+import { jsonByteLength, lruCache, voidCache } from '../src/util/cache.js';
+import { decodeIPC, tableByteLength } from '../src/util/decode-ipc.js';
+import { QueryResult } from '../src/util/query-result.js';
 
 describe('QueryConsolidation', () => {
   async function getConsolidatedQueries(...qs: unknown[]) {
@@ -101,5 +105,119 @@ describe('QueryConsolidation', () => {
       q1.toString(),
       Query.from({ source: 'table' }).select({ col0: 'y', col1: 'z' }).toString(),
     ]);
+  });
+});
+
+describe('QueryConsolidationCaching', () => {
+  interface CacheCall {
+    key: string;
+    value: unknown;
+    bytes?: number;
+    owner?: object;
+  }
+
+  function recordingCache(): Cache & { calls: CacheCall[] } {
+    const calls: CacheCall[] = [];
+    return {
+      calls,
+      get: () => undefined,
+      set(key, value, bytes, owner) {
+        calls.push({ key, value, bytes, owner });
+        return value;
+      },
+      clear: () => {}
+    };
+  }
+
+  function decodedTable(columns: Record<string, unknown[]>): Table {
+    return decodeIPC(tableToIPC(tableFromArrays(columns), {})!);
+  }
+
+  // DescribeQuery is not a SelectQuery, so the consolidator never groups real
+  // describe queries; this shim makes the consolidated query a DescribeQuery.
+  function describeQuery(select: Record<string, string>): SelectQuery {
+    const query = Query.from({ source: 'table' }).select(select);
+    query.setSelect = function (...expr) {
+      SelectQuery.prototype.setSelect.apply(this, expr);
+      return Query.describe(this) as unknown as SelectQuery;
+    };
+    return query;
+  }
+
+  function selectQueries(...columns: string[]) {
+    return columns.map(c => Query.from({ source: 'table' }).select({ c }));
+  }
+
+  async function consolidate(
+    queries: unknown[],
+    data: Table,
+    cache: Cache
+  ): Promise<unknown[]> {
+    const entries: QueryEntry[] = queries.map(query => ({
+      request: { type: 'arrow', cache: true, query: query as QueryType },
+      result: new QueryResult()
+    }));
+    const c = consolidator(entry => {
+      if (entry.request.cache === false) entry.result.fulfill(data);
+    }, cache);
+    for (const entry of entries) {
+      c.add(entry, Priority.Normal);
+    }
+    return Promise.all(entries.map(entry => entry.result));
+  }
+
+  it('should charge projected extracts to the merged table', async () => {
+    const data = decodedTable({ col0: [1, 2], col1: [3, 4], col2: [5, 6] });
+    const queries = selectQueries('x', 'y', 'z');
+    const cache = recordingCache();
+    const extracts = await consolidate(queries, data, cache) as Table[];
+
+    expect(cache.calls.map(call => call.key))
+      .toEqual(queries.map(query => String(query)));
+    for (const [index, call] of cache.calls.entries()) {
+      expect(call.value).toBe(extracts[index]);
+      expect(call.bytes).toBe(tableByteLength(data));
+      expect(call.owner).toBe(data);
+    }
+
+    expect(new Set(extracts).size).toBe(3);
+    expect(extracts.some(extract => extract === data)).toBe(false);
+    expect(Array.from(extracts[1])).toEqual([{ c: 3 }, { c: 4 }]);
+  });
+
+  it('should keep extracts of one merged buffer under a tight byte budget', async () => {
+    const data = decodedTable({ col0: [1, 2], col1: [3, 4], col2: [5, 6] });
+    const queries = selectQueries('x', 'y', 'z');
+    const bytes = tableByteLength(data)!;
+    const cache = lruCache({ maxBytes: bytes + 1 });
+    const extracts = await consolidate(queries, data, cache);
+
+    queries.forEach((query, index) => {
+      expect(cache.get(String(query))).toBe(extracts[index]);
+    });
+
+    cache.set('other', {}, bytes);
+    expect(queries.map(query => cache.get(String(query))))
+      .toEqual([undefined, undefined, undefined]);
+    expect(cache.get('other')).toEqual({});
+  });
+
+  it('should charge describe extracts by their JSON length', async () => {
+    const data = decodedTable({
+      column_name: ['col0', 'col1'],
+      column_type: ['DOUBLE', 'VARCHAR']
+    });
+    const queries = [describeQuery({ a: 'x' }), describeQuery({ b: 'y' })];
+    const cache = recordingCache();
+    const extracts = await consolidate(queries, data, cache);
+
+    expect(extracts).toEqual([
+      [{ column_name: 'a', column_type: 'DOUBLE' }],
+      [{ column_name: 'b', column_type: 'VARCHAR' }]
+    ]);
+    for (const [index, call] of cache.calls.entries()) {
+      expect(call.bytes).toBe(jsonByteLength(extracts[index]));
+      expect(call.owner).toBeUndefined();
+    }
   });
 });

--- a/packages/mosaic/core/test/query-manager.test.ts
+++ b/packages/mosaic/core/test/query-manager.test.ts
@@ -3,25 +3,7 @@ import { Table, tableFromArrays, tableToIPC } from '@uwdata/flechette';
 import { describe, it, expect } from 'vitest';
 import { QueryManager } from '../src/QueryManager.js';
 import { QueryResult } from '../src/util/query-result.js';
-import { Cache, QueryRequest } from '../src/types.js';
-import { jsonByteLength } from '../src/util/cache.js';
-
-interface CacheWrite {
-  key: string;
-  value: unknown;
-  bytes?: number;
-}
-
-function recordingCache(writes: CacheWrite[]): Cache {
-  return {
-    get: () => undefined,
-    set: (key, value, bytes) => {
-      writes.push({ key, value, bytes });
-      return value;
-    },
-    clear: () => {}
-  };
-}
+import { QueryRequest } from '../src/types.js';
 
 describe('QueryManager', () => {
   it('should run a simple query', async () => {
@@ -76,55 +58,14 @@ describe('QueryManager', () => {
     expect(queryManager.pendingResults).toHaveLength(1);
   });
 
-  it('caches an arrow result with its IPC byte length', async () => {
-    const bytes = tableToIPC(tableFromArrays({ a: [1, 2, 3] }), {})!;
-    const writes: CacheWrite[] = [];
-    const queryManager = new QueryManager();
-    queryManager.cache(recordingCache(writes));
-
-    // @ts-expect-error assumes type value
-    queryManager.connector({ query: async () => bytes });
-
-    const table = await queryManager.request({
-      type: 'arrow',
-      query: 'SELECT * FROM test',
-      cache: true
-    }) as Table;
-
-    expect(table.numRows).toBe(3);
-    expect(writes).toHaveLength(2);
-    expect(writes[0].value).toBeInstanceOf(Promise);
-    expect(writes[0].bytes).toBeUndefined();
-    expect(writes[1].value).toBe(table);
-    expect(writes[1].bytes).toBe(bytes.length);
-  });
-
-  it('caches a json result with its JSON byte length', async () => {
-    const rows = [{ a: 1 }, { a: 2 }];
-    const writes: CacheWrite[] = [];
-    const queryManager = new QueryManager();
-    queryManager.cache(recordingCache(writes));
-
-    // @ts-expect-error assumes type value
-    queryManager.connector({ query: async () => rows });
-
-    const data = await queryManager.request({
-      type: 'json',
-      query: 'SELECT * FROM test',
-      cache: true
-    });
-
-    expect(data).toBe(rows);
-    expect(writes[1].bytes).toBe(jsonByteLength(rows));
-  });
-
-  it('serves a cached arrow result as a decoded table', async () => {
+  it('caches a decoded arrow result with its IPC byte length', async () => {
     const bytes = tableToIPC(tableFromArrays({ a: [1, 2, 3] }), {})!;
     const store = new Map<string, unknown>();
+    const sizes: (number | undefined)[] = [];
     const queryManager = new QueryManager();
     queryManager.cache({
       get: key => store.get(key),
-      set: (key, value) => (store.set(key, value), value),
+      set: (key, value, size) => (store.set(key, value), sizes.push(size), value),
       clear: () => store.clear()
     });
 
@@ -143,11 +84,11 @@ describe('QueryManager', () => {
       cache: true
     };
     const first = await queryManager.request(request) as Table;
-    const second = await queryManager.request(request) as Table;
+    const second = await queryManager.request(request);
 
-    expect(calls).toBe(1);
-    expect(second).toBeInstanceOf(Table);
+    expect(first.numRows).toBe(3);
     expect(second).toBe(first);
-    expect(second.numRows).toBe(3);
+    expect(calls).toBe(1);
+    expect(sizes).toEqual([undefined, bytes.length]);
   });
 });

--- a/packages/mosaic/core/test/query-manager.test.ts
+++ b/packages/mosaic/core/test/query-manager.test.ts
@@ -5,6 +5,12 @@ import { QueryResult } from '../src/util/query-result.js';
 import { QueryRequest } from '../src/types.js';
 
 describe('QueryManager', () => {
+  const cachedRequest: QueryRequest = {
+    type: 'arrow',
+    query: 'SELECT * FROM test',
+    cache: true
+  };
+
   it('should run a simple query', async () => {
     const queryManager = new QueryManager();
 
@@ -78,13 +84,8 @@ describe('QueryManager', () => {
       }
     });
 
-    const request: QueryRequest = {
-      type: 'arrow',
-      query: 'SELECT * FROM test',
-      cache: true
-    };
-    const pending = queryManager.request(request);
-    const second = queryManager.request(request);
+    const pending = queryManager.request(cachedRequest);
+    const second = queryManager.request(cachedRequest);
     const first = await pending as Table;
 
     expect(first.numRows).toBe(3);
@@ -108,13 +109,8 @@ describe('QueryManager', () => {
       }
     });
 
-    const request: QueryRequest = {
-      type: 'arrow',
-      query: 'SELECT * FROM test',
-      cache: true
-    };
-    await expect(queryManager.request(request)).rejects.toThrow('transient');
-    const data = await queryManager.request(request) as Table;
+    await expect(queryManager.request(cachedRequest)).rejects.toThrow('transient');
+    const data = await queryManager.request(cachedRequest) as Table;
 
     expect(calls).toBe(2);
     expect(data.numRows).toBe(1);
@@ -134,17 +130,12 @@ describe('QueryManager', () => {
       }
     });
 
-    const request: QueryRequest = {
-      type: 'arrow',
-      query: 'SELECT * FROM test',
-      cache: true
-    };
-    await queryManager.request(request);
-    await queryManager.request(request);
+    await queryManager.request(cachedRequest);
+    await queryManager.request(cachedRequest);
     expect(calls).toBe(1);
 
     queryManager.ipc({ useDate: false });
-    await queryManager.request(request);
+    await queryManager.request(cachedRequest);
 
     expect(calls).toBe(2);
   });

--- a/packages/mosaic/core/test/query-manager.test.ts
+++ b/packages/mosaic/core/test/query-manager.test.ts
@@ -66,7 +66,8 @@ describe('QueryManager', () => {
     queryManager.cache({
       get: key => store.get(key),
       set: (key, value, size) => (store.set(key, value), sizes.push(size), value),
-      clear: () => store.clear()
+      clear: () => store.clear(),
+      bytes: () => 0
     });
 
     let calls = 0;

--- a/packages/mosaic/core/test/query-manager.test.ts
+++ b/packages/mosaic/core/test/query-manager.test.ts
@@ -1,8 +1,27 @@
 import { Table, tableFromArrays } from '@uwdata/flechette';
+import { Table, tableFromArrays, tableToIPC } from '@uwdata/flechette';
 import { describe, it, expect } from 'vitest';
 import { QueryManager } from '../src/QueryManager.js';
 import { QueryResult } from '../src/util/query-result.js';
-import { QueryRequest } from '../src/types.js';
+import { Cache, QueryRequest } from '../src/types.js';
+import { jsonByteLength } from '../src/util/cache.js';
+
+interface CacheWrite {
+  key: string;
+  value: unknown;
+  bytes?: number;
+}
+
+function recordingCache(writes: CacheWrite[]): Cache {
+  return {
+    get: () => undefined,
+    set: (key, value, bytes) => {
+      writes.push({ key, value, bytes });
+      return value;
+    },
+    clear: () => {}
+  };
+}
 
 describe('QueryManager', () => {
   it('should run a simple query', async () => {
@@ -18,7 +37,7 @@ describe('QueryManager', () => {
     });
 
     const request: QueryRequest = {
-      type: 'arrow',
+      type: 'json',
       query: 'SELECT 1'
     };
 
@@ -47,7 +66,7 @@ describe('QueryManager', () => {
     };
 
     const request2: QueryRequest = {
-      type: 'arrow',
+      type: 'json',
       query: 'SELECT * FROM test'
     };
 
@@ -55,5 +74,80 @@ describe('QueryManager', () => {
     queryManager.request(request2);
 
     expect(queryManager.pendingResults).toHaveLength(1);
+  });
+
+  it('caches an arrow result with its IPC byte length', async () => {
+    const bytes = tableToIPC(tableFromArrays({ a: [1, 2, 3] }), {})!;
+    const writes: CacheWrite[] = [];
+    const queryManager = new QueryManager();
+    queryManager.cache(recordingCache(writes));
+
+    // @ts-expect-error assumes type value
+    queryManager.connector({ query: async () => bytes });
+
+    const table = await queryManager.request({
+      type: 'arrow',
+      query: 'SELECT * FROM test',
+      cache: true
+    }) as Table;
+
+    expect(table.numRows).toBe(3);
+    expect(writes).toHaveLength(2);
+    expect(writes[0].value).toBeInstanceOf(Promise);
+    expect(writes[0].bytes).toBeUndefined();
+    expect(writes[1].value).toBe(table);
+    expect(writes[1].bytes).toBe(bytes.length);
+  });
+
+  it('caches a json result with its JSON byte length', async () => {
+    const rows = [{ a: 1 }, { a: 2 }];
+    const writes: CacheWrite[] = [];
+    const queryManager = new QueryManager();
+    queryManager.cache(recordingCache(writes));
+
+    // @ts-expect-error assumes type value
+    queryManager.connector({ query: async () => rows });
+
+    const data = await queryManager.request({
+      type: 'json',
+      query: 'SELECT * FROM test',
+      cache: true
+    });
+
+    expect(data).toBe(rows);
+    expect(writes[1].bytes).toBe(jsonByteLength(rows));
+  });
+
+  it('serves a cached arrow result as a decoded table', async () => {
+    const bytes = tableToIPC(tableFromArrays({ a: [1, 2, 3] }), {})!;
+    const store = new Map<string, unknown>();
+    const queryManager = new QueryManager();
+    queryManager.cache({
+      get: key => store.get(key),
+      set: (key, value) => (store.set(key, value), value),
+      clear: () => store.clear()
+    });
+
+    let calls = 0;
+    queryManager.connector({
+      // @ts-expect-error assumes type value
+      query: async () => {
+        calls += 1;
+        return bytes;
+      }
+    });
+
+    const request: QueryRequest = {
+      type: 'arrow',
+      query: 'SELECT * FROM test',
+      cache: true
+    };
+    const first = await queryManager.request(request) as Table;
+    const second = await queryManager.request(request) as Table;
+
+    expect(calls).toBe(1);
+    expect(second).toBeInstanceOf(Table);
+    expect(second).toBe(first);
+    expect(second.numRows).toBe(3);
   });
 });

--- a/packages/mosaic/core/test/query-manager.test.ts
+++ b/packages/mosaic/core/test/query-manager.test.ts
@@ -1,4 +1,3 @@
-import { Table, tableFromArrays } from '@uwdata/flechette';
 import { Table, tableFromArrays, tableToIPC } from '@uwdata/flechette';
 import { describe, it, expect } from 'vitest';
 import { QueryManager } from '../src/QueryManager.js';
@@ -14,12 +13,12 @@ describe('QueryManager', () => {
       // @ts-expect-error assumes type value
       query: async ({ sql }) => {
         expect(sql).toBe('SELECT 1');
-        return tableFromArrays({ column: [1] });
+        return tableToIPC(tableFromArrays({ column: [1] }), {})!;
       }
     });
 
     const request: QueryRequest = {
-      type: 'json',
+      type: 'arrow',
       query: 'SELECT 1'
     };
 
@@ -48,7 +47,7 @@ describe('QueryManager', () => {
     };
 
     const request2: QueryRequest = {
-      type: 'json',
+      type: 'arrow',
       query: 'SELECT * FROM test'
     };
 

--- a/packages/mosaic/core/test/query-manager.test.ts
+++ b/packages/mosaic/core/test/query-manager.test.ts
@@ -83,13 +83,41 @@ describe('QueryManager', () => {
       query: 'SELECT * FROM test',
       cache: true
     };
-    const first = await queryManager.request(request) as Table;
-    const second = await queryManager.request(request);
+    const pending = queryManager.request(request);
+    const second = queryManager.request(request);
+    const first = await pending as Table;
 
     expect(first.numRows).toBe(3);
-    expect(second).toBe(first);
+    expect(await second).toBe(first);
     expect(calls).toBe(1);
-    expect(sizes).toEqual([undefined, bytes.length]);
+    expect(sizes).toEqual([bytes.length]);
+  });
+
+  it('does not cache a rejected query', async () => {
+    const bytes = tableToIPC(tableFromArrays({ a: [1] }), {})!;
+    const queryManager = new QueryManager();
+    queryManager.cache(true);
+
+    let calls = 0;
+    queryManager.connector({
+      // @ts-expect-error assumes type value
+      query: async () => {
+        calls += 1;
+        if (calls === 1) throw new Error('transient');
+        return bytes;
+      }
+    });
+
+    const request: QueryRequest = {
+      type: 'arrow',
+      query: 'SELECT * FROM test',
+      cache: true
+    };
+    await expect(queryManager.request(request)).rejects.toThrow('transient');
+    const data = await queryManager.request(request) as Table;
+
+    expect(calls).toBe(2);
+    expect(data.numRows).toBe(1);
   });
 
   it('drops cached results when the extraction options change', async () => {

--- a/packages/mosaic/core/test/query-manager.test.ts
+++ b/packages/mosaic/core/test/query-manager.test.ts
@@ -91,4 +91,33 @@ describe('QueryManager', () => {
     expect(calls).toBe(1);
     expect(sizes).toEqual([undefined, bytes.length]);
   });
+
+  it('drops cached results when the extraction options change', async () => {
+    const bytes = tableToIPC(tableFromArrays({ a: [1] }), {})!;
+    const queryManager = new QueryManager();
+    queryManager.cache(true);
+
+    let calls = 0;
+    queryManager.connector({
+      // @ts-expect-error assumes type value
+      query: async () => {
+        calls += 1;
+        return bytes;
+      }
+    });
+
+    const request: QueryRequest = {
+      type: 'arrow',
+      query: 'SELECT * FROM test',
+      cache: true
+    };
+    await queryManager.request(request);
+    await queryManager.request(request);
+    expect(calls).toBe(1);
+
+    queryManager.ipc({ useDate: false });
+    await queryManager.request(request);
+
+    expect(calls).toBe(2);
+  });
 });

--- a/packages/mosaic/core/test/socket-connector.test.ts
+++ b/packages/mosaic/core/test/socket-connector.test.ts
@@ -120,15 +120,15 @@ describe('SocketConnector', () => {
     expect(log).toHaveBeenCalledOnce();
   });
 
-  it('decodes binary responses for arrow requests and resolves exec on text', async () => {
+  it('resolves arrow requests with the raw bytes and exec on text', async () => {
     const { connector, socket } = connect();
     const exec = connector.query({ type: 'exec', sql: 'CREATE TABLE t (a INT)' });
-    const arrow = connector.query({ type: 'arrow', sql: 'SELECT 1' }).catch(error => error);
+    const arrow = connector.query({ type: 'arrow', sql: 'SELECT 1' });
+    const bytes = new Uint8Array([1, 2, 3]);
     socket().emit('open');
     socket().emit('message', { data: '{}' });
-    socket().emit('message', { data: new Uint8Array([1, 2, 3]) });
+    socket().emit('message', { data: bytes });
     await exec;
-    // an undecodable buffer rejects instead of leaving the request pending
-    expect(await arrow).toBeInstanceOf(Error);
+    expect(await arrow).toBe(bytes);
   });
 });

--- a/packages/vgplot/widget/src/index.js
+++ b/packages/vgplot/widget/src/index.js
@@ -131,7 +131,7 @@ export default {
       } else {
         switch (msg.type) {
           case 'arrow': {
-            logger.log('arrow', buffers[0]);
+            logger.log('arrow bytes', buffers[0].buffer.byteLength);
             query.resolve(buffers[0].buffer);
             break;
           }

--- a/packages/vgplot/widget/src/index.js
+++ b/packages/vgplot/widget/src/index.js
@@ -1,4 +1,4 @@
-import { coordinator, decodeIPC, isSelection } from '@uwdata/mosaic-core';
+import { coordinator, isSelection } from '@uwdata/mosaic-core';
 import { parseSpec, astToDOM } from '@uwdata/mosaic-spec';
 import './style.css';
 import { v4 as uuidv4 } from 'uuid';
@@ -131,9 +131,8 @@ export default {
       } else {
         switch (msg.type) {
           case 'arrow': {
-            const table = decodeIPC(buffers[0].buffer);
-            logger.log('table', table);
-            query.resolve(table);
+            logger.log('arrow', buffers[0]);
+            query.resolve(buffers[0].buffer);
             break;
           }
           default: {


### PR DESCRIPTION
The client-side query cache now evicts by bytes instead of entry count, so dashboards with large results stay within a predictable memory budget (256 MiB by default, configurable via `lruCache({ maxBytes })`).

Sizes come from the connector: connectors return the raw Arrow IPC bytes and the coordinator decodes them, recording each table's byte length. Since flechette decodes as views over the IPC buffer, that length is the memory the cached table actually retains. Results extracted from one consolidated query share a buffer and are charged once, so they are not double counted.

Stacked on #1172, which removes the `json` query type, and merges after it.

Builds on @SayeVikram's work in cmudig/mosaic#30; those commits are included here and the final shape replaces the size estimation with the connector byte contract.

**Breaking changes**

- `Connector.query` for `"arrow"` requests returns Arrow IPC bytes (the new `ArrowIPCBytes` type) instead of a decoded table. Third-party connectors need to return the bytes they already receive.
- The `ipc` extraction option moves from the connector constructors to the `Coordinator` options. Setting new options clears the cache, since cached tables were decoded under the previous ones.
- `lruCache` takes `maxBytes` instead of `max`, and the cache exposes `bytes()` for the total currently charged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DXBUeXThM8TTmYRdPjWz3
