### PR TITLE
feat!: remove json query type from connectors

### DIFF
--- a/dev/parse.html
+++ b/dev/parse.html
@@ -7,16 +7,18 @@
 <body>
 <script type="module">
   import yaml from '../node_modules/yaml/browser/index.js';
+  import { decodeIPC } from '@uwdata/mosaic-core';
   import { coordinator, setDatabaseConnector } from './setup.js';
   setDatabaseConnector('wasm');
   const db = coordinator.databaseConnector();
 
   self.parse = async function(query) {
     const t0 = Date.now();
-    const result = await db.query({
-      type: 'json',
+    const bytes = await db.query({
+      type: 'arrow',
       sql: `SELECT json_serialize_sql($$${query}$$, skip_empty:=true, skip_null:=true) AS ast`
     });
+    const result = decodeIPC(bytes).toArray();
     const ast = JSON.parse(result[0].ast);
     ast._time = Date.now() - t0;
     return ast;

--- a/dev/parse.html
+++ b/dev/parse.html
@@ -7,18 +7,17 @@
 <body>
 <script type="module">
   import yaml from '../node_modules/yaml/browser/index.js';
-  import { decodeIPC } from '@uwdata/mosaic-core';
   import { coordinator, setDatabaseConnector } from './setup.js';
   setDatabaseConnector('wasm');
   const db = coordinator.databaseConnector();
 
   self.parse = async function(query) {
     const t0 = Date.now();
-    const bytes = await db.query({
+    const table = await db.query({
       type: 'arrow',
       sql: `SELECT json_serialize_sql($$${query}$$, skip_empty:=true, skip_null:=true) AS ast`
     });
-    const result = decodeIPC(bytes).toArray();
+    const result = table.toArray();
     const ast = JSON.parse(result[0].ast);
     ast._time = Date.now() - t0;
     return ast;

--- a/docs/api/core/connectors.md
+++ b/docs/api/core/connectors.md
@@ -6,7 +6,7 @@ A connector instance should expose a `query(query)` method that returns a Promis
 The _query_ argument is an object that may include the following properties:
 
 - _sql_: The SQL query to evaluate.
-- _type_: The query format type, such as `"exec"` (no return value), `"arrow"`, and `"json"`.
+- _type_: The query format type, either `"exec"` (no return value) or `"arrow"`.
 - Any additional connector-specific options.
 
 Once instantiated, register a connector with the coordinator using the [`coordinator.databaseConnector()`](coordinator#databaseconnector) method.

--- a/docs/api/core/coordinator.md
+++ b/docs/api/core/coordinator.md
@@ -77,12 +77,11 @@ The supported _options_ are:
 `coordinator.query(query, options)`
 
 Request a _query_ and return a request Promise that resolves when the query is complete.
-A query result table will be returned, with format determined by the _type_ options.
+An Arrow table will be returned.
 The input _query_ should produce a SQL query upon string coercion.
 
 The supported _options_ are:
 
-- _type_: The return format type. Only `"arrow"` (the default) is supported.
 - _cache_: A Boolean flag (default `true`) indicating if the query result should be cached.
 - _priority_: A value indicating the query priority, one of: `Priority.High`, `Priority.Normal` (the default), or `Priority.Low`.
 

--- a/docs/api/core/coordinator.md
+++ b/docs/api/core/coordinator.md
@@ -82,7 +82,7 @@ The input _query_ should produce a SQL query upon string coercion.
 
 The supported _options_ are:
 
-- _type_: The return format type. One of `"arrow"` (default) or `"json"`.
+- _type_: The return format type. Only `"arrow"` (the default) is supported.
 - _cache_: A Boolean flag (default `true`) indicating if the query result should be cached.
 - _priority_: A value indicating the query priority, one of: `Priority.High`, `Priority.Normal` (the default), or `Priority.Low`.
 

--- a/docs/api/duckdb/data-server.md
+++ b/docs/api/duckdb/data-server.md
@@ -22,7 +22,7 @@ The following _options_ are supported:
 
 Once launched, the data server will accept HTTP POST requests containing JSON content that consists of a single object with the following properties:
 
-- _type_: The type of query. The type `"exec"` indicates that the provided query should be run with no return value. The `"arrow"` and `"json"` types indicate that a result table should be returned in the corresponding format.
+- _type_: The type of query. The type `"exec"` indicates that the provided query should be run with no return value. The `"arrow"` type indicates that the result table should be returned as Arrow IPC bytes.
 - _sql_: The SQL query string to issue to DuckDB.
 
 ### Examples

--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -169,19 +169,17 @@ export class Coordinator {
   query(
     query: QueryType,
     options: {
-      type?: 'arrow';
       cache?: boolean;
       priority?: number;
       [key: string]: unknown;
     } = {}
   ): QueryResult<Table> {
     const {
-      type = 'arrow',
       cache = true,
       priority = Priority.Normal,
       ...otherOptions
     } = options;
-    return this.manager.request({ type, query, cache, options: otherOptions }, priority) as QueryResult<Table>;
+    return this.manager.request({ type: 'arrow', query, cache, options: otherOptions }, priority) as QueryResult<Table>;
   }
 
   /**
@@ -194,7 +192,7 @@ export class Coordinator {
    */
   prefetch(
     query: QueryType,
-    options: { type?: 'arrow'; [key: string]: unknown } = {}
+    options: { [key: string]: unknown } = {}
   ): QueryResult<Table> {
     return this.query(query, { ...options, cache: true, priority: Priority.Low });
   }

--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { SocketConnector } from './connectors/socket.js';
 import { type Connector } from './connectors/Connector.js';
 import { PreAggregator, type PreAggregateOptions } from './preagg/PreAggregator.js';
@@ -169,38 +168,20 @@ export class Coordinator {
    */
   query(
     query: QueryType,
-    options?: {
+    options: {
       type?: 'arrow';
       cache?: boolean;
       priority?: number;
       [key: string]: unknown;
-    }
-  ): QueryResult<Table>;
-  query(
-    query: QueryType,
-    options?: {
-      type?: 'json';
-      cache?: boolean;
-      priority?: number;
-      [key: string]: unknown;
-    }
-  ): QueryResult<unknown>;
-  query(
-    query: QueryType,
-    options: {
-      type?: 'arrow' | 'json';
-      cache?: boolean;
-      priority?: number;
-      [key: string]: unknown;
     } = {}
-  ): QueryResult<any> {
+  ): QueryResult<Table> {
     const {
       type = 'arrow',
       cache = true,
       priority = Priority.Normal,
       ...otherOptions
     } = options;
-    return this.manager.request({ type, query, cache, options: otherOptions }, priority);
+    return this.manager.request({ type, query, cache, options: otherOptions }, priority) as QueryResult<Table>;
   }
 
   /**
@@ -213,16 +194,8 @@ export class Coordinator {
    */
   prefetch(
     query: QueryType,
-    options?: { type?: 'arrow'; [key: string]: unknown }
-  ): QueryResult<Table>
-  prefetch(
-    query: QueryType,
-    options?: { type?: 'json'; [key: string]: unknown }
-  ): QueryResult<unknown>
-  prefetch(
-    query: QueryType,
-    options: any = {}
-  ): QueryResult<any> {
+    options: { type?: 'arrow'; [key: string]: unknown } = {}
+  ): QueryResult<Table> {
     return this.query(query, { ...options, cache: true, priority: Priority.Low });
   }
 

--- a/packages/mosaic/core/src/QueryManager.ts
+++ b/packages/mosaic/core/src/QueryManager.ts
@@ -98,7 +98,7 @@ export class QueryManager {
       }
 
       // @ts-expect-error type may be exec | arrow
-      const promise = this.db!.query({ type, sql: sql!, ...options });
+      const promise = this.db!.query({ ...options, type, sql: sql! });
       if (cache) this.clientCache!.set(sql!, promise);
 
       const data = await promise;

--- a/packages/mosaic/core/src/QueryManager.ts
+++ b/packages/mosaic/core/src/QueryManager.ts
@@ -97,7 +97,7 @@ export class QueryManager {
         this._logger.debug('Query', { type, sql, ...options });
       }
 
-      // @ts-expect-error type may be exec | json | arrow
+      // @ts-expect-error type may be exec | arrow
       const promise = this.db!.query({ type, sql: sql!, ...options });
       if (cache) this.clientCache!.set(sql!, promise);
 

--- a/packages/mosaic/core/src/connectors/Connector.ts
+++ b/packages/mosaic/core/src/connectors/Connector.ts
@@ -17,14 +17,8 @@ export interface ExecQueryRequest extends ConnectorQueryRequest {
   type: 'exec';
 }
 
-export interface JSONQueryRequest extends ConnectorQueryRequest {
-  /** The query type. */
-  type: 'json';
-}
-
 export interface Connector {
   /** Issue a query and return the result. */
   query(query: ArrowQueryRequest): Promise<Table>;
   query(query: ExecQueryRequest): Promise<void>;
-  query(query: JSONQueryRequest): Promise<Record<string, unknown>[]>;
 }

--- a/packages/mosaic/core/src/connectors/NodeConnector.ts
+++ b/packages/mosaic/core/src/connectors/NodeConnector.ts
@@ -5,8 +5,7 @@ import type {
   ArrowQueryRequest,
   Connector,
   ConnectorQueryRequest,
-  ExecQueryRequest,
-  JSONQueryRequest
+  ExecQueryRequest
 } from './Connector.js';
 
 /**
@@ -39,16 +38,10 @@ export class NodeConnector implements Connector {
    */
   async query(query: ArrowQueryRequest): Promise<Table>;
   async query(query: ExecQueryRequest): Promise<void>;
-  async query(query: JSONQueryRequest): Promise<Record<string, unknown>[]>;
   async query(query: ConnectorQueryRequest): Promise<unknown> {
     const { type, sql } = query;
-    switch (type) {
-      case 'exec':
-        return this._db.exec(sql);
-      case 'arrow':
-        return decodeIPC(await this._db.arrowBuffer(sql), this._ipc);
-      default:
-        return this._db.query(sql);
-    }
+    return type === 'exec'
+      ? this._db.exec(sql)
+      : decodeIPC(await this._db.arrowBuffer(sql), this._ipc);
   }
 }

--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -1,5 +1,5 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
-import type { ArrowQueryRequest, Connector, ExecQueryRequest, JSONQueryRequest, ConnectorQueryRequest } from './Connector.js';
+import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import { decodeIPC } from '../util/decode-ipc.js';
 
 interface RestOptions {
@@ -32,7 +32,6 @@ export class RestConnector implements Connector {
 
   async query(query: ArrowQueryRequest): Promise<Table>;
   async query(query: ExecQueryRequest): Promise<void>;
-  async query(query: JSONQueryRequest): Promise<Record<string, unknown>[]>;
   async query(query: ConnectorQueryRequest): Promise<unknown> {
     const req = fetch(this._uri, {
       method: 'POST',
@@ -48,8 +47,8 @@ export class RestConnector implements Connector {
       throw new Error(`Query failed with HTTP status ${res.status}: ${await res.text()}`);
     }
 
-    return query.type === 'exec' ? req
-      : query.type === 'arrow' ? decodeIPC(await res.arrayBuffer(), this._ipc)
-      : res.json();
+    return query.type === 'exec'
+      ? req
+      : decodeIPC(await res.arrayBuffer(), this._ipc);
   }
 }

--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -48,7 +48,7 @@ export class RestConnector implements Connector {
     }
 
     return query.type === 'exec'
-      ? req
+      ? undefined
       : decodeIPC(await res.arrayBuffer(), this._ipc);
   }
 }

--- a/packages/mosaic/core/src/connectors/socket.ts
+++ b/packages/mosaic/core/src/connectors/socket.ts
@@ -1,5 +1,5 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
-import type { ArrowQueryRequest, Connector, ExecQueryRequest, JSONQueryRequest, ConnectorQueryRequest } from './Connector.js';
+import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import { decodeIPC } from '../util/decode-ipc.js';
 
 interface SocketOptions {
@@ -137,7 +137,6 @@ export class SocketConnector implements Connector {
 
   query(query: ArrowQueryRequest): Promise<Table>;
   query(query: ExecQueryRequest): Promise<void>;
-  query(query: JSONQueryRequest): Promise<Record<string, unknown>[]>;
   query(query: ConnectorQueryRequest): Promise<unknown> {
     return new Promise(
       (resolve, reject) => this.enqueue(query, resolve, reject)

--- a/packages/mosaic/core/src/connectors/wasm.ts
+++ b/packages/mosaic/core/src/connectors/wasm.ts
@@ -1,5 +1,5 @@
 import type { ExtractionOptions, Table } from '@uwdata/flechette';
-import type { ArrowQueryRequest, Connector, ExecQueryRequest, JSONQueryRequest, ConnectorQueryRequest } from './Connector.js';
+import type { ArrowQueryRequest, Connector, ExecQueryRequest, ConnectorQueryRequest } from './Connector.js';
 import * as duckdb from '@duckdb/duckdb-wasm';
 import { decodeIPC } from '../util/decode-ipc.js';
 
@@ -74,14 +74,11 @@ export class DuckDBWASMConnector implements Connector {
 
   async query(query: ArrowQueryRequest): Promise<Table>;
   async query(query: ExecQueryRequest): Promise<void>;
-  async query(query: JSONQueryRequest): Promise<Record<string, unknown>[]>;
   async query(query: ConnectorQueryRequest): Promise<unknown> {
     const { type, sql } = query;
     const con = await this.getConnection();
     const result = await getArrowIPC(con, sql);
-    return type === 'exec' ? undefined
-      : type === 'arrow' ? decodeIPC(result, this._ipc)
-      : decodeIPC(result).toArray();
+    return type === 'exec' ? undefined : decodeIPC(result, this._ipc);
   }
 }
 

--- a/packages/mosaic/core/src/types.ts
+++ b/packages/mosaic/core/src/types.ts
@@ -11,7 +11,7 @@ export type QueryType =
 
 /** Type for a query request. */
 export interface QueryRequest {
-  type: 'exec' | 'json' | 'arrow';
+  type: 'exec' | 'arrow';
   query: MaybeArray<QueryType>;
   cache?: boolean;
   options?: Record<string, unknown>;

--- a/packages/mosaic/core/test/coordinator.test.ts
+++ b/packages/mosaic/core/test/coordinator.test.ts
@@ -1,6 +1,7 @@
+import { tableFromArrays } from '@uwdata/flechette';
 import { Query } from '@uwdata/mosaic-sql';
 import { describe, it, expect } from 'vitest';
-import { clausePoint, type Connector, Coordinator, coordinator, type JSONQueryRequest, makeClient, Selection } from '../src/index.js';
+import { type ArrowQueryRequest, clausePoint, type Connector, Coordinator, coordinator, makeClient, Selection } from '../src/index.js';
 import { QueryResult, QueryState } from '../src/util/query-result.js';
 
 async function wait() {
@@ -97,10 +98,10 @@ describe('coordinator', () => {
 
     // Mock the connector
     const connector = {
-      async query(req: JSONQueryRequest) {
+      async query(req: ArrowQueryRequest) {
         const index = req.sql.includes("WHERE") ? 1 : 0;
         events.push(`CONNECT ${index}`);
-        return { index };
+        return tableFromArrays({ index: [index] });
       },
     } as unknown as Connector;
 

--- a/packages/mosaic/core/test/query-manager.test.ts
+++ b/packages/mosaic/core/test/query-manager.test.ts
@@ -1,3 +1,4 @@
+import { Table, tableFromArrays } from '@uwdata/flechette';
 import { describe, it, expect } from 'vitest';
 import { QueryManager } from '../src/QueryManager.js';
 import { QueryResult } from '../src/util/query-result.js';
@@ -12,7 +13,7 @@ describe('QueryManager', () => {
       // @ts-expect-error assumes type value
       query: async ({ sql }) => {
         expect(sql).toBe('SELECT 1');
-        return [{ column: 1 }];
+        return tableFromArrays({ column: [1] });
       }
     });
 
@@ -24,8 +25,8 @@ describe('QueryManager', () => {
     const result = queryManager.request(request);
     expect(result).toBeInstanceOf(QueryResult);
 
-    const data = await result;
-    expect(data).toEqual([{ column: 1 }]);
+    const data = await result as Table;
+    expect(data.toArray()).toEqual([{ column: 1 }]);
   });
 
   it('should not run a query when there is a pending exec', async () => {

--- a/packages/server/bench/bench.py
+++ b/packages/server/bench/bench.py
@@ -68,7 +68,7 @@ BENCHMARKS: list[tuple[str, str, str]] = [
     ("aggregate: count", "arrow", "SELECT count(*) AS cnt FROM flights"),
     (
         "aggregate: min/max",
-        "json",
+        "arrow",
         "SELECT min(delay) AS lo, max(delay) AS hi FROM flights",
     ),
     (
@@ -78,7 +78,7 @@ BENCHMARKS: list[tuple[str, str, str]] = [
     ),
     (
         "group-by small: species",
-        "json",
+        "arrow",
         "SELECT species, count(*) AS cnt, avg(body_mass) AS mean_mass FROM penguins GROUP BY species",
     ),
     # -- histogram / binning (medium results) --
@@ -89,7 +89,7 @@ BENCHMARKS: list[tuple[str, str, str]] = [
     ),
     (
         "group-by: distance stats",
-        "json",
+        "arrow",
         "SELECT distance, count(*) AS cnt, avg(delay) AS mean_delay, min(delay) AS lo, max(delay) AS hi FROM flights GROUP BY distance ORDER BY cnt DESC",
     ),
     (
@@ -264,7 +264,7 @@ def has_cmd(name: str) -> bool:
 def wait_for_server(host: str, port: int, timeout: int = 30) -> bool:
     for _ in range(timeout):
         try:
-            http_post(host, port, {"type": "json", "sql": "SELECT 1"})
+            http_post(host, port, {"type": "arrow", "sql": "SELECT 1"})
             return True
         except Exception:  # ruff: ignore[blind-except]
             time.sleep(1)
@@ -403,7 +403,7 @@ def run_benchmarks(
     # Check server
     print(f"Checking server at http://{host}:{port} ...")
     try:
-        http_post(host, port, {"type": "json", "sql": "SELECT 1"})
+        http_post(host, port, {"type": "arrow", "sql": "SELECT 1"})
     except Exception as e:  # ruff: ignore[blind-except]
         print(f"ERROR: No server responding at http://{host}:{port}: {e}")
         return results

--- a/packages/server/duckdb-server-go/README.md
+++ b/packages/server/duckdb-server-go/README.md
@@ -1,6 +1,6 @@
 # DuckDB Go Server
 
-A Go-based server that runs a local DuckDB instance and support queries over Web Sockets or HTTP/HTTPS, returning data in either [Apache Arrow](https://arrow.apache.org/) or JSON format.
+A Go-based server that runs a local DuckDB instance and support queries over Web Sockets or HTTP/HTTPS, returning data in [Apache Arrow](https://arrow.apache.org/) format.
 
 _Note:_ This package provides a local DuckDB server. To instead use DuckDB-WASM in the browser, use the `wasmConnector` in the [`mosaic-core`](https://github.com/uwdata/mosaic/tree/main/packages/mosaic/mosaic-core) package.
 
@@ -191,7 +191,7 @@ is a useful autoloading cross-check, but it is not exhaustive: the pinned Azure 
 Trusted initialization can still load filesystem extensions and attach remote Iceberg or other catalogs before accepting
 queries. Queries against those attached catalogs use catalog and table identifiers rather than caller-supplied URI
 literals, so they remain usable. Enabling this policy rejects all `exec` commands and rejects the known nested-SQL
-binders and executors `query`, `json_execute_serialized_sql`, and `json_serialize_plan` outright. `json` and `arrow`
+binders and executors `query`, `json_execute_serialized_sql`, and `json_serialize_plan` outright. `arrow`
 requests are limited to statements DuckDB can serialize for validation. Connector initialization is outside that command
 path.
 
@@ -243,7 +243,7 @@ when DuckDB or its extensions change. To restrict file-reading functions, also e
 scans such as `FROM 'data.parquet'` are rejected as unqualified table references. These controls are not a sandbox: run the
 server with access only to external resources that are safe for every tenant.
 
-If `--schema-match-headers`, `--function-blocklist`, or `--function-allowlist` is configured, `json` and `arrow` requests
+If `--schema-match-headers`, `--function-blocklist`, or `--function-allowlist` is configured, `arrow` requests
 are limited to statements DuckDB can serialize for validation; unsupported forms such as `PRAGMA` and `SET` are rejected,
 with HTTP requests receiving a 400 response. All `exec` requests are also rejected until full-statement authorization is
 supported. This includes every `Coordinator.exec(...)` call, such as data loading, preloading, and DDL/DML. Mosaic
@@ -251,7 +251,7 @@ pre-aggregation also uses `exec` to create schemas and tables, so set `preagg: {
 
 ## API
 
-The server supports queries via HTTP GET and POST, and WebSockets. The GET endpoint is useful for debugging. For example, you can query it with [this url](<http://localhost:3000/?query={"sql":"select 1","type":"json"}>).
+The server supports queries via HTTP GET and POST, and WebSockets. The GET endpoint is useful for debugging. For example, you can query it with [this url](<http://localhost:3000/?query={"sql":"select 1","type":"arrow"}>).
 
 Each endpoint takes a JSON object with a command in the `type`. The server supports the following commands.
 
@@ -262,10 +262,6 @@ Executes the SQL query in the `sql` field.
 ### `arrow`
 
 Executes the SQL query in the `sql` field and returns the result in Apache Arrow format.
-
-### `json`
-
-Executes the SQL query in the `sql` field and returns the result in JSON format.
 
 ## Developers
 

--- a/packages/server/duckdb-server-go/pkg/query/options_test.go
+++ b/packages/server/duckdb-server-go/pkg/query/options_test.go
@@ -93,7 +93,7 @@ func TestNewNormalizesCustomFunctionOptions(t *testing.T) {
 		require.NoError(t, connector.Close())
 	})
 
-	_, err = db.QueryJSON(t.Context(), "SELECT md5('mosaic')", nil)
+	_, err = db.QueryArrow(t.Context(), "SELECT md5('mosaic')", nil)
 	require.NoError(t, err)
 }
 

--- a/packages/server/duckdb-server-go/pkg/query/query.go
+++ b/packages/server/duckdb-server-go/pkg/query/query.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -204,81 +203,6 @@ func (db *DB) validateQuery(ctx context.Context, query string, allowedSchemas []
 	err := db.ValidateSQL(ctx, query, validators...)
 	if err != nil {
 		return fmt.Errorf("query: validation failed: %w", err)
-	}
-
-	return nil
-}
-
-func (db *DB) QueryJSON(ctx context.Context, query string, allowedSchemas []string) (json.RawMessage, error) {
-	err := db.validateQuery(ctx, query, allowedSchemas)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-
-	err = db.writeJSON(ctx, query, &buf)
-	if err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
-}
-
-func (db *DB) WriteJSON(ctx context.Context, query string, allowedSchemas []string, w io.Writer) error {
-	err := db.validateQuery(ctx, query, allowedSchemas)
-	if err != nil {
-		return err
-	}
-
-	return db.writeJSON(ctx, query, w)
-}
-
-// SECURITY: writeJSON executes without policy validation. Call it only after validateQuery succeeds for the same query
-// and request-scoped allowed schemas.
-func (db *DB) writeJSON(ctx context.Context, query string, w io.Writer) error {
-	arrow, err := db.getArrowConn(ctx)
-	if err != nil {
-		return err
-	}
-	defer db.putArrowConn(arrow)
-
-	rdr, err := arrow.QueryContext(ctx, query)
-	if err != nil {
-		return fmt.Errorf("query: failed to execute query: %w", err)
-	}
-	defer rdr.Release()
-
-	_, err = w.Write([]byte("["))
-	if err != nil {
-		return fmt.Errorf("query: failed to write start of JSON array: %w", err)
-	}
-
-	for i := 0; rdr.Next(); i++ {
-		if i > 0 {
-			_, err = w.Write([]byte(","))
-			if err != nil {
-				return fmt.Errorf("query: failed to write comma between records: %w", err)
-			}
-		}
-
-		var jsonBytes []byte
-		jsonBytes, err = rdr.RecordBatch().MarshalJSON()
-		if err != nil {
-			return fmt.Errorf("failed to marshal record to JSON: %w", err)
-		}
-
-		// a record is a batch of rows, and MarshalJSON returns a JSON array of objects. If there are multiple records,
-		// we want a combined JSON array of objects, not an array of arrays, so we trim the outer brackets
-		_, err = w.Write(jsonBytes[1 : len(jsonBytes)-1])
-		if err != nil {
-			return fmt.Errorf("failed to write JSON to writer: %w", err)
-		}
-	}
-
-	_, err = w.Write([]byte("]"))
-	if err != nil {
-		return fmt.Errorf("query: failed to write end of JSON array: %w", err)
 	}
 
 	return nil

--- a/packages/server/duckdb-server-go/pkg/query/query_test.go
+++ b/packages/server/duckdb-server-go/pkg/query/query_test.go
@@ -1,12 +1,14 @@
 package query
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log/slog"
 	"os"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/duckdb/duckdb-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,6 +45,27 @@ func setupTestDB(t *testing.T, opts ...OptionFunc) *DB {
 	return db
 }
 
+func arrowRows(t *testing.T, data []byte) []map[string]any {
+	t.Helper()
+
+	rdr, err := ipc.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	defer rdr.Release()
+
+	rows := []map[string]any{}
+	for rdr.Next() {
+		batchJSON, err := rdr.RecordBatch().MarshalJSON()
+		require.NoError(t, err)
+
+		var batch []map[string]any
+		require.NoError(t, json.Unmarshal(batchJSON, &batch))
+		rows = append(rows, batch...)
+	}
+	require.NoError(t, rdr.Err())
+
+	return rows
+}
+
 func TestDB_FunctionBlocklist(t *testing.T) {
 	db := setupTestDB(t, WithFunctionBlocklist([]string{" RANGE ", "MD5", "SUM", "ROW_NUMBER"}))
 	ctx := context.Background()
@@ -51,48 +74,16 @@ func TestDB_FunctionBlocklist(t *testing.T) {
 		name     string
 		function string
 		query    string
-		format   string
 	}{
-		{
-			name:     "JSON table function",
-			function: "range",
-			query:    "SELECT * FROM range(3)",
-			format:   "json",
-		},
-		{
-			name:     "JSON scalar function",
-			function: "md5",
-			query:    "SELECT md5('mosaic')",
-			format:   "json",
-		},
-		{
-			name:     "JSON window aggregate",
-			function: "sum",
-			query:    "SELECT sum(i) OVER () FROM (VALUES (1), (2), (3)) t(i)",
-			format:   "json",
-		},
-		{
-			name:     "JSON window function",
-			function: "row_number",
-			query:    "SELECT row_number() OVER ()",
-			format:   "json",
-		},
-		{
-			name:     "Arrow table function",
-			function: "range",
-			query:    "SELECT * FROM range(3)",
-			format:   "arrow",
-		},
+		{name: "table function", function: "range", query: "SELECT * FROM range(3)"},
+		{name: "scalar function", function: "md5", query: "SELECT md5('mosaic')"},
+		{name: "window aggregate", function: "sum", query: "SELECT sum(i) OVER () FROM (VALUES (1), (2), (3)) t(i)"},
+		{name: "window function", function: "row_number", query: "SELECT row_number() OVER ()"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var err error
-			if tt.format == "arrow" {
-				_, err = db.QueryArrow(ctx, tt.query, nil)
-			} else {
-				_, err = db.QueryJSON(ctx, tt.query, nil)
-			}
+			_, err := db.QueryArrow(ctx, tt.query, nil)
 
 			require.ErrorContains(t, err, "use of function '"+tt.function+"' is not allowed")
 		})
@@ -109,28 +100,22 @@ func TestDB_FunctionAllowlist(t *testing.T) {
 		}))
 
 		tests := []struct {
-			name   string
-			query  string
-			format string
+			name  string
+			query string
 		}{
-			{name: "scalar function", query: "SELECT md5('mosaic')", format: "json"},
-			{name: "window function", query: "SELECT row_number() OVER ()", format: "json"},
-			{name: "operator", query: "SELECT 1 + 2", format: "json"},
-			{name: "Arrow table function", query: "SELECT * FROM range(3)", format: "arrow"},
-			{name: "normalized function name", query: "SELECT count(*)", format: "json"},
-			{name: "main-qualified function", query: "SELECT main.md5('mosaic')", format: "json"},
-			{name: "main-qualified normalized function", query: "SELECT main.count(*) FROM (SELECT 1)", format: "json"},
-			{name: "helper over qualified column", query: "SELECT [main.x] FROM (SELECT 1 AS x) AS main", format: "json"},
+			{name: "scalar function", query: "SELECT md5('mosaic')"},
+			{name: "window function", query: "SELECT row_number() OVER ()"},
+			{name: "operator", query: "SELECT 1 + 2"},
+			{name: "table function", query: "SELECT * FROM range(3)"},
+			{name: "normalized function name", query: "SELECT count(*)"},
+			{name: "main-qualified function", query: "SELECT main.md5('mosaic')"},
+			{name: "main-qualified normalized function", query: "SELECT main.count(*) FROM (SELECT 1)"},
+			{name: "helper over qualified column", query: "SELECT [main.x] FROM (SELECT 1 AS x) AS main"},
 		}
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				var err error
-				if tt.format == "arrow" {
-					_, err = db.QueryArrow(ctx, tt.query, nil)
-				} else {
-					_, err = db.QueryJSON(ctx, tt.query, nil)
-				}
+				_, err := db.QueryArrow(ctx, tt.query, nil)
 				require.NoError(t, err)
 			})
 		}
@@ -142,7 +127,7 @@ func TestDB_FunctionAllowlist(t *testing.T) {
 			Include:         []string{"md"},
 		}))
 
-		_, err := db.QueryJSON(ctx, "SELECT md5('mosaic')", nil)
+		_, err := db.QueryArrow(ctx, "SELECT md5('mosaic')", nil)
 		require.ErrorIs(t, err, ErrAccessDenied)
 		require.ErrorContains(t, err, "function 'md5' is not in the allowlist")
 	})
@@ -153,7 +138,7 @@ func TestDB_FunctionAllowlist(t *testing.T) {
 			Include:         []string{"md5"},
 		}))
 
-		_, err := db.QueryJSON(ctx, "SELECT md5(lower('mosaic'))", nil)
+		_, err := db.QueryArrow(ctx, "SELECT md5(lower('mosaic'))", nil)
 		require.ErrorIs(t, err, ErrAccessDenied)
 		require.ErrorContains(t, err, "function 'lower' is not in the allowlist")
 	})
@@ -178,7 +163,7 @@ func TestDB_FunctionAllowlist(t *testing.T) {
 			Include:         []string{"read_parquet"},
 		}))
 
-		_, err := db.QueryJSON(ctx, "SELECT * FROM read_parquet(['local.parquet'])", nil)
+		_, err := db.QueryArrow(ctx, "SELECT * FROM read_parquet(['local.parquet'])", nil)
 		require.ErrorIs(t, err, ErrAccessDenied)
 		require.ErrorContains(t, err, "function 'list_value' is not in the allowlist")
 	})
@@ -201,7 +186,7 @@ func TestDB_FunctionAllowlist(t *testing.T) {
 			"SELECT strptime('2020-01-01', '%Y-%m-%d')",
 			"SELECT * FROM range(3)",
 		} {
-			_, err := db.QueryJSON(ctx, query, nil)
+			_, err := db.QueryArrow(ctx, query, nil)
 			require.NoError(t, err, query)
 		}
 	})
@@ -231,7 +216,7 @@ func TestDB_FunctionAllowlist(t *testing.T) {
 	t.Run("defaults reject unsafe name collisions", func(t *testing.T) {
 		db := setupTestDB(t, WithFunctionAllowlist(FunctionAllowlistOptions{}))
 
-		_, err := db.QueryJSON(ctx, "SELECT * FROM histogram('duckdb_tables', 'table_name')", nil)
+		_, err := db.QueryArrow(ctx, "SELECT * FROM histogram('duckdb_tables', 'table_name')", nil)
 		require.ErrorIs(t, err, ErrAccessDenied)
 		require.ErrorContains(t, err, "function 'histogram' is not in the allowlist")
 	})
@@ -257,7 +242,7 @@ func TestDB_FunctionAllowlist(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.function, func(t *testing.T) {
-				_, err := db.QueryJSON(ctx, tt.query, nil)
+				_, err := db.QueryArrow(ctx, tt.query, nil)
 				require.ErrorIs(t, err, ErrAccessDenied)
 				require.ErrorContains(t, err, "function '"+tt.function+"' is not in the allowlist")
 			})
@@ -267,10 +252,10 @@ func TestDB_FunctionAllowlist(t *testing.T) {
 	t.Run("defaults can be disabled", func(t *testing.T) {
 		db := setupTestDB(t, WithFunctionAllowlist(FunctionAllowlistOptions{DisableDefaults: true}))
 
-		_, err := db.QueryJSON(ctx, "SELECT 1", nil)
+		_, err := db.QueryArrow(ctx, "SELECT 1", nil)
 		require.NoError(t, err)
 
-		_, err = db.QueryJSON(ctx, "SELECT 1 + 2", nil)
+		_, err = db.QueryArrow(ctx, "SELECT 1 + 2", nil)
 		require.ErrorIs(t, err, ErrAccessDenied)
 		require.ErrorContains(t, err, "function '+' is not in the allowlist")
 	})
@@ -280,10 +265,10 @@ func TestDB_FunctionAllowlist(t *testing.T) {
 			Exclude: []string{" SUM "},
 		}))
 
-		_, err := db.QueryJSON(ctx, "SELECT 1 + 2", nil)
+		_, err := db.QueryArrow(ctx, "SELECT 1 + 2", nil)
 		require.NoError(t, err)
 
-		_, err = db.QueryJSON(ctx, "SELECT sum(i) FROM (VALUES (1), (2)) t(i)", nil)
+		_, err = db.QueryArrow(ctx, "SELECT sum(i) FROM (VALUES (1), (2)) t(i)", nil)
 		require.ErrorIs(t, err, ErrAccessDenied)
 		require.ErrorContains(t, err, "function 'sum' is not in the allowlist")
 	})
@@ -292,30 +277,19 @@ func TestDB_FunctionAllowlist(t *testing.T) {
 func TestDB_FunctionAllowlistHandlesUnsupportedStatements(t *testing.T) {
 	db := setupTestDB(t, WithFunctionAllowlist(FunctionAllowlistOptions{}))
 
-	_, err := db.QueryJSON(t.Context(), "PRAGMA version", nil)
+	_, err := db.QueryArrow(t.Context(), "PRAGMA version", nil)
 	require.ErrorIs(t, err, ErrUnsupportedStatement)
 	require.ErrorContains(t, err, "query: validation failed: query: not implemented: Only SELECT statements can be serialized to json")
 }
 
 func TestDB_FunctionBlocklistHandlesUnsupportedStatements(t *testing.T) {
 	db := setupTestDB(t, WithFunctionBlocklist([]string{"range"}))
-	ctx := context.Background()
 
-	t.Run("JSON", func(t *testing.T) {
-		_, err := db.QueryJSON(ctx, "PRAGMA version", nil)
-		require.ErrorIs(t, err, ErrUnsupportedStatement)
-		require.ErrorContains(t, err, "query: validation failed: query: not implemented: Only SELECT statements can be serialized to json")
-		require.NotContains(t, err.Error(), "()")
-		require.NotContains(t, err.Error(), " at :")
-	})
-
-	t.Run("Arrow", func(t *testing.T) {
-		_, err := db.QueryArrow(ctx, "PRAGMA version", nil)
-		require.ErrorIs(t, err, ErrUnsupportedStatement)
-		require.ErrorContains(t, err, "query: validation failed: query: not implemented: Only SELECT statements can be serialized to json")
-		require.NotContains(t, err.Error(), "()")
-		require.NotContains(t, err.Error(), " at :")
-	})
+	_, err := db.QueryArrow(t.Context(), "PRAGMA version", nil)
+	require.ErrorIs(t, err, ErrUnsupportedStatement)
+	require.ErrorContains(t, err, "query: validation failed: query: not implemented: Only SELECT statements can be serialized to json")
+	require.NotContains(t, err.Error(), "()")
+	require.NotContains(t, err.Error(), " at :")
 }
 
 func TestDB_Exec(t *testing.T) {
@@ -358,11 +332,10 @@ func TestDB_Exec(t *testing.T) {
 	})
 }
 
-func TestDB_QueryJSON(t *testing.T) {
+func TestDB_QueryArrowRows(t *testing.T) {
 	db := setupTestDB(t)
 	ctx := context.Background()
 
-	// Setup test data
 	err := db.Exec(ctx, "CREATE TABLE products (id INTEGER, name VARCHAR, price DECIMAL)")
 	require.NoError(t, err)
 	err = db.Exec(ctx, "INSERT INTO products VALUES (1, 'Apple', 1.50), (2, 'Banana', 0.75), (3, 'Orange', 2.00), (NULL, NULL, NULL)")
@@ -379,30 +352,20 @@ func TestDB_QueryJSON(t *testing.T) {
 	}
 
 	t.Run("simple select", func(t *testing.T) {
-		gotJSON, err := db.QueryJSON(ctx, query, nil)
+		got, err := db.QueryArrow(ctx, query, nil)
 		require.NoError(t, err)
-
-		// Verify JSON structure
-		var got []map[string]any
-		err = json.Unmarshal(gotJSON, &got)
-		require.NoError(t, err)
-		assert.Equal(t, want, got)
+		assert.Equal(t, want, arrowRows(t, got))
 	})
 
 	t.Run("invalid query", func(t *testing.T) {
-		_, err := db.QueryJSON(ctx, "SELECT * FROM nonexistent_table", nil)
+		_, err := db.QueryArrow(ctx, "SELECT * FROM nonexistent_table", nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("empty result set", func(t *testing.T) {
-		result, err := db.QueryJSON(ctx, "SELECT * FROM products WHERE id > 100", nil)
+		result, err := db.QueryArrow(ctx, "SELECT * FROM products WHERE id > 100", nil)
 		require.NoError(t, err)
-
-		var data []any
-		err = json.Unmarshal(result, &data)
-		require.NoError(t, err)
-		assert.Len(t, data, 0)
-		assert.Equal(t, "[]", string(result))
+		assert.Empty(t, arrowRows(t, result))
 	})
 }
 

--- a/packages/server/duckdb-server-go/pkg/query/remote_uri_test.go
+++ b/packages/server/duckdb-server-go/pkg/query/remote_uri_test.go
@@ -348,28 +348,28 @@ func TestDBRemoteURILiteralRejection(t *testing.T) {
 
 	db := setupTestDB(t, WithRemoteURILiteralRejection())
 
-	data, err := db.QueryJSON(t.Context(), "SELECT * FROM read_csv("+quoteLiteral(path)+")", nil)
+	data, err := db.QueryArrow(t.Context(), "SELECT * FROM read_csv("+quoteLiteral(path)+")", nil)
 	require.NoError(t, err)
-	assert.JSONEq(t, `[{"value": 42}]`, string(data))
+	assert.Equal(t, []map[string]any{{"value": float64(42)}}, arrowRows(t, data))
 
 	list := fmt.Sprintf("[%s, %s]", quoteLiteral(path), quoteLiteral(secondPath))
-	data, err = db.QueryJSON(t.Context(), "SELECT * FROM read_csv("+list+") ORDER BY value", nil)
+	data, err = db.QueryArrow(t.Context(), "SELECT * FROM read_csv("+list+") ORDER BY value", nil)
 	require.NoError(t, err)
-	assert.JSONEq(t, `[{"value": 42}, {"value": 43}]`, string(data))
+	assert.Equal(t, []map[string]any{{"value": float64(42)}, {"value": float64(43)}}, arrowRows(t, data))
 
-	data, err = db.QueryJSON(t.Context(), "SELECT 'https://example.com' AS url WHERE url = 'https://example.com'", nil)
+	data, err = db.QueryArrow(t.Context(), "SELECT 'https://example.com' AS url WHERE url = 'https://example.com'", nil)
 	require.NoError(t, err)
-	assert.JSONEq(t, `[{"url": "https://example.com"}]`, string(data))
+	assert.Equal(t, []map[string]any{{"url": "https://example.com"}}, arrowRows(t, data))
 
-	_, err = db.QueryJSON(t.Context(), "SELECT * FROM read_csv('https://example.com/file.csv')", nil)
+	_, err = db.QueryArrow(t.Context(), "SELECT * FROM read_csv('https://example.com/file.csv')", nil)
 	require.ErrorIs(t, err, ErrAccessDenied)
 	assert.ErrorContains(t, err, "remote URI prefix 'https://' is not allowed in path argument to function 'read_csv'")
 
-	_, err = db.QueryJSON(t.Context(), "SELECT * FROM query('SELECT 42')", nil)
+	_, err = db.QueryArrow(t.Context(), "SELECT * FROM query('SELECT 42')", nil)
 	require.ErrorIs(t, err, ErrAccessDenied)
 	assert.ErrorContains(t, err, "nested SQL executor 'query' is not allowed")
 
-	_, err = db.QueryJSON(
+	_, err = db.QueryArrow(
 		t.Context(),
 		"SELECT json_serialize_plan('SELECT * FROM read_csv(''https://example.com/file.csv'')')",
 		nil,
@@ -377,7 +377,7 @@ func TestDBRemoteURILiteralRejection(t *testing.T) {
 	require.ErrorIs(t, err, ErrAccessDenied)
 	assert.ErrorContains(t, err, "nested SQL executor 'json_serialize_plan' is not allowed")
 
-	_, err = db.QueryJSON(
+	_, err = db.QueryArrow(
 		t.Context(),
 		"SELECT system.json_serialize_plan('SELECT * FROM read_csv(''https://example.com/file.csv'')')",
 		nil,
@@ -386,14 +386,14 @@ func TestDBRemoteURILiteralRejection(t *testing.T) {
 	assert.ErrorContains(t, err, "nested SQL executor 'json_serialize_plan' is not allowed")
 
 	autocompleteSQL := "SELECT * FROM '" + filepath.Join(filepath.Dir(path), "loc")
-	_, err = db.QueryJSON(
+	_, err = db.QueryArrow(
 		t.Context(),
 		"SELECT * FROM sql_auto_complete("+quoteLiteral(autocompleteSQL)+", max_file_suggestion_count := 10)",
 		nil,
 	)
 	require.NoError(t, err)
 
-	_, err = db.QueryJSON(
+	_, err = db.QueryArrow(
 		t.Context(),
 		"SELECT * FROM sql_auto_complete('SELECT * FROM ''S3://no-such-bucket/file', max_file_suggestion_count := 10)",
 		nil,
@@ -401,7 +401,7 @@ func TestDBRemoteURILiteralRejection(t *testing.T) {
 	require.ErrorIs(t, err, ErrAccessDenied)
 	assert.ErrorContains(t, err, "remote URI prefix 's3://' is not allowed in path argument to function 'sql_auto_complete'")
 
-	_, err = db.QueryJSON(t.Context(), "PRAGMA import_database('s3://bucket/export')", nil)
+	_, err = db.QueryArrow(t.Context(), "PRAGMA import_database('s3://bucket/export')", nil)
 	require.ErrorIs(t, err, ErrUnsupportedStatement)
 
 	err = db.Exec(t.Context(), "SELECT 1")

--- a/packages/server/duckdb-server-go/pkg/server/authorization.go
+++ b/packages/server/duckdb-server-go/pkg/server/authorization.go
@@ -19,7 +19,6 @@ type CommandType string
 const (
 	CommandArrow CommandType = "arrow"
 	CommandExec  CommandType = "exec"
-	CommandJSON  CommandType = "json"
 )
 
 // Command is the immutable command information presented for authorization.

--- a/packages/server/duckdb-server-go/pkg/server/authorization_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/authorization_test.go
@@ -26,7 +26,6 @@ type spyCommandExecutor struct {
 	failOnCallExecutor
 	exec       func(context.Context, string) error
 	queryArrow func(context.Context, string, []string) ([]byte, error)
-	queryJSON  func(context.Context, string, []string) (json.RawMessage, error)
 }
 
 func (s *spyCommandExecutor) Exec(ctx context.Context, sql string) error {
@@ -43,13 +42,6 @@ func (s *spyCommandExecutor) QueryArrow(ctx context.Context, sql string, schemas
 	return s.queryArrow(ctx, sql, schemas)
 }
 
-func (s *spyCommandExecutor) QueryJSON(ctx context.Context, sql string, schemas []string) (json.RawMessage, error) {
-	if s.queryJSON == nil {
-		return s.failOnCallExecutor.QueryJSON(ctx, sql, schemas)
-	}
-	return s.queryJSON(ctx, sql, schemas)
-}
-
 func TestCommandDenialPrecedesExecutor(t *testing.T) {
 	var executorCalls int
 	spy := &spyCommandExecutor{
@@ -62,10 +54,6 @@ func TestCommandDenialPrecedesExecutor(t *testing.T) {
 			executorCalls++
 			return nil, nil
 		},
-		queryJSON: func(context.Context, string, []string) (json.RawMessage, error) {
-			executorCalls++
-			return json.RawMessage(`[]`), nil
-		},
 	}
 
 	handler := mustHandler(t, spy, WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
@@ -74,7 +62,7 @@ func TestCommandDenialPrecedesExecutor(t *testing.T) {
 		}, nil
 	})))
 
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"SELECT * FROM sensitive_data"}`))
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"arrow","sql":"SELECT * FROM sensitive_data"}`))
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
 
@@ -92,29 +80,29 @@ func TestCommandAuthorizationRunsImmediatelyBeforeExecutor(t *testing.T) {
 
 	spy := &spyCommandExecutor{
 		failOnCallExecutor: failOnCallExecutor{t},
-		queryJSON: func(_ context.Context, gotSQL string, schemas []string) (json.RawMessage, error) {
+		queryArrow: func(_ context.Context, gotSQL string, schemas []string) ([]byte, error) {
 			appendEvent("executor")
 			require.Equal(t, sql, gotSQL)
 			require.Empty(t, schemas)
-			return json.RawMessage(`[{"value":1}]`), nil
+			return []byte("result"), nil
 		},
 	}
 
 	handler := mustHandler(t, spy, WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
 		return func(_ context.Context, command Command) error {
 			appendEvent("authorize")
-			require.Equal(t, CommandJSON, command.Type())
+			require.Equal(t, CommandArrow, command.Type())
 			require.Equal(t, sql, command.SQL())
 			return nil
 		}, nil
 	})))
 
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"SELECT 1 AS value"}`))
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"arrow","sql":"SELECT 1 AS value"}`))
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusOK, res.Code, res.Body.String())
-	require.JSONEq(t, `[{"value":1}]`, res.Body.String())
+	require.Equal(t, "result", res.Body.String())
 	require.Equal(t, []string{"authorize", "executor"}, events)
 }
 
@@ -125,9 +113,9 @@ func TestCanceledRequestContextReachesAuthorizationAndExecutor(t *testing.T) {
 
 	spy := &spyCommandExecutor{
 		failOnCallExecutor: failOnCallExecutor{t},
-		queryJSON: func(ctx context.Context, _ string, _ []string) (json.RawMessage, error) {
+		queryArrow: func(ctx context.Context, _ string, _ []string) ([]byte, error) {
 			executorContextErr = ctx.Err()
-			return json.RawMessage(`[]`), nil
+			return nil, nil
 		},
 	}
 
@@ -141,7 +129,7 @@ func TestCanceledRequestContextReachesAuthorizationAndExecutor(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"SELECT 1"}`)).WithContext(ctx)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"arrow","sql":"SELECT 1"}`)).WithContext(ctx)
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
 
@@ -159,9 +147,9 @@ func TestAuthorizerHandlesConcurrentRequests(t *testing.T) {
 	var executorCalls atomic.Int32
 	spy := &spyCommandExecutor{
 		failOnCallExecutor: failOnCallExecutor{t},
-		queryJSON: func(context.Context, string, []string) (json.RawMessage, error) {
+		queryArrow: func(context.Context, string, []string) ([]byte, error) {
 			executorCalls.Add(1)
-			return json.RawMessage(`[]`), nil
+			return nil, nil
 		},
 	}
 
@@ -179,7 +167,7 @@ func TestAuthorizerHandlesConcurrentRequests(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"SELECT 1"}`))
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"arrow","sql":"SELECT 1"}`))
 			res := httptest.NewRecorder()
 			handler.ServeHTTP(res, req)
 			statuses <- res.Code
@@ -213,7 +201,7 @@ func TestHTTPAuthorizerReceivesExactValidatedCommandAndRequestContext(t *testing
 			new: func(t *testing.T) *http.Request {
 				t.Helper()
 				values := make(url.Values)
-				values.Set("type", string(CommandJSON))
+				values.Set("type", string(CommandArrow))
 				values.Set("sql", sql)
 				return httptest.NewRequest(http.MethodGet, "/?"+values.Encode(), nil)
 			},
@@ -223,7 +211,7 @@ func TestHTTPAuthorizerReceivesExactValidatedCommandAndRequestContext(t *testing
 			new: func(t *testing.T) *http.Request {
 				t.Helper()
 				body, err := json.Marshal(map[string]any{
-					"type": CommandJSON,
+					"type": CommandArrow,
 					"sql":  sql,
 				})
 				require.NoError(t, err)
@@ -245,7 +233,7 @@ func TestHTTPAuthorizerReceivesExactValidatedCommandAndRequestContext(t *testing
 				return func(ctx context.Context, command Command) error {
 					commandCalls.Add(1)
 					require.Equal(t, identity, ctx.Value(authorizationContextKey{}))
-					require.Equal(t, CommandJSON, command.Type())
+					require.Equal(t, CommandArrow, command.Type())
 					require.Equal(t, sql, command.SQL())
 					return nil
 				}, nil
@@ -405,7 +393,7 @@ func TestHTTPAuthorizerConfigurationFailsClosed(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(tt.authorizer))
 
-			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"SELECT 1"}`))
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"arrow","sql":"SELECT 1"}`))
 			res := httptest.NewRecorder()
 			handler.ServeHTTP(res, req)
 
@@ -428,7 +416,7 @@ func TestHTTPValidationPrecedesCommandAuthorization(t *testing.T) {
 
 	handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(authorizer))
 
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json"}`))
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"arrow"}`))
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, req)
 
@@ -611,12 +599,12 @@ func TestWebSocketAuthorizesEveryMessageAndKeepsConnectionAfterDenial(t *testing
 
 	// A command denial is an application response, not a connection failure.
 	require.NoError(t, wsjson.Write(server.ctx, conn, map[string]any{
-		"type": CommandJSON,
+		"type": CommandArrow,
 		"sql":  allowedSQL,
 	}))
-	var rows []map[string]int
-	require.NoError(t, wsjson.Read(server.ctx, conn, &rows))
-	require.Equal(t, []map[string]int{{"value": 9}}, rows)
+	_, payload, err := conn.Read(server.ctx)
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{{"value": float64(9)}}, arrowRows(t, payload))
 
 	require.Equal(t, int32(1), requestCalls.Load())
 	require.Equal(t, int32(2), commandCalls.Load())
@@ -631,7 +619,7 @@ func TestWebSocketAuthorizesEveryMessageAndKeepsConnectionAfterDenial(t *testing
 	require.Equal(t, observation{
 		requestIdentity: identity,
 		commandIdentity: identity,
-		typ:             CommandJSON,
+		typ:             CommandArrow,
 		sql:             allowedSQL,
 	}, second)
 }
@@ -685,7 +673,7 @@ func TestWebSocketCommandAuthorizationErrorMapping(t *testing.T) {
 			}()
 
 			require.NoError(t, wsjson.Write(server.ctx, conn, map[string]any{
-				"type": CommandJSON,
+				"type": CommandArrow,
 				"sql":  "SELECT 1",
 			}))
 			var response struct {

--- a/packages/server/duckdb-server-go/pkg/server/server.go
+++ b/packages/server/duckdb-server-go/pkg/server/server.go
@@ -30,7 +30,6 @@ type commandResponse struct {
 var commandResponses = map[CommandType]commandResponse{
 	CommandExec:  {wsMessage: websocket.MessageText},
 	CommandArrow: {contentType: "application/vnd.apache.arrow.stream", wsMessage: websocket.MessageBinary},
-	CommandJSON:  {contentType: "application/json", wsMessage: websocket.MessageText},
 }
 
 type queryParamsError string
@@ -44,7 +43,6 @@ func (e queryParamsError) Error() string {
 type commandExecutor interface {
 	Exec(context.Context, string) error
 	QueryArrow(context.Context, string, []string) ([]byte, error)
-	QueryJSON(context.Context, string, []string) (json.RawMessage, error)
 }
 
 type handler struct {
@@ -283,9 +281,6 @@ func (s *handler) execCommand(ctx context.Context, params queryParams, allowedSc
 
 	case CommandArrow:
 		response.data, err = s.db.QueryArrow(ctx, command.SQL(), allowedSchemas)
-
-	case CommandJSON:
-		response.data, err = s.db.QueryJSON(ctx, command.SQL(), allowedSchemas)
 
 	default:
 		return commandResponse{}, fmt.Errorf("server: no executor for command type %q", command.Type())

--- a/packages/server/duckdb-server-go/pkg/server/server_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
 	"github.com/duckdb/duckdb-go/v2"
@@ -53,15 +55,32 @@ func (e failOnCallExecutor) QueryArrow(context.Context, string, []string) ([]byt
 	return nil, e.fail("QueryArrow")
 }
 
-func (e failOnCallExecutor) QueryJSON(context.Context, string, []string) (json.RawMessage, error) {
-	return nil, e.fail("QueryJSON")
-}
-
 func (e failOnCallExecutor) fail(method string) error {
 	e.Helper()
 	err := fmt.Errorf("unexpected command executor call: %s", method)
 	e.Error(err)
 	return err
+}
+
+func arrowRows(t *testing.T, data []byte) []map[string]any {
+	t.Helper()
+
+	rdr, err := ipc.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	defer rdr.Release()
+
+	rows := []map[string]any{}
+	for rdr.Next() {
+		batchJSON, err := rdr.RecordBatch().MarshalJSON()
+		require.NoError(t, err)
+
+		var batch []map[string]any
+		require.NoError(t, json.Unmarshal(batchJSON, &batch))
+		rows = append(rows, batch...)
+	}
+	require.NoError(t, rdr.Err())
+
+	return rows
 }
 
 type webSocketTestServer struct {
@@ -140,7 +159,7 @@ func TestHandleHTTPPolicyErrors(t *testing.T) {
 			Include:         []string{"lower"},
 		}))
 		s := mustHandler(t, db)
-		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"SELECT md5('mosaic')"}`))
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"arrow","sql":"SELECT md5('mosaic')"}`))
 		res := httptest.NewRecorder()
 
 		s.ServeHTTP(res, req)
@@ -152,7 +171,7 @@ func TestHandleHTTPPolicyErrors(t *testing.T) {
 	t.Run("blocked function is forbidden", func(t *testing.T) {
 		db := setupTestDB(t, query.WithFunctionBlocklist([]string{"md5"}))
 		s := mustHandler(t, db)
-		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"SELECT md5('mosaic')"}`))
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"arrow","sql":"SELECT md5('mosaic')"}`))
 		res := httptest.NewRecorder()
 
 		s.ServeHTTP(res, req)
@@ -166,7 +185,7 @@ func TestHandleHTTPPolicyErrors(t *testing.T) {
 		require.NoError(t, db.Exec(t.Context(), "CREATE SCHEMA tenant_a; CREATE TABLE tenant_a.secret (value INTEGER)"))
 
 		s := mustHandler(t, db, WithSchemaMatchHeaders("X-Tenant"))
-		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"SELECT * FROM tenant_a.secret"}`))
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"arrow","sql":"SELECT * FROM tenant_a.secret"}`))
 		req.Header.Set("X-Tenant", "tenant_b")
 		res := httptest.NewRecorder()
 
@@ -192,7 +211,7 @@ func TestHandleHTTPPolicyErrors(t *testing.T) {
 	t.Run("unsupported statement under policy is a bad request", func(t *testing.T) {
 		db := setupTestDB(t, query.WithFunctionBlocklist([]string{"md5"}))
 		s := mustHandler(t, db)
-		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"PRAGMA version"}`))
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"arrow","sql":"PRAGMA version"}`))
 		res := httptest.NewRecorder()
 
 		s.ServeHTTP(res, req)
@@ -206,7 +225,7 @@ func TestHandleHTTPPolicyErrors(t *testing.T) {
 	t.Run("syntax error under policy is a bad request", func(t *testing.T) {
 		db := setupTestDB(t, query.WithFunctionBlocklist([]string{"md5"}))
 		s := mustHandler(t, db)
-		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"json","sql":"SELECT ("}`))
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"arrow","sql":"SELECT ("}`))
 		res := httptest.NewRecorder()
 
 		s.ServeHTTP(res, req)
@@ -248,7 +267,7 @@ func TestHandleHTTPQueryParamsErrors(t *testing.T) {
 		},
 		{
 			name:     "missing SQL",
-			body:     `{"type":"json"}`,
+			body:     `{"type":"arrow"}`,
 			wantBody: "missing required 'sql' parameter\n",
 		},
 	}

--- a/packages/server/duckdb-server-rust/Cargo.lock
+++ b/packages/server/duckdb-server-rust/Cargo.lock
@@ -56,12 +56,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,12 +1112,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,7 +1294,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -1314,11 +1302,6 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "hashlink"

--- a/packages/server/duckdb-server-rust/Readme.md
+++ b/packages/server/duckdb-server-rust/Readme.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/duckdb-server.svg)](https://crates.io/crates/duckdb-server)
 
-A Rust-based server that runs a local DuckDB instance and support queries over Web Sockets or HTTP/HTTPS, returning data in either [Apache Arrow](https://arrow.apache.org/) or JSON format.
+A Rust-based server that runs a local DuckDB instance and support queries over Web Sockets or HTTP/HTTPS, returning data in [Apache Arrow](https://arrow.apache.org/) format.
 
 _Note:_ This package provides a local DuckDB server. To instead use DuckDB-WASM in the browser, use the `wasmConnector` in the [`mosaic-core`](https://github.com/uwdata/mosaic/tree/main/packages/mosaic/mosaic-core) package.
 
@@ -44,7 +44,7 @@ mkcert localhost
 
 ## API
 
-The server supports queries via HTTP GET and POST, and WebSockets. The GET endpoint is useful for debugging. For example, you can query it with [this url](<http://localhost:3000/?query={"sql":"select 1","type":"json"}>).
+The server supports queries via HTTP GET and POST, and WebSockets. The GET endpoint is useful for debugging. For example, you can query it with [this url](<http://localhost:3000/?query={"sql":"select 1","type":"arrow"}>).
 
 Each endpoint takes a JSON object with a command in the `type`. The server supports the following commands.
 
@@ -55,10 +55,6 @@ Executes the SQL query in the `sql` field.
 ### `arrow`
 
 Executes the SQL query in the `sql` field and returns the result in Apache Arrow format.
-
-### `json`
-
-Executes the SQL query in the `sql` field and returns the result in JSON format.
 
 ## Developers
 

--- a/packages/server/duckdb-server-rust/benches/benchmark.rs
+++ b/packages/server/duckdb-server-rust/benches/benchmark.rs
@@ -11,22 +11,21 @@ pub fn benchmark(c: &mut Criterion) {
     let state = Arc::new(AppState { db: Box::new(db) });
 
     let mut group = c.benchmark_group("handle");
-    for command in [Command::Arrow, Command::Json].iter() {
-        group.bench_with_input(
-            BenchmarkId::from_parameter(to_value(command).unwrap().to_string()),
-            command,
-            |b, command| {
-                b.to_async(FuturesExecutor).iter(|| {
-                    let params = QueryParams {
-                        query_type: Some(command.clone()),
-                        sql: Some("SELECT 1 AS foo".to_string()),
-                        ..QueryParams::default()
-                    };
-                    handle(&state, params)
-                })
-            },
-        );
-    }
+    let command = Command::Arrow;
+    group.bench_with_input(
+        BenchmarkId::from_parameter(to_value(&command).unwrap().to_string()),
+        &command,
+        |b, command| {
+            b.to_async(FuturesExecutor).iter(|| {
+                let params = QueryParams {
+                    query_type: Some(command.clone()),
+                    sql: Some("SELECT 1 AS foo".to_string()),
+                    ..QueryParams::default()
+                };
+                handle(&state, params)
+            })
+        },
+    );
     group.finish();
 }
 

--- a/packages/server/duckdb-server-rust/src/db.rs
+++ b/packages/server/duckdb-server-rust/src/db.rs
@@ -5,7 +5,6 @@ use duckdb::DuckdbConnectionManager;
 #[async_trait]
 pub trait Database: Send + Sync {
     async fn execute(&self, sql: &str) -> Result<()>;
-    async fn get_json(&self, sql: &str) -> Result<Vec<u8>>;
     async fn get_arrow(&self, sql: &str) -> Result<Vec<u8>>;
 }
 
@@ -31,20 +30,6 @@ impl Database for ConnectionPool {
         let conn = self.get()?;
         conn.execute_batch(sql)?;
         Ok(())
-    }
-
-    async fn get_json(&self, sql: &str) -> Result<Vec<u8>> {
-        let conn = self.get()?;
-        let mut stmt = conn.prepare(sql)?;
-        let arrow = stmt.query_arrow([])?;
-
-        let buf = Vec::new();
-        let mut writer = arrow::json::ArrayWriter::new(buf);
-        for batch in arrow {
-            writer.write(&batch)?;
-        }
-        writer.finish()?;
-        Ok(writer.into_inner())
     }
 
     async fn get_arrow(&self, sql: &str) -> Result<Vec<u8>> {

--- a/packages/server/duckdb-server-rust/src/interfaces.rs
+++ b/packages/server/duckdb-server-rust/src/interfaces.rs
@@ -16,7 +16,6 @@ pub struct AppState {
 pub enum Command {
     Arrow,
     Exec,
-    Json,
 }
 
 #[derive(Deserialize, Serialize, Debug, Default)]
@@ -29,7 +28,6 @@ pub struct QueryParams {
 
 pub enum QueryResponse {
     Arrow(Vec<u8>),
-    Json(String),
     Response(Response),
     Empty,
 }
@@ -41,12 +39,6 @@ impl IntoResponse for QueryResponse {
                 StatusCode::OK,
                 [("Content-Type", "application/vnd.apache.arrow.stream")],
                 Bytes::from(bytes),
-            )
-                .into_response(),
-            QueryResponse::Json(value) => (
-                StatusCode::OK,
-                [("Content-Type", "application/json")],
-                value,
             )
                 .into_response(),
             QueryResponse::Response(response) => response,

--- a/packages/server/duckdb-server-rust/src/query.rs
+++ b/packages/server/duckdb-server-rust/src/query.rs
@@ -22,15 +22,6 @@ pub async fn handle(state: &AppState, params: QueryParams) -> Result<QueryRespon
                 Err(AppError::BadRequest)
             }
         }
-        Some(Command::Json) => {
-            if let Some(sql) = params.sql.as_deref() {
-                let json = state.db.get_json(sql).await?;
-                let string = String::from_utf8(json)?;
-                Ok(QueryResponse::Json(string))
-            } else {
-                Err(AppError::BadRequest)
-            }
-        }
         None => Err(AppError::BadRequest),
     }
 }

--- a/packages/server/duckdb-server-rust/src/test.rs
+++ b/packages/server/duckdb-server-rust/src/test.rs
@@ -20,27 +20,6 @@ use crate::interfaces::{AppState, Command};
 use crate::{app, query::handle};
 
 #[tokio::test]
-async fn get_json() -> Result<()> {
-    let db = ConnectionPool::new(":memory:", 1)?;
-
-    let state = Arc::new(AppState { db: Box::new(db) });
-
-    let params = QueryParams {
-        query_type: Some(Command::Json),
-        sql: Some("SELECT 1 AS foo".to_string()),
-        ..QueryParams::default()
-    };
-
-    let json = handle(&state, params).await.unwrap();
-
-    if let QueryResponse::Json(json) = json {
-        assert_eq!(json, "[{\"foo\":1}]");
-    }
-
-    Ok(())
-}
-
-#[tokio::test]
 async fn get_arrow() -> Result<()> {
     let db = ConnectionPool::new(":memory:", 1)?;
 
@@ -55,15 +34,7 @@ async fn get_arrow() -> Result<()> {
     let arrow = handle(&state, params).await.unwrap();
 
     if let QueryResponse::Arrow(arrow) = arrow {
-        let mut reader = FileReader::try_new(std::io::Cursor::new(arrow), None)?;
-        let actual_batch = reader.next().unwrap();
-        let actual_batch = actual_batch?;
-
-        let schema = Arc::new(Schema::new(vec![Field::new("foo", DataType::Int32, true)]));
-        let foo_values = Int32Array::from(vec![1]);
-        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(foo_values)])?;
-
-        assert_eq!(actual_batch, batch);
+        assert_foo_batch(&arrow)?;
     }
 
     Ok(())
@@ -76,7 +47,7 @@ async fn select_1_get() -> Result<()> {
     let response = app
         .oneshot(
             Request::builder()
-                .uri("/?type=json&sql=SELECT%201%20as%20foo")
+                .uri("/?type=arrow&sql=SELECT%201%20as%20foo")
                 .body(Body::empty())?,
         )
         .await?;
@@ -84,33 +55,7 @@ async fn select_1_get() -> Result<()> {
     assert_eq!(response.status(), StatusCode::OK);
 
     let body = response.into_body().collect().await?.to_bytes();
-    assert_eq!(&body[..], b"[{\"foo\":1}]");
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn select_1_post() -> Result<()> {
-    let app = app::app(None, None)?;
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method(http::Method::POST)
-                .uri("/")
-                .header(http::header::CONTENT_TYPE, "application/json")
-                .body(Body::from(serde_json::to_vec(
-                    &json!({"type": "json", "sql": "select 1 as foo"}),
-                )?))?,
-        )
-        .await?;
-
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body = response.into_body().collect().await?.to_bytes();
-    assert_eq!(&body[..], b"[{\"foo\":1}]");
-
-    Ok(())
+    assert_foo_batch(&body)
 }
 
 #[tokio::test]
@@ -131,17 +76,17 @@ async fn query_arrow() -> Result<()> {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body = response.into_body().collect().await?;
+    let body = response.into_body().collect().await?.to_bytes();
+    assert_foo_batch(&body)
+}
 
-    let mut reader = FileReader::try_new(std::io::Cursor::new(body.to_bytes()), None)?;
-    let actual_batch = reader.next().unwrap();
-    let actual_batch = actual_batch?;
+fn assert_foo_batch(bytes: &[u8]) -> Result<()> {
+    let mut reader = FileReader::try_new(std::io::Cursor::new(bytes), None)?;
+    let actual_batch = reader.next().unwrap()?;
 
     let schema = Arc::new(Schema::new(vec![Field::new("foo", DataType::Int32, true)]));
-    let foo_values = Int32Array::from(vec![1]);
-    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(foo_values)])?;
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1]))])?;
 
     assert_eq!(actual_batch, batch);
-
     Ok(())
 }

--- a/packages/server/duckdb-server-rust/src/websocket.rs
+++ b/packages/server/duckdb-server-rust/src/websocket.rs
@@ -38,9 +38,6 @@ pub async fn handle(mut socket: WebSocket, state: Arc<AppState>) {
                             QueryResponse::Arrow(arrow) => {
                                 socket.send(Message::Binary(arrow.into())).await
                             }
-                            QueryResponse::Json(json) => {
-                                socket.send(Message::Text(json.into())).await
-                            }
                             QueryResponse::Empty => socket.send(Message::Text("{}".into())).await,
                             QueryResponse::Response(_) => {
                                 socket

--- a/packages/server/duckdb-server/README.md
+++ b/packages/server/duckdb-server/README.md
@@ -2,7 +2,7 @@
 
 [![PyPi](https://img.shields.io/pypi/v/duckdb-server.svg)](https://pypi.org/project/duckdb-server/)
 
-A Python-based server that runs a local DuckDB instance and support queries over Web Sockets or HTTP, returning data in either [Apache Arrow](https://arrow.apache.org/) or JSON format.
+A Python-based server that runs a local DuckDB instance and support queries over Web Sockets or HTTP, returning data in [Apache Arrow](https://arrow.apache.org/) format.
 
 _Note:_ This package provides a local DuckDB server. To instead use DuckDB-WASM in the browser, use the `wasmConnector` in the [`mosaic-core`](https://github.com/uwdata/mosaic/tree/main/packages/mosaic/mosaic-core) package.
 
@@ -32,7 +32,7 @@ To set up a local certificate for SSL, use https://github.com/FiloSottile/mkcert
 
 ## API
 
-The server supports queries via HTTP GET and POST, and WebSockets. The GET endpoint is useful for debugging. For example, you can query it with [this url](<http://localhost:3000/?query={"sql":"select 1","type":"json"}>).
+The server supports queries via HTTP GET and POST, and WebSockets. The GET endpoint is useful for debugging. For example, you can query it with [this url](<http://localhost:3000/?query={"sql":"select 1","type":"arrow"}>).
 
 Each endpoint takes a JSON object with a command in the `type`. The server supports the following commands.
 
@@ -43,10 +43,6 @@ Executes the SQL query in the `sql` field.
 ### `arrow`
 
 Executes the SQL query in the `sql` field and returns the result in Apache Arrow format.
-
-### `json`
-
-Executes the SQL query in the `sql` field and returns the result in JSON format.
 
 ## Publishing
 

--- a/packages/server/duckdb-server/pkg/query.py
+++ b/packages/server/duckdb-server/pkg/query.py
@@ -22,8 +22,3 @@ def arrow_to_bytes(reader: pa.RecordBatchReader) -> bytes:
 
 def get_arrow_bytes(con: duckdb.DuckDBPyConnection, sql: str) -> bytes:
     return arrow_to_bytes(get_arrow(con, sql))
-
-
-def get_json(con: duckdb.DuckDBPyConnection, sql: str) -> str | None:
-    result = con.query(sql).df()
-    return result.to_json(orient="records")

--- a/packages/server/duckdb-server/pkg/server.py
+++ b/packages/server/duckdb-server/pkg/server.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict
 import ujson
 from socketify import App, CompressOptions, OpCode
 
-from pkg.query import get_arrow_bytes, get_json
+from pkg.query import get_arrow_bytes
 
 if TYPE_CHECKING:
     import duckdb
@@ -24,7 +24,7 @@ SLOW_QUERY_THRESHOLD = 5000
 
 
 class _QueryParams(TypedDict):
-    type: Literal["arrow", "exec", "json"]
+    type: Literal["arrow", "exec"]
     sql: str
     uuid: str  # name
 
@@ -32,7 +32,6 @@ class _QueryParams(TypedDict):
 class Handler(Protocol):
     def done(self) -> None: ...
     def arrow(self, buffer: bytes) -> None: ...
-    def json(self, data: Any) -> None: ...
     def error(self, error: Any) -> None: ...
 
 
@@ -52,10 +51,6 @@ class SocketHandler(Handler):
         ok = self.ws.send(buffer, OpCode.BINARY)
         self.check(ok)
 
-    def json(self, data: Any) -> None:
-        ok = self.ws.send(data, OpCode.TEXT)
-        self.check(ok)
-
     def error(self, error: object) -> None:
         ok = self.ws.send({"error": str(error)}, OpCode.TEXT)
         self.check(ok)
@@ -71,10 +66,6 @@ class HTTPHandler(Handler):
     def arrow(self, buffer: bytes) -> None:
         self.res.write_header("Content-Type", "application/octet-stream")
         self.res.end(buffer)
-
-    def json(self, data: Any) -> None:
-        self.res.write_header("Content-Type", "application/json")
-        self.res.end(data)
 
     def error(self, error: object) -> None:
         self.res.write_status(500)
@@ -100,9 +91,6 @@ def handle_query(
         elif command == "arrow":
             buffer = get_arrow_bytes(con, sql)
             handler.arrow(buffer)
-        elif command == "json":
-            json = get_json(con, sql)
-            handler.json(json)
         else:
             msg = f"Unknown command {command}"
             raise ValueError(msg)

--- a/packages/server/duckdb-server/pkg/tests/test_query.py
+++ b/packages/server/duckdb-server/pkg/tests/test_query.py
@@ -5,13 +5,7 @@ from functools import partial
 import duckdb
 import pyarrow as pa
 
-from pkg.query import get_arrow, get_json
-
-
-def test_query_json() -> None:
-    con = duckdb.connect()
-
-    assert partial(get_json, con)("SELECT 1 AS a") == '[{"a":1}]'
+from pkg.query import get_arrow
 
 
 def test_query_arrow() -> None:

--- a/packages/server/duckdb/README.md
+++ b/packages/server/duckdb/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@uwdata/mosaic-duckdb.svg)](https://www.npmjs.com/package/@uwdata/mosaic-duckdb)
 
-A Promise-based Node.js API to DuckDB, along with a data server that supports transfer of [Apache Arrow](https://arrow.apache.org/) and JSON data over either Web Sockets or HTTP.
+A Promise-based Node.js API to DuckDB, along with a data server that supports transfer of [Apache Arrow](https://arrow.apache.org/) data over either Web Sockets or HTTP.
 
 _Warning_: Due to persistent quality issues involving the Node.js DuckDB client and Arrow extension, we recommend using the Python-based [`duckdb-server`](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server) package instead. However, we retain this package for both backwards compatibility and potential future use as quality issues improve.
 

--- a/packages/server/duckdb/src/data-server.js
+++ b/packages/server/duckdb/src/data-server.js
@@ -76,8 +76,8 @@ export function queryHandler(db) {
     }
 
     try {
-      const { sql, type = 'json' } = query;
-      console.log(`> ${type.toUpperCase()}${sql ? ` ${sql}` : ''}`);
+      const { sql, type } = query;
+      console.log(`> ${String(type).toUpperCase()}${sql ? ` ${sql}` : ''}`);
 
       // process query and return result
       switch (type) {
@@ -89,10 +89,6 @@ export function queryHandler(db) {
         case 'arrow':
           // Apache Arrow response format
           res.arrow(await db.arrowBuffer(sql));
-          break;
-        case 'json':
-          // JSON response format
-          res.json(await db.query(sql));
           break;
         default:
           res.error(`Unrecognized command: ${type}`, 400);
@@ -111,10 +107,6 @@ function httpResponse(res) {
       res.setHeader('Content-Type', 'application/vnd.apache.arrow.stream');
       for (const chunk of data) res.write(chunk);
       res.end();
-    },
-    json(data) {
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify(data));
     },
     done() {
       res.writeHead(200);

--- a/packages/server/duckdb/src/data-server.js
+++ b/packages/server/duckdb/src/data-server.js
@@ -76,7 +76,7 @@ export function queryHandler(db) {
     }
 
     try {
-      const { sql, type } = query;
+      const { sql, type = 'arrow' } = query;
       console.log(`> ${String(type).toUpperCase()}${sql ? ` ${sql}` : ''}`);
 
       // process query and return result

--- a/packages/vgplot/widget/mosaic_widget/__init__.py
+++ b/packages/vgplot/widget/mosaic_widget/__init__.py
@@ -28,7 +28,7 @@ SLOW_QUERY_THRESHOLD = 5000
 
 
 class _QueryParams(TypedDict):
-    type: Literal["arrow", "exec", "json"]
+    type: Literal["arrow", "exec"]
     sql: str
     uuid: str  # name
 
@@ -153,10 +153,6 @@ class MosaicWidget(anywidget.AnyWidget):
             elif command == "exec":
                 self.con.execute(sql)
                 self.send({"type": "exec", "uuid": uuid})
-            elif command == "json":
-                result = self.con.query(sql).df()
-                json = result.to_dict(orient="records")
-                self.send({"type": "json", "uuid": uuid, "result": json})
             else:
                 msg = f"Unknown command {command}"
                 raise ValueError(msg)

--- a/packages/vgplot/widget/src/index.js
+++ b/packages/vgplot/widget/src/index.js
@@ -136,11 +136,6 @@ export default {
             query.resolve(table);
             break;
           }
-          case 'json': {
-            logger.log('json', msg.result);
-            query.resolve(msg.result);
-            break;
-          }
           default: {
             query.resolve({});
             break;


### PR DESCRIPTION
Connectors now speak one result format. Every JavaScript consumer inside Mosaic already decodes Arrow IPC, so dropping the `json` query type removes a second return shape from `Connector.query` and collapses the `Coordinator.query`/`prefetch` overloads to a single signature.

Targets `main` and merges before #1171, which builds the size-based cache on top of this contract.

## Breaking change

- `Connector.query` no longer accepts `{ type: 'json' }`; `JSONQueryRequest` is removed from `@uwdata/mosaic-core`.
- `coordinator.query()` and `coordinator.prefetch()` drop the `type` option entirely, since only one value remained. They always give you an Arrow table.
- `QueryRequest.type` is `'exec' | 'arrow'`.
- The rest connector returns `undefined` for an `exec` request, matching its declared type and the other connectors. It returned the fetch promise before.

Options you pass through to the database are now spread before the request fields, so a stray `type` or `sql` key cannot overwrite them.

The servers and the widget drop the type as well, so a `json` request now gets the same error as any unknown command:

- `duckdb-server` (Python): the `json` command and handlers.
- `duckdb-server-rust`: `Command::Json`, `QueryResponse::Json`, and `get_json`.
- `duckdb-server-go`: `CommandJSON` and `QueryJSON`; tests decode Arrow instead.
- Node data server: the `json` case, and the default type is now `arrow` rather than `json`.
- Python widget: the `json` branch of the query handler.

Closes #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NpEWY6NSZN7s9wFNqh6eU
