### PR TITLE
fix(core): prevent unbindable preaggregation queries, harden preagg tests

### DIFF
--- a/packages/mosaic/core/src/preagg/PreAggregator.ts
+++ b/packages/mosaic/core/src/preagg/PreAggregator.ts
@@ -1,4 +1,4 @@
-import { ExprNode, ScaleOptions, SelectQuery, Query, ExprValue, MaybeArray, FunctionNode, TableRefNode, createSchema, SelectClauseNode, OrderByNode, and, asNode, ceil, collectColumns, createTable, float64, floor, isBetween, int32, mul, round, scaleTransform, sub, isSelectQuery, isAggregateExpression, ColumnNameRefNode, rewrite } from '@uwdata/mosaic-sql';
+import { ExprNode, ScaleOptions, SelectQuery, Query, ExprValue, MaybeArray, FunctionNode, TableRefNode, VerbatimNode, createSchema, SelectClauseNode, OrderByNode, and, asNode, ceil, collectColumns, createTable, float64, floor, isBetween, int32, mul, round, scaleTransform, sub, isSelectQuery, isAggregateExpression, ColumnNameRefNode, rewrite, walk } from '@uwdata/mosaic-sql';
 import type { Coordinator } from '../Coordinator.js';
 import type { MosaicClient } from '../MosaicClient.js';
 import type { Selection } from '../Selection.js';
@@ -216,15 +216,17 @@ export class PreAggregator {
         client.query(filter) as SelectQuery,
         active, preaggCols, schema
       );
-      _info.result = mc.exec([
-        createSchema(schema),
-        createTable(_info.table, _info.create, { temp: false })
-      ]);
-      // if create query fails, log and mark as failed
-      _info.result.catch((e: Error) => {
-        mc.logger().error(e);
-        _info.result = null; // indicates lack of view
-      });
+      if (_info) {
+        _info.result = mc.exec([
+          createSchema(schema),
+          createTable(_info.table, _info.create, { temp: false })
+        ]);
+        // if create query fails, log and mark as failed
+        _info.result.catch((e: Error) => {
+          mc.logger().error(e);
+          _info.result = null; // indicates lack of view
+        });
+      }
       info = _info;
     }
 
@@ -335,14 +337,15 @@ function binInterval(
  * @param active Active (selected) columns.
  * @param preaggCols Pre-aggregation columns.
  * @param schema Database schema name.
- * @returns Pre-aggregation information.
+ * @returns Pre-aggregation information, or null if active column
+ *  expressions can not be pushed down to subqueries.
  */
 function preaggregateInfo(
   query: SelectQuery,
   active: ActiveColumnsResult,
   preaggCols: PreAggColumnsResult,
   schema: string
-): PreAggregateInfo {
+): PreAggregateInfo | null {
   const { groupby, having, orderby, output, preagg, qualify } = preaggCols;
   const { columns = {} } = active;
 
@@ -356,8 +359,11 @@ function preaggregateInfo(
     .groupby(groupby, Object.keys(columns));
 
   // ensure active clause columns are selected by subqueries
+  // bail if a column expression contains verbatim SQL text, as any
+  // column references within it can not be identified for pushdown
   const [subq] = create.subqueries;
   if (subq) {
+    if (Object.values(columns).some(hasVerbatim)) return null;
     const cols = Object.values(columns)
       .flatMap(c => collectColumns(c).map(c => c.column));
     subqueryPushdown(subq, cols);
@@ -405,6 +411,22 @@ function replaceIndices(exprs: ExprNode[], select: SelectClauseNode[]) {
     }
     return expr;
   });
+}
+
+/**
+ * Test if an expression contains verbatim SQL content.
+ * @param node The expression to test.
+ * @returns True if the expression contains a verbatim node.
+ */
+function hasVerbatim(node: ExprNode): boolean {
+  let found = false;
+  walk(node, n => {
+    if (n instanceof VerbatimNode) {
+      found = true;
+      return -1;
+    }
+  });
+  return found;
 }
 
 /**

--- a/packages/mosaic/core/src/preagg/PreAggregator.ts
+++ b/packages/mosaic/core/src/preagg/PreAggregator.ts
@@ -1,10 +1,11 @@
-import { ExprNode, ScaleOptions, SelectQuery, Query, ExprValue, MaybeArray, FunctionNode, TableRefNode, VerbatimNode, createSchema, SelectClauseNode, OrderByNode, and, asNode, ceil, collectColumns, createTable, float64, floor, isBetween, int32, mul, round, scaleTransform, sub, isSelectQuery, isAggregateExpression, ColumnNameRefNode, rewrite, walk } from '@uwdata/mosaic-sql';
+import { ExprNode, ScaleOptions, SelectQuery, Query, ExprValue, MaybeArray, FunctionNode, TableRefNode, VerbatimNode, createSchema, SelectClauseNode, OrderByNode, and, asNode, ceil, collectColumns, createTable, float64, floor, isBetween, int32, mul, round, scaleTransform, sub, isSelectQuery, isAggregateExpression, ColumnNameRefNode, rewrite } from '@uwdata/mosaic-sql';
 import type { Coordinator } from '../Coordinator.js';
 import type { MosaicClient } from '../MosaicClient.js';
 import type { Selection } from '../Selection.js';
 import type { BinMethod, ClauseSource, IntervalMetadata, SelectionClause } from '../SelectionClause.js';
 import { fnv_hash } from '../util/hash.js';
 import { resolvePositional } from '../util/positional.js';
+import { containsNode } from './contains-node.js';
 import { preaggColumns, PreAggColumnsResult } from './preagg-columns.js';
 
 /**
@@ -363,7 +364,7 @@ function preaggregateInfo(
   // column references within it can not be identified for pushdown
   const [subq] = create.subqueries;
   if (subq) {
-    if (Object.values(columns).some(hasVerbatim)) return null;
+    if (Object.values(columns).some(c => containsNode(c, VerbatimNode))) return null;
     const cols = Object.values(columns)
       .flatMap(c => collectColumns(c).map(c => c.column));
     subqueryPushdown(subq, cols);
@@ -411,22 +412,6 @@ function replaceIndices(exprs: ExprNode[], select: SelectClauseNode[]) {
     }
     return expr;
   });
-}
-
-/**
- * Test if an expression contains verbatim SQL content.
- * @param node The expression to test.
- * @returns True if the expression contains a verbatim node.
- */
-function hasVerbatim(node: ExprNode): boolean {
-  let found = false;
-  walk(node, n => {
-    if (n instanceof VerbatimNode) {
-      found = true;
-      return -1;
-    }
-  });
-  return found;
 }
 
 /**

--- a/packages/mosaic/core/src/preagg/contains-node.ts
+++ b/packages/mosaic/core/src/preagg/contains-node.ts
@@ -1,0 +1,22 @@
+import { walk } from '@uwdata/mosaic-sql';
+import type { SQLNode } from '@uwdata/mosaic-sql';
+
+/**
+ * Test if an expression contains a node of a given type.
+ * @param root The root node of the expression to test.
+ * @param ctor The node class to search for.
+ * @returns True if the expression contains a matching node.
+ */
+export function containsNode(
+  root: SQLNode,
+  ctor: new (...args: never[]) => SQLNode
+): boolean {
+  let found = false;
+  walk(root, node => {
+    if (node instanceof ctor) {
+      found = true;
+      return -1; // stop traversal
+    }
+  });
+  return found;
+}

--- a/packages/mosaic/core/src/preagg/preagg-columns.ts
+++ b/packages/mosaic/core/src/preagg/preagg-columns.ts
@@ -1,7 +1,8 @@
-import { asNode, collectAggregates, FromClauseNode, isAggregateExpression, isColumnRef, isSelectQuery, isTableRef, rewrite, sql, walk, WindowNode } from '@uwdata/mosaic-sql';
+import { asNode, collectAggregates, FromClauseNode, isAggregateExpression, isColumnRef, isSelectQuery, isTableRef, rewrite, sql, WindowNode } from '@uwdata/mosaic-sql';
 import type { AggregateNode, ColumnRefNode, ExprNode, Query, SelectQuery } from '@uwdata/mosaic-sql';
 import type { MosaicClient } from '../MosaicClient.js';
 import { resolvePositional } from '../util/positional.js';
+import { containsNode } from './contains-node.js';
 import { sufficientStatistics } from './sufficient-statistics.js';
 
 // result of determining columns for preaggregation optimization
@@ -47,10 +48,10 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
   const avg = (ref: ColumnRefNode) => {
     const name = ref.column;
     const expr = getBase(q, q => q._select.find(c => c.alias === name)?.expr);
-    if (typeof expr === 'number') throw new Error();            // base queries disagree
-    if (expr && isAggregateExpression(expr)) throw new Error(); // aggregate-valued operand
-    if (expr && hasWindow(expr)) throw new Error();             // window-valued operand
-    if (!expr && q.subqueries.length) throw new Error();        // unresolvable through subqueries
+    if (typeof expr === 'number') throw new Error();                // base queries disagree
+    if (expr && isAggregateExpression(expr)) throw new Error();     // aggregate-valued operand
+    if (expr && containsNode(expr, WindowNode)) throw new Error();  // window-valued operand
+    if (!expr && q.subqueries.length) throw new Error();            // unresolvable through subqueries
     return sql`(SELECT avg(${expr ?? ref}) FROM ${from})`;
   };
 
@@ -71,7 +72,7 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
       } else {
         // bail if expression contains a window function, as
         // window values cannot serve as groupby dimensions
-        if (hasWindow(expr)) return null;
+        if (containsNode(expr, WindowNode)) return null;
         // include non-aggregates in preagg table and update results
         preagg[alias] = expr;
         output[alias] = asNode(alias);
@@ -119,21 +120,6 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
     // bail if unsupported aggregate was encountered
     return null;
   }
-}
-
-/**
- * Test if an expression contains a window function call.
- * @param expr The expression to test.
- */
-function hasWindow(expr: ExprNode): boolean {
-  let win = false;
-  walk(expr, node => {
-    if (node instanceof WindowNode) {
-      win = true;
-      return -1; // stop traversal
-    }
-  });
-  return win;
 }
 
 /**

--- a/packages/mosaic/core/src/preagg/preagg-columns.ts
+++ b/packages/mosaic/core/src/preagg/preagg-columns.ts
@@ -1,4 +1,4 @@
-import { asNode, collectAggregates, FromClauseNode, isAggregateExpression, isColumnRef, isSelectQuery, isTableRef, rewrite, sql } from '@uwdata/mosaic-sql';
+import { asNode, collectAggregates, FromClauseNode, isAggregateExpression, isColumnRef, isSelectQuery, isTableRef, rewrite, sql, walk, WindowNode } from '@uwdata/mosaic-sql';
 import type { AggregateNode, ColumnRefNode, ExprNode, Query, SelectQuery } from '@uwdata/mosaic-sql';
 import type { MosaicClient } from '../MosaicClient.js';
 import { resolvePositional } from '../util/positional.js';
@@ -47,6 +47,10 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
   const avg = (ref: ColumnRefNode) => {
     const name = ref.column;
     const expr = getBase(q, q => q._select.find(c => c.alias === name)?.expr);
+    if (typeof expr === 'number') throw new Error();            // base queries disagree
+    if (expr && isAggregateExpression(expr)) throw new Error(); // aggregate-valued operand
+    if (expr && hasWindow(expr)) throw new Error();             // window-valued operand
+    if (!expr && q.subqueries.length) throw new Error();        // unresolvable through subqueries
     return sql`(SELECT avg(${expr ?? ref}) FROM ${from})`;
   };
 
@@ -112,6 +116,21 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
     // bail if unsupported aggregate was encountered
     return null;
   }
+}
+
+/**
+ * Test if an expression contains a window function call.
+ * @param expr The expression to test.
+ */
+function hasWindow(expr: ExprNode): boolean {
+  let win = false;
+  walk(expr, node => {
+    if (node instanceof WindowNode) {
+      win = true;
+      return -1; // stop traversal
+    }
+  });
+  return win;
 }
 
 /**

--- a/packages/mosaic/core/src/preagg/preagg-columns.ts
+++ b/packages/mosaic/core/src/preagg/preagg-columns.ts
@@ -69,6 +69,9 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
         // rewrite original select clause to use preaggregates
         output[alias] = result;
       } else {
+        // bail if expression contains a window function, as
+        // window values cannot serve as groupby dimensions
+        if (hasWindow(expr)) return null;
         // include non-aggregates in preagg table and update results
         preagg[alias] = expr;
         output[alias] = asNode(alias);

--- a/packages/mosaic/core/src/preagg/preagg-columns.ts
+++ b/packages/mosaic/core/src/preagg/preagg-columns.ts
@@ -38,7 +38,7 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
   const from = getBase(q, q => {
     const node = q._from[0];
     const ref = node instanceof FromClauseNode && node.expr;
-    return isTableRef(ref) ? ref.name : ref;
+    return isTableRef(ref) ? String(ref) : ref;
   });
   if (typeof from !== 'string') return null;
 
@@ -47,7 +47,7 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
   const avg = (ref: ColumnRefNode) => {
     const name = ref.column;
     const expr = getBase(q, q => q._select.find(c => c.alias === name)?.expr);
-    return sql`(SELECT avg(${expr ?? ref}) FROM "${from}")`;
+    return sql`(SELECT avg(${expr ?? ref}) FROM ${from})`;
   };
 
   const aggrs = new Map<AggregateNode, ExprNode>();

--- a/packages/mosaic/core/src/preagg/preagg-columns.ts
+++ b/packages/mosaic/core/src/preagg/preagg-columns.ts
@@ -5,6 +5,9 @@ import { resolvePositional } from '../util/positional.js';
 import { containsNode } from './contains-node.js';
 import { sufficientStatistics } from './sufficient-statistics.js';
 
+// marks a value that differs across the base queries of a set operation
+const DIVERGENT = Symbol('divergent base');
+
 // result of determining columns for preaggregation optimization
 export interface PreAggColumnsResult {
   // Columns to include in a created preaggregate table
@@ -48,7 +51,7 @@ export function preaggColumns(client: MosaicClient): PreAggColumnsResult | null 
   const avg = (ref: ColumnRefNode) => {
     const name = ref.column;
     const expr = getBase(q, q => q._select.find(c => c.alias === name)?.expr);
-    if (typeof expr === 'number') throw new Error();                // base queries disagree
+    if (expr === DIVERGENT) throw new Error();                      // base queries disagree
     if (expr && isAggregateExpression(expr)) throw new Error();     // aggregate-valued operand
     if (expr && containsNode(expr, WindowNode)) throw new Error();  // window-valued operand
     if (!expr && q.subqueries.length) throw new Error();            // unresolvable through subqueries
@@ -164,13 +167,13 @@ function analyzeExpression(
  * @param get A getter function to extract
  *  a value from a base query.
  * @returns the base query value, or
- *  `undefined` if there is no source table, or `NaN` if the
+ *  `undefined` if there is no source table, or `DIVERGENT` if the
  *  query operates over multiple source tables.
  */
 function getBase<T>(
   query: Query,
   get: (q: SelectQuery) => T
-): T | number | undefined {
+): T | typeof DIVERGENT | undefined {
   const subq = query.subqueries;
 
   // select query
@@ -183,7 +186,7 @@ function getBase<T>(
   for (let i = 1; i < subq.length; ++i) {
     const value = getBase(subq[i], get);
     if (value === undefined) continue;
-    if (value !== base) return NaN;
+    if (value !== base) return DIVERGENT;
   }
   return base;
 }

--- a/packages/mosaic/core/test/preaggregator.test.ts
+++ b/packages/mosaic/core/test/preaggregator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { CreateQuery, ExprNode, FilterExpr } from "@uwdata/mosaic-sql";
-import { Query, add, argmax, argmin, asTableRef, avg, corr, count, covarPop, covariance, desc, filterPushdown, geomean, gt, literal, loadObjects, max, min, mul, neq, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, sql, stddev, stddevPop, sum, upper, varPop, variance } from '@uwdata/mosaic-sql';
+import { Query, add, argmax, argmin, asTableRef, avg, corr, count, covarPop, covariance, desc, filterPushdown, geomean, gt, literal, loadObjects, max, min, mul, neq, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, row_number, sql, stddev, stddevPop, sum, upper, varPop, variance } from '@uwdata/mosaic-sql';
 import { clausePoint, Coordinator, Selection, SelectionClause } from '../src/index.js';
 import type { PreAggregateInfo } from '../src/preagg/PreAggregator.js';
 import { preaggColumns } from '../src/preagg/preagg-columns.js';
@@ -215,6 +215,50 @@ describe('PreAggregator', () => {
         .select({ measure: add(1, sum('freq')) });
     };
     expect(await run(queryNoGroup)).toStrictEqual([4, true]);
+  });
+
+  it('does not support variance over a CTE aggregate column', async () => {
+    // mean-centering cannot use a CTE-derived aggregate column,
+    // so the query should run through the non-optimized route
+    const query = (predicate: FilterExpr = []) => {
+      const counts = Query.from('testData')
+        .select({ dim: 'dim', freq: count() })
+        .groupby('dim', 'order')
+        .where(predicate);
+      return Query.with({ counts })
+        .from('counts')
+        .select({ measure: variance('freq') });
+    };
+    expect(await run(query)).toStrictEqual([0, false]);
+  });
+
+  it('does not support variance over a multi-level CTE column', async () => {
+    // mean-centering cannot resolve a column defined in an intermediate
+    // CTE, so the query should run through the non-optimized route
+    const query = (predicate: FilterExpr = []) => {
+      const inner = Query.from('testData')
+        .select({ v: mul('x', 2), dim: 'dim' })
+        .where(predicate);
+      const outer = Query.from('inner_cte').select({ w: 'v', dim: 'dim' });
+      return Query.with({ inner_cte: inner, outer_cte: outer })
+        .from('outer_cte')
+        .select({ measure: variance('w') });
+    };
+    expect(await run(query)).toStrictEqual([2, false]);
+  });
+
+  it('does not support variance over a CTE window column', async () => {
+    // mean-centering cannot use a CTE-derived window column,
+    // so the query should run through the non-optimized route
+    const query = (predicate: FilterExpr = []) => {
+      const ranked = Query.from('testData')
+        .select({ rk: row_number().orderby('order'), dim: 'dim' })
+        .where(predicate);
+      return Query.with({ ranked })
+        .from('ranked')
+        .select({ measure: variance('rk') });
+    };
+    expect(await run(query)).toStrictEqual([1, false]);
   });
 
   it('supports queries with column index references', async () => {

--- a/packages/mosaic/core/test/preaggregator.test.ts
+++ b/packages/mosaic/core/test/preaggregator.test.ts
@@ -294,6 +294,17 @@ describe('PreAggregator', () => {
     expect(await run(query)).toStrictEqual([13, true]);
   });
 
+  it('does not support window functions without aggregate inputs', async () => {
+    // should handle query, but through non-optimized route
+    const query = (predicate: FilterExpr = []) => {
+      return Query.from('testData')
+        .select({ measure: avg('x'), rn: row_number().orderby('dim'), dim: 'dim' })
+        .groupby('dim')
+        .where(predicate);
+    };
+    expect(await run(query)).toStrictEqual([3.5, false]);
+  });
+
   it('supports queries with having clause', async () => {
     const query = (predicate: FilterExpr = []) => {
       return Query.from('testData')

--- a/packages/mosaic/core/test/preaggregator.test.ts
+++ b/packages/mosaic/core/test/preaggregator.test.ts
@@ -391,6 +391,26 @@ describe('PreAggregator', () => {
     expect(rows.get(0).n).toBe(2);
   });
 
+  it('skips expression-valued selection fields over subqueries', async () => {
+    const size = sql`CASE WHEN "x" > 2 THEN 'big' ELSE 'small' END`;
+    const clause = clausePoint(size, 'big', { source: {} });
+    const query = (predicate: FilterExpr = []) => {
+      const counts = Query.from('testData')
+        .select({ order: 'order', freq: count() })
+        .groupby('order')
+        .where(predicate);
+      return Query.with({ counts })
+        .from('counts')
+        .select({ measure: sum('freq') });
+    };
+
+    // column references within verbatim SQL text can not be pushed
+    // down to subqueries, so expect the non-optimized route
+    const { value, info } = await runQuery(query, clause);
+    expect(value).toBe(2);
+    expect(info).toBeFalsy();
+  });
+
   it('supports case-insensitive collisions among groupby dimensions', async () => {
     const query = (predicate: FilterExpr = []) => {
       return Query.from('testData')

--- a/packages/mosaic/core/test/preaggregator.test.ts
+++ b/packages/mosaic/core/test/preaggregator.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import type { CreateQuery, ExprNode, FilterExpr } from "@uwdata/mosaic-sql";
-import { Query, add, argmax, argmin, avg, corr, count, covarPop, covariance, desc, filterPushdown, geomean, gt, literal, loadObjects, max, min, mul, neq, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, sql, stddev, stddevPop, sum, upper, varPop, variance } from '@uwdata/mosaic-sql';
+import { Query, add, argmax, argmin, asTableRef, avg, corr, count, covarPop, covariance, desc, filterPushdown, geomean, gt, literal, loadObjects, max, min, mul, neq, product, regrAvgX, regrAvgY, regrCount, regrIntercept, regrR2, regrSXX, regrSXY, regrSYY, regrSlope, sql, stddev, stddevPop, sum, upper, varPop, variance } from '@uwdata/mosaic-sql';
 import { clausePoint, Coordinator, Selection, SelectionClause } from '../src/index.js';
 import type { PreAggregateInfo } from '../src/preagg/PreAggregator.js';
 import { preaggColumns } from '../src/preagg/preagg-columns.js';
 import { NodeConnector } from '../src/connectors/NodeConnector.js';
 import { TestClient } from './util/test-client.js';
 
-async function setup(loadQuery: CreateQuery) {
+async function setup(loadQuery: CreateQuery | string) {
   const mc = new Coordinator(await NodeConnector.make(), {
     logger: null,
     cache: false,
@@ -32,11 +32,16 @@ const loadQuery = loadObjects('testData', [
  * Query the test dataset with the given measure, filtered by the clause.
  * @param measure The aggregate measure or query function for the client.
  * @param clause The selection clause to apply.
+ * @param load The query to load the test dataset.
  * @returns The measure value, the pre-aggregation entry (if any),
  *  and the coordinator.
  */
-async function runQuery(measure: RunMeasure, clause: SelectionClause) {
-  const mc = await setup(loadQuery);
+async function runQuery(
+  measure: RunMeasure,
+  clause: SelectionClause,
+  load: CreateQuery | string = loadQuery
+) {
+  const mc = await setup(load);
   const sel = Selection.single({ cross: true });
 
   return new Promise<{ value: number, info?: PreAggregateInfo, mc: Coordinator }>((resolve, reject) => {
@@ -265,6 +270,24 @@ describe('PreAggregator', () => {
         .qualify(gt('measure', 7), gt(avg('x'), 0));
     };
     expect(await run(query)).toStrictEqual([13, true]);
+  });
+
+  it('supports schema-qualified base tables', async () => {
+    const load = `CREATE SCHEMA s; CREATE TABLE s.data AS
+      SELECT * FROM (VALUES ('a', 1), ('b', 3), ('b', 4)) t(dim, x)`;
+    const query = (predicate: FilterExpr = []) => {
+      return Query.from(asTableRef(['s', 'data'])!)
+        .select({ measure: stddev('x') })
+        .where(predicate);
+    };
+    const clause = clausePoint('dim', 'b', { source: {} });
+    const { value, info, mc } = await runQuery(query, clause, load);
+    expect(value).toBe(Math.sqrt(0.5));
+
+    // the materialized view must exist; a create query that fails to bind
+    // is otherwise masked by the coordinator's fallback to standard queries
+    const rows = await mc.query(Query.from(info!.table).select({ n: count() }));
+    expect(rows.get(0).n).toBe(2);
   });
 
   it('supports queries with filter pushdown applied', async () => {


### PR DESCRIPTION
Fixes #1189, #1187, #1188, #1190. Part of the audit tracked in #1170.

> **Note:** This fix was created by Claude (an agent team ran a binder-error audit of the SQL layer; each fix went through automated implementation, simplification, and adversarial review passes, and the combined branch was re-reviewed for assembly fidelity).

The preaggregator emits an unbindable `CREATE TABLE` in four different shapes. Since #1090 (and now #1158) the coordinator recovers by falling back to the client's query, so every one of these fails silently as a lost optimization — charts are correct, the speedup just never happens. Relatedly, `preaggregator.test.ts` mostly asserted `!!info`, which is also true when the create fails and the fallback answers; that is why none of these were caught. One commit per issue, plus two droppable refactors:

1. #1189 `fix: Qualify preagg mean-centering subquery table refs` — `getBase` keeps the full serialized table path (`"s"."data"`), restoring the optimization for schema-qualified tables (and fixing cross-schema base-identity comparison as a side effect).
2. #1187 `fix: Bail out of preaggregation when mean-centering CTE-derived columns` — four explicit guards (divergent bases / aggregate-valued / window-valued / unresolvable-through-subqueries operands) throw into the existing bail channel.
3. #1188 `fix: Skip preaggregation for window functions without aggregate inputs` — a plain window function among selection outputs skips the optimization instead of landing in `GROUP BY` (conservative interim relative to #259's CTE-hoisting idea).
4. #1190 `fix: Skip preaggregation when verbatim active columns meet subqueries` — `preaggregateInfo` returns null when verbatim selection fields can't be pushed into client CTEs.
5. `refactor(core): Share one node-presence test across preagg bail-outs` — dedupes the walk helpers into `containsNode` (new `preagg/contains-node.ts`).
6. `refactor(core): Use a symbol for getBase's divergent-base result` — replaces the NaN sentinel; callers read `expr === DIVERGENT` instead of `typeof expr === 'number'`.

Commits 5–6 are separately droppable (reviewer-verified they revert cleanly in order) if you'd rather keep this PR fixes-only.

## Relationship to #1158

Complementary, verified empirically per fix: #1158 recovers *after* a failed view create; these guards prevent the invalid `CREATE TABLE` from being issued at all (cases 2–4), removing the error/log noise the recovery path would absorb. Case 1 is the only one that makes preaggregation *work* rather than bail.

## Test hardening

The schema-qualified test probes the materialized view directly; the bail-out tests assert the non-optimized route plus correct values. Six new tests total (core 72/72); revert checks reproduce exactly the expected per-fix failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
