### PR TITLE
refactor(sql): Collapse toDuckDBValue into literalToSQL

### DIFF
--- a/docs/api/sql/data-loading.md
+++ b/docs/api/sql/data-loading.md
@@ -41,7 +41,7 @@ The supported _options_ are:
 // Loads file.csv into the table "table1" with default options:
 // CREATE TABLE IF NOT EXISTS table1 AS
 //   SELECT *
-//   FROM read_csv('file.csv', auto_detect=true, sample_size=-1)
+//   FROM read_csv('file.csv', auto_detect=TRUE, sample_size=-1)
 loadCSV("table1", "file.csv");
 ```
 
@@ -65,7 +65,7 @@ The supported _options_ are:
 // Loads file.json into the table "table1" with default options:
 // CREATE TABLE IF NOT EXISTS table1 AS
 //   SELECT *
-//   FROM read_json('file.json', auto_detect=true, json_format='auto')
+//   FROM read_json('file.json', auto_detect=TRUE, json_format='auto')
 loadJSON("table1", "file.json");
 ```
 

--- a/docs/sql/index.md
+++ b/docs/sql/index.md
@@ -155,7 +155,7 @@ import { loadCSV, loadParquet } from "@uwdata/mosaic-sql";
 // Loads file.csv into the table "table1" with default options:
 // CREATE TABLE IF NOT EXISTS table1 AS
 //   SELECT *
-//   FROM read_csv('file.csv', auto_detect=true, sample_size=-1)
+//   FROM read_csv('file.csv', auto_detect=TRUE, sample_size=-1)
 const q1 = loadCSV("table1", "file.csv");
 
 // Load named columns from a parquet file, filtered upon load:

--- a/packages/mosaic/sql/src/load/load.ts
+++ b/packages/mosaic/sql/src/load/load.ts
@@ -73,30 +73,6 @@ export function loadObjects(
 
 function parameters(options: Record<string, unknown>) {
   return Object.entries(options)
-    .map(([key, value]) => `${key}=${toDuckDBValue(value)}`)
+    .map(([key, value]) => `${key}=${literalToSQL(value)}`)
     .join(', ');
-}
-
-function toDuckDBValue(value: unknown): string {
-  switch (typeof value) {
-    case 'boolean':
-      return String(value);
-    case 'string':
-      return literalToSQL(value);
-    case 'undefined':
-    case 'object':
-      if (value == null) {
-        return 'NULL';
-      } else if (Array.isArray(value)) {
-        return '[' + value.map(v => toDuckDBValue(v)).join(', ') + ']';
-      } else {
-        return '{'
-          + Object.entries(value)
-              .map(([k, v]) => `${literalToSQL(k)}: ${toDuckDBValue(v)}`)
-              .join(', ')
-          + '}';
-      }
-    default:
-      return `${value}`;
-  }
 }

--- a/packages/mosaic/sql/test/load.test.ts
+++ b/packages/mosaic/sql/test/load.test.ts
@@ -14,7 +14,7 @@ describe('loadCSV', () => {
       where: 'colX > 5'
     };
     expect(loadCSV('table', 'data.csv', base).toString()).toBe(
-      `CREATE TABLE IF NOT EXISTS "table" AS SELECT colA, colB FROM read_csv('data.csv', auto_detect=true, sample_size=-1) WHERE colX > 5`
+      `CREATE TABLE IF NOT EXISTS "table" AS SELECT colA, colB FROM read_csv('data.csv', auto_detect=TRUE, sample_size=-1) WHERE colX > 5`
     );
 
     const ext = {
@@ -23,7 +23,7 @@ describe('loadCSV', () => {
       replace: true
     };
     expect(loadCSV('table', 'data.csv', ext).toString()).toBe(
-      `CREATE OR REPLACE VIEW "table" AS SELECT colA, colB FROM read_csv('data.csv', auto_detect=true, sample_size=-1) WHERE colX > 5`
+      `CREATE OR REPLACE VIEW "table" AS SELECT colA, colB FROM read_csv('data.csv', auto_detect=TRUE, sample_size=-1) WHERE colX > 5`
     );
   });
 
@@ -38,7 +38,7 @@ describe('loadCSV', () => {
       skip: 2
     };
     expect(loadCSV('table', 'data.csv', opt).toString()).toBe(
-      `CREATE TABLE IF NOT EXISTS "table" AS SELECT * FROM read_csv('data.csv', auto_detect=false, sample_size=-1, all_varchar=true, columns={'line': 'VARCHAR'}, force_not_null=['line'], new_line='\\n', header=false, skip=2)`
+      `CREATE TABLE IF NOT EXISTS "table" AS SELECT * FROM read_csv('data.csv', auto_detect=FALSE, sample_size=-1, all_varchar=TRUE, columns={'line': 'VARCHAR'}, force_not_null=['line'], new_line='\\n', header=FALSE, skip=2)`
     );
   });
 
@@ -46,14 +46,14 @@ describe('loadCSV', () => {
   it('escapes single quotes in file paths', async () => {
     const file = dataFile(`john's data.csv`);
     await expect(loadCSV('data', file)).toBeValidQuery(
-      `CREATE TABLE IF NOT EXISTS "data" AS SELECT * FROM read_csv('${file.replaceAll(`'`, `''`)}', auto_detect=true, sample_size=-1)`
+      `CREATE TABLE IF NOT EXISTS "data" AS SELECT * FROM read_csv('${file.replaceAll(`'`, `''`)}', auto_detect=TRUE, sample_size=-1)`
     );
   });
 
   it('escapes single quotes in string options', async () => {
     const file = dataFile('quoted.csv');
     await expect(loadCSV('data2', file, { quote: `'` })).toBeValidQuery(
-      `CREATE TABLE IF NOT EXISTS "data2" AS SELECT * FROM read_csv('${file}', auto_detect=true, sample_size=-1, quote='''')`
+      `CREATE TABLE IF NOT EXISTS "data2" AS SELECT * FROM read_csv('${file}', auto_detect=TRUE, sample_size=-1, quote='''')`
     );
   });
 });


### PR DESCRIPTION
Fixes #1179. Part of the audit tracked in #1170. Stacked on #1176 — retarget to `main` once that merges; the diff here is only this change.

> **Note:** This fix was created by Claude (an agent team ran a binder-error audit of the SQL layer; this refactor was proposed by its simplifier pass and approved by @domoritz in the full-collapse form).

## What changed

`toDuckDBValue` in `load.ts` is deleted and `parameters()` calls `literalToSQL` directly, so read options go through the same serializer and escaping path as every other literal. Booleans in read options now emit `TRUE`/`FALSE` instead of `true`/`false` (identical to DuckDB) and non-finite numbers emit `NULL` instead of `Infinity` (which never bound). Test expectations and the generated-SQL examples in `docs/sql/index.md` and `docs/api/sql/data-loading.md` are updated for the casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEmcoxyFx2BRM5BbmJGFsa
