### PR TITLE
docs: fix loadJSON option name in generated SQL example

### DIFF
--- a/docs/api/sql/data-loading.md
+++ b/docs/api/sql/data-loading.md
@@ -65,7 +65,7 @@ The supported _options_ are:
 // Loads file.json into the table "table1" with default options:
 // CREATE TABLE IF NOT EXISTS table1 AS
 //   SELECT *
-//   FROM read_json('file.json', auto_detect=true, json_format='auto')
+//   FROM read_json('file.json', auto_detect=true, format='auto')
 loadJSON("table1", "file.json");
 ```
 


### PR DESCRIPTION
The `loadJSON` example in `docs/api/sql/data-loading.md` showed `json_format='auto'`; the code emits `format='auto'`.

> **Note:** This fix was created by Claude (noticed during the S-02 refactor in #1180).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEmcoxyFx2BRM5BbmJGFsa