### PR TITLE
fix: Wrap queries used as expressions in scalar subquery nodes

### DIFF
--- a/docs/api/sql/operators.md
+++ b/docs/api/sql/operators.md
@@ -1,6 +1,7 @@
 # Operators
 
 SQL comparison operator expressions.
+A query provided as an operand is included as a scalar subquery.
 
 ## and
 

--- a/docs/api/sql/queries.md
+++ b/docs/api/sql/queries.md
@@ -169,6 +169,7 @@ Coerce this query object to a SQL query string.
 
 Select columns and return this query instance.
 The _expressions_ argument may include column name strings, [`column` references](./expressions#column), and maps from column names to expressions (either as JavaScript `object` values or nested key-value arrays as produced by `Object.entries`).
+A query provided as an expression is included as a scalar subquery.
 
 ## from
 

--- a/packages/mosaic/sql/src/util/ast.ts
+++ b/packages/mosaic/sql/src/util/ast.ts
@@ -1,8 +1,11 @@
 import type { ColumnRefNode } from '../ast/column-ref.js';
 import type { TableRefNode } from '../ast/table-ref.js';
+import type { Query } from '../ast/query.js';
 import { FromClauseNode, FromNode } from '../ast/from.js';
 import { ExprNode, type SQLNode } from '../ast/node.js';
 import { ParamNode } from '../ast/param.js';
+import { ScalarSubqueryNode } from '../ast/subquery.js';
+import { PIVOT_QUERY, SELECT_QUERY, SET_OPERATION } from '../constants.js';
 import { WindowDefNode } from '../ast/window.js';
 import { column } from '../functions/column.js';
 import { literal, verbatim } from '../functions/literal.js';
@@ -37,13 +40,29 @@ export function asVerbatim(value: unknown): ExprNode {
 /**
  * Interpret a value as a literal AST node. All other primitive values
  * are interpreted as SQL literals. Dynamic parameters are interpreted
- * as param AST nodes, while existing AST nodes are left as-is.
+ * as param AST nodes, while existing AST nodes are left as-is, except
+ * for queries, which are wrapped as scalar subqueries.
  * @param value The value to interpret as a literal AST node.
  */
 export function asLiteral(value: unknown): ExprNode {
-  return value instanceof ExprNode ? value
+  return isQueryNode(value) ? new ScalarSubqueryNode(value)
+    : value instanceof ExprNode ? value
     : isParamLike(value) ? new ParamNode(value)
     : literal(value);
+}
+
+/**
+ * Check if a value is a query AST node. Tests node type strings rather
+ * than using `isQuery`, as importing the `Query` class here would create
+ * a circular module dependency.
+ * @param value The value to check.
+ */
+function isQueryNode(value: unknown): value is Query {
+  return value instanceof ExprNode && (
+    value.type === SELECT_QUERY ||
+    value.type === SET_OPERATION ||
+    value.type === PIVOT_QUERY
+  );
 }
 
 /**

--- a/packages/mosaic/sql/src/util/ast.ts
+++ b/packages/mosaic/sql/src/util/ast.ts
@@ -17,7 +17,8 @@ import { isArray, isParamLike, isString } from './type-check.js';
  * Interpret a value as a SQL AST node. String values are assumed to be
  * column references. All other primitive values are interpreted as
  * SQL literals. Dynamic parameters are interpreted as param AST nodes,
- * while existing AST nodes are left as-is.
+ * while existing AST nodes are left as-is, except for queries, which
+ * are wrapped as scalar subqueries.
  * @param value The value to interpret as a SQL AST node.
  */
 export function asNode(value: unknown): ExprNode {
@@ -28,7 +29,8 @@ export function asNode(value: unknown): ExprNode {
  * Interpret a value as a verbatim SQL AST node. String values will be
  * passed through to queries as verbatim text. All other primitive values
  * are interpreted as SQL literals. Dynamic parameters are interpreted
- * as param AST nodes, while existing AST nodes are left as-is.
+ * as param AST nodes, while existing AST nodes are left as-is, except
+ * for queries, which are wrapped as scalar subqueries.
  * @param value The value to interpret as a verbatim AST node.
  */
 export function asVerbatim(value: unknown): ExprNode {

--- a/packages/mosaic/sql/test/subquery.test.ts
+++ b/packages/mosaic/sql/test/subquery.test.ts
@@ -34,6 +34,24 @@ describe('Scalar subqueries', () => {
       'SELECT "num1" FROM "t1" WHERE ("num1" > (SELECT avg("num1") AS "a" FROM "t1"))'
     );
   });
+  it('wrap set operations used as operator operands', async () => {
+    const u = Query
+      .union(
+        Query.select('num1').from('t1'),
+        Query.select('num1').from('t2')
+      )
+      .limit(1);
+    await expect(
+      Query.select('num1').from('t1').where(gt('num1', u))
+    ).toBeValidQuery(
+      'SELECT "num1" FROM "t1" WHERE ("num1" > (SELECT "num1" FROM "t1" UNION SELECT "num1" FROM "t2" LIMIT 1))'
+    );
+  });
+  it('wrap pivot queries used as expressions', () => {
+    // structural only: DuckDB rejects multi-column pivots as scalar subqueries
+    const q = Query.select({ p: Query.pivot('t1') }).from('t1');
+    expect(String(q)).toBe('SELECT (PIVOT "t1") AS "p" FROM "t1"');
+  });
   it('wrap queries used in select lists', async () => {
     await expect(
       Query

--- a/packages/mosaic/sql/test/subquery.test.ts
+++ b/packages/mosaic/sql/test/subquery.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { column, InOpNode, Query, ScalarSubqueryNode } from '../src/index.js';
+import { avg, column, eq, gt, InOpNode, max, Query, ScalarSubqueryNode } from '../src/index.js';
 import { validateQuery } from './util/validate.js';
 
 describe('Scalar subqueries', () => {
@@ -15,5 +15,32 @@ describe('Scalar subqueries', () => {
     expect(String(subq)).toBe('(SELECT "num1" FROM "t1" LIMIT 3)');
     expect(String(test)).toBe('("num1" IN (SELECT "num1" FROM "t1" LIMIT 3))');
     await validateQuery(`SELECT ${test} FROM "t1"`)
+  });
+  it('wrap queries used as operator operands', async () => {
+    await expect(
+      Query
+        .select('num1')
+        .from('t1')
+        .where(eq(column('num1'), Query.select({ m: max('num1') }).from('t1')))
+    ).toBeValidQuery(
+      'SELECT "num1" FROM "t1" WHERE ("num1" = (SELECT max("num1") AS "m" FROM "t1"))'
+    );
+    await expect(
+      Query
+        .select('num1')
+        .from('t1')
+        .where(gt('num1', Query.select({ a: avg('num1') }).from('t1')))
+    ).toBeValidQuery(
+      'SELECT "num1" FROM "t1" WHERE ("num1" > (SELECT avg("num1") AS "a" FROM "t1"))'
+    );
+  });
+  it('wrap queries used in select lists', async () => {
+    await expect(
+      Query
+        .select({ m: Query.select({ a: avg('num1') }).from('t1') })
+        .from('t1')
+    ).toBeValidQuery(
+      'SELECT (SELECT avg("num1") AS "a" FROM "t1") AS "m" FROM "t1"'
+    );
   });
 });

--- a/packages/mosaic/sql/test/subquery.test.ts
+++ b/packages/mosaic/sql/test/subquery.test.ts
@@ -1,5 +1,6 @@
 import { expect, describe, it } from 'vitest';
-import { avg, column, eq, gt, InOpNode, max, Query, ScalarSubqueryNode } from '../src/index.js';
+import * as sql from '../src/index.js';
+import { asLiteral, avg, column, eq, gt, InOpNode, max, Query, ScalarSubqueryNode } from '../src/index.js';
 import { validateQuery } from './util/validate.js';
 
 describe('Scalar subqueries', () => {
@@ -60,5 +61,26 @@ describe('Scalar subqueries', () => {
     ).toBeValidQuery(
       'SELECT (SELECT avg("num1") AS "a" FROM "t1") AS "m" FROM "t1"'
     );
+  });
+  it('wrap every exported query subclass', () => {
+    const examples: Record<string, Query> = {
+      SelectQuery: Query.select('num1').from('t1'),
+      SetOperation: Query.union(
+        Query.select('num1').from('t1'),
+        Query.select('num1').from('t2')
+      ),
+      PivotQuery: Query.pivot('t1')
+    };
+
+    const subclasses = Object.entries(sql)
+      .filter(([, v]) => typeof v === 'function' && v.prototype instanceof Query)
+      .map(([name]) => name);
+
+    // a subclass without an example above is new and untested, not exempt
+    expect(subclasses.sort()).toStrictEqual(Object.keys(examples).sort());
+
+    for (const name of subclasses) {
+      expect(asLiteral(examples[name])).toBeInstanceOf(ScalarSubqueryNode);
+    }
   });
 });


### PR DESCRIPTION
Fixes #1191. Part of the audit tracked in #1170.

> **Note:** This fix was created by Claude (an agent team ran a binder-error audit of the SQL layer; the fix went through automated implementation, simplification, and adversarial review passes).

## What changed

`asNode` in `util/ast.ts` wraps a `Query` operand in a `ScalarSubqueryNode`, so every operator (`eq`, `gt`, `add`, …) emits `(SELECT …)` instead of bare `SELECT …`. Three follow-up commits from review: a test that covers set-operation and pivot query operands, a test that enumerates every exported `Query` subclass from the module and asserts each wraps (so a future subclass fails the test instead of silently serializing unwrapped), and a sentence in the SQL API docs noting that query expressions become scalar subqueries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEmcoxyFx2BRM5BbmJGFsa
