### PR TITLE
fix(sql): quote interval literals to support negative and fractional steps

### DIFF
--- a/packages/mosaic/sql/src/visit/codegen/duckdb.ts
+++ b/packages/mosaic/sql/src/visit/codegen/duckdb.ts
@@ -176,7 +176,8 @@ export class DuckDBCodeGenerator extends SQLCodeGenerator {
 
   visitInterval(node: IntervalNode): string {
     const { steps, name } = node;
-    return `INTERVAL ${steps} ${name}`;
+    // the quoted form supports negative and fractional steps
+    return `INTERVAL '${steps} ${name}'`;
   }
 
   visitJoinClause(node: JoinNode): string {

--- a/packages/mosaic/sql/test/bin.test.ts
+++ b/packages/mosaic/sql/test/bin.test.ts
@@ -43,84 +43,94 @@ describe('Binning transforms', () => {
 
     it('supports explicit time intervals', async () => {
       await expect(binDate('ts1', years, { interval: 'year', step: 2 }))
-        .toBeValidExpr('time_bucket(INTERVAL 2 year, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '2 year', "ts1")`);
 
       await expect(binDate('ts1', years, { interval: 'month', step: 6 }))
-        .toBeValidExpr('time_bucket(INTERVAL 6 month, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '6 month', "ts1")`);
 
       await expect(binDate('ts1', months, { interval: 'month', step: 1 }))
-        .toBeValidExpr('time_bucket(INTERVAL 1 month, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '1 month', "ts1")`);
 
       await expect(binDate('ts1', months, { interval: 'month', step: 3 }))
-        .toBeValidExpr('time_bucket(INTERVAL 3 month, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '3 month', "ts1")`);
 
       await expect(binDate('ts1', days, { interval: 'day', step: 2 }))
-        .toBeValidExpr('time_bucket(INTERVAL 2 day, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '2 day', "ts1")`);
 
       await expect(binDate('ts1', days, { interval: 'hour', step: 12 }))
-        .toBeValidExpr('time_bucket(INTERVAL 12 hour, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '12 hour', "ts1")`);
 
       await expect(binDate('ts1', [10, 20], { interval: 'millisecond', step: 10 }))
-        .toBeValidExpr('time_bucket(INTERVAL 10 millisecond, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '10 millisecond', "ts1")`);
 
       await expect(binDate('ts1', [0.1, 0.2], { interval: 'microsecond', step: 10 }))
-        .toBeValidExpr('time_bucket(INTERVAL 10 microsecond, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '10 microsecond', "ts1")`);
     });
 
     it('infers time intervals with steps', async () => {
       await expect(binDate('ts1', years, { steps: 11 }))
-        .toBeValidExpr('time_bucket(INTERVAL 1 year, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '1 year', "ts1")`);
 
       await expect(binDate('ts1', years, { steps: 30 }))
-        .toBeValidExpr('time_bucket(INTERVAL 3 month, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '3 month', "ts1")`);
 
       await expect(binDate('ts1', months, { steps: 25 }))
-        .toBeValidExpr('time_bucket(INTERVAL 1 month, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '1 month', "ts1")`);
 
       await expect(binDate('ts1', months, { steps: 100 }))
-        .toBeValidExpr('time_bucket(INTERVAL 7 day, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '7 day', "ts1")`);
 
       await expect(binDate('ts1', days, { steps: 10 }))
-        .toBeValidExpr('time_bucket(INTERVAL 1 day, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '1 day', "ts1")`);
 
       await expect(binDate('ts1', days, { steps: 20 }))
-        .toBeValidExpr('time_bucket(INTERVAL 12 hour, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '12 hour', "ts1")`);
 
       await expect(binDate('ts1', [10, 20], { steps: 10 }))
-        .toBeValidExpr('time_bucket(INTERVAL 1 millisecond, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '1 millisecond', "ts1")`);
 
       await expect(binDate('ts1', [0.1, 0.2], { steps: 10 }))
-        .toBeValidExpr('time_bucket(INTERVAL 10 microsecond, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '10 microsecond', "ts1")`);
     });
 
     it('infers time intervals', async () => {
       await expect(binDate('ts1', years))
-        .toBeValidExpr('time_bucket(INTERVAL 3 month, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '3 month', "ts1")`);
 
       await expect(binDate('ts1', months))
-        .toBeValidExpr('time_bucket(INTERVAL 1 month, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '1 month', "ts1")`);
 
       await expect(binDate('ts1', days))
-        .toBeValidExpr('time_bucket(INTERVAL 6 hour, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '6 hour', "ts1")`);
 
       await expect(binDate('ts1', [1e7, 2e7]))
-        .toBeValidExpr('time_bucket(INTERVAL 5 minute, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '5 minute', "ts1")`);
 
       await expect(binDate('ts1', [1e5, 2e5]))
-        .toBeValidExpr('time_bucket(INTERVAL 5 second, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '5 second', "ts1")`);
 
       await expect(binDate('ts1', [0, 100]))
-        .toBeValidExpr('time_bucket(INTERVAL 5 millisecond, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '5 millisecond', "ts1")`);
 
       await expect(binDate('ts1', [0, 0.1]))
-        .toBeValidExpr('time_bucket(INTERVAL 5 microsecond, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '5 microsecond', "ts1")`);
     });
 
     it('handles degenerate span', async () => {
       await expect(binDate('ts1', [1, 1]))
-        .toBeValidExpr('time_bucket(INTERVAL 1 day, "ts1")');
+        .toBeValidExpr(`time_bucket(INTERVAL '1 day', "ts1")`);
       await expect(binDate('ts1', [1, 1], { offset: 1 }))
-        .toBeValidExpr('(time_bucket(INTERVAL 1 day, "ts1") + INTERVAL 1 day)');
+        .toBeValidExpr(`(time_bucket(INTERVAL '1 day', "ts1") + INTERVAL '1 day')`);
+    });
+
+    it('supports negative offsets', async () => {
+      await expect(binDate('ts1', days, { interval: 'day', offset: -1 }))
+        .toBeValidExpr(`(time_bucket(INTERVAL '1 day', "ts1") + INTERVAL '-1 day')`);
+    });
+
+    it('supports fractional steps', async () => {
+      await expect(binDate('ts1', days, { interval: 'day', step: 0.5 }))
+        .toBeValidExpr(`time_bucket(INTERVAL '0.5 day', "ts1")`);
     });
   });
 });

--- a/packages/mosaic/sql/test/interval.test.ts
+++ b/packages/mosaic/sql/test/interval.test.ts
@@ -5,46 +5,52 @@ describe('Interval functions', () => {
   it('includes interval', async () => {
     const expr = interval('CENTURY', 2);
     expect(expr instanceof IntervalNode).toBe(true);
-    await expect(expr).toBeValidExpr('INTERVAL 2 CENTURY');
+    await expect(expr).toBeValidExpr(`INTERVAL '2 CENTURY'`);
   });
   it('includes years', async () => {
     const expr = years(5);
     expect(expr instanceof IntervalNode).toBe(true);
-    await expect(expr).toBeValidExpr('INTERVAL 5 YEARS');
+    await expect(expr).toBeValidExpr(`INTERVAL '5 YEARS'`);
   });
   it('includes months', async () => {
     const expr = months(5);
     expect(expr instanceof IntervalNode).toBe(true);
-    await expect(expr).toBeValidExpr('INTERVAL 5 MONTHS');
+    await expect(expr).toBeValidExpr(`INTERVAL '5 MONTHS'`);
   });
   it('includes days', async () => {
     const expr = days(5);
     expect(expr instanceof IntervalNode).toBe(true);
-    await expect(expr).toBeValidExpr('INTERVAL 5 DAYS');
+    await expect(expr).toBeValidExpr(`INTERVAL '5 DAYS'`);
   });
   it('includes hours', async () => {
     const expr = hours(5);
     expect(expr instanceof IntervalNode).toBe(true);
-    await expect(expr).toBeValidExpr('INTERVAL 5 HOURS');
+    await expect(expr).toBeValidExpr(`INTERVAL '5 HOURS'`);
   });
   it('includes minutes', async () => {
     const expr = minutes(5);
     expect(expr instanceof IntervalNode).toBe(true);
-    await expect(expr).toBeValidExpr('INTERVAL 5 MINUTES');
+    await expect(expr).toBeValidExpr(`INTERVAL '5 MINUTES'`);
   });
   it('includes seconds', async () => {
     const expr = seconds(5);
     expect(expr instanceof IntervalNode).toBe(true);
-    await expect(expr).toBeValidExpr('INTERVAL 5 SECONDS');
+    await expect(expr).toBeValidExpr(`INTERVAL '5 SECONDS'`);
   });
   it('includes milliseconds', async () => {
     const expr = milliseconds(5);
     expect(expr instanceof IntervalNode).toBe(true);
-    await expect(expr).toBeValidExpr('INTERVAL 5 MILLISECONDS');
+    await expect(expr).toBeValidExpr(`INTERVAL '5 MILLISECONDS'`);
   });
   it('includes microseconds', async () => {
     const expr = microseconds(5);
     expect(expr instanceof IntervalNode).toBe(true);
-    await expect(expr).toBeValidExpr('INTERVAL 5 MICROSECONDS');
+    await expect(expr).toBeValidExpr(`INTERVAL '5 MICROSECONDS'`);
+  });
+  it('supports negative steps', async () => {
+    await expect(days(-3)).toBeValidExpr(`INTERVAL '-3 DAYS'`);
+  });
+  it('supports fractional steps', async () => {
+    await expect(days(0.5)).toBeValidExpr(`INTERVAL '0.5 DAYS'`);
   });
 });

--- a/packages/mosaic/sql/test/window.test.ts
+++ b/packages/mosaic/sql/test/window.test.ts
@@ -58,7 +58,7 @@ describe('Window functions', () => {
     await expect(first_value('num1').frame(frameRange([2, currentRow()])).orderby('num1'))
       .toBeValidExpr('first_value("num1") OVER (ORDER BY "num1" RANGE BETWEEN 2 PRECEDING AND CURRENT ROW)');
     await expect(first_value('num1').frame(frameRange([preceding(days(3)), following(days(2))])).orderby('ts1'))
-      .toBeValidExpr('first_value("num1") OVER (ORDER BY "ts1" RANGE BETWEEN INTERVAL 3 DAYS PRECEDING AND INTERVAL 2 DAYS FOLLOWING)');
+      .toBeValidExpr(`first_value("num1") OVER (ORDER BY "ts1" RANGE BETWEEN INTERVAL '3 DAYS' PRECEDING AND INTERVAL '2 DAYS' FOLLOWING)`);
   });
 
   it('support groups frame', async () => {


### PR DESCRIPTION
Fixes #1192. Part of the audit tracked in #1170.

> **Note:** This fix was created by Claude (an agent team ran a binder-error audit of the SQL layer; the fix went through automated implementation, simplification, and adversarial review passes).

## What changed

`visitInterval` quotes the interval value (`INTERVAL '-3 DAYS'`), the form DuckDB accepts for negative and fractional steps as well as positive integers. Existing interval test expectations are updated to the quoted form; new binder-backed tests cover negative `days()`, negative `binDate` offsets, and a fractional step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEmcoxyFx2BRM5BbmJGFsa
