### PR TITLE
fix: Avoid forward CTE reference in filterPushdown when the target is a CTE

### DIFF
--- a/packages/mosaic/sql/src/transforms/filter-query.ts
+++ b/packages/mosaic/sql/src/transforms/filter-query.ts
@@ -68,12 +68,18 @@ export function filterPushdown(
     }
   });
 
-  // add filtered table as CTE node
+  // add filtered table as CTE node, after the target CTE if there is one:
+  // non-recursive WITH clauses can not use forward references
   const cte = new WithClauseNode(
     filteredName,
     Query.select("*").from(tableRef).where(filter)
   );
-  clone._with = [cte, ...clone._with];
+  const index = 1 + clone._with.findIndex(w => w.name === tableRef.name);
+  clone._with = [
+    ...clone._with.slice(0, index),
+    cte,
+    ...clone._with.slice(index)
+  ];
   return clone;
 }
 

--- a/packages/mosaic/sql/test/filter-pushdown.test.ts
+++ b/packages/mosaic/sql/test/filter-pushdown.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest';
-import { column, count, cross_join, div, eq, filterPushdown, FromClauseNode, gt, join, Query, ScalarSubqueryNode, sum, TableRefNode } from '../src/index.js';
+import { column, count, cross_join, cte, div, eq, filterPushdown, FromClauseNode, gt, join, Query, ScalarSubqueryNode, sum, TableRefNode } from '../src/index.js';
 
 describe('filterPushdown', () => {
   it('does nothing given empty filter', async () => {
@@ -130,6 +130,39 @@ describe('filterPushdown', () => {
     const f = filterPushdown(q, 't1', gt('num2', 2));
     await expect(f).toBeValidQuery(
       'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1" JOIN "t2" ON ("t1"."num3" = "t2"."num3")'
+    );
+  });
+
+  it('updates tables defined as CTEs', async () => {
+    const q = Query
+      .with({ mycte: Query.select('*').from('t1') })
+      .select('*').from('mycte');
+    const f = filterPushdown(q, 'mycte', gt('num1', 1));
+    await expect(f).toBeValidQuery(
+      'WITH "mycte" AS (SELECT * FROM "t1"), "_mycte" AS (SELECT * FROM "mycte" WHERE ("num1" > 1)) SELECT * FROM "_mycte" AS "mycte"'
+    );
+  });
+
+  it('updates tables defined as CTEs with dependent CTEs', async () => {
+    const q = Query
+      .with({
+        mycte: Query.select('*').from('t1'),
+        derived: Query.select('num1').from('mycte')
+      })
+      .select('*').from('derived');
+    const f = filterPushdown(q, 'mycte', gt('num1', 1));
+    await expect(f).toBeValidQuery(
+      'WITH "mycte" AS (SELECT * FROM "t1"), "_mycte" AS (SELECT * FROM "mycte" WHERE ("num1" > 1)), "derived" AS (SELECT "num1" FROM "_mycte" AS "mycte") SELECT * FROM "derived"'
+    );
+  });
+
+  it('updates tables defined as CTEs with column aliases', async () => {
+    const q = Query
+      .with(cte('mycte', Query.select('num1').from('t1'), null, ['val']))
+      .select('*').from('mycte');
+    const f = filterPushdown(q, 'mycte', gt('val', 1));
+    await expect(f).toBeValidQuery(
+      'WITH "mycte"("val") AS (SELECT "num1" FROM "t1"), "_mycte" AS (SELECT * FROM "mycte" WHERE ("val" > 1)) SELECT * FROM "_mycte" AS "mycte"'
     );
   });
 


### PR DESCRIPTION
Fixes #1194. Part of the audit tracked in #1170.

> **Note:** This fix was created by Claude (an agent team ran a binder-error audit of the SQL layer; the fix went through automated implementation, simplification, and adversarial review passes).

## What changed

When the `filterPushdown` target is one of the query's own CTEs, the filtered CTE is inserted right after that CTE's definition instead of being prepended to the `WITH` list, so it no longer references a name defined later in the same clause. Pushdown onto a base table is unchanged. A binder-backed test covers the CTE-target case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEmcoxyFx2BRM5BbmJGFsa
