### PR TITLE
fix: Throw when DISTINCT has no aggregate argument

### DIFF
--- a/docs/api/sql/aggregate-functions.md
+++ b/docs/api/sql/aggregate-functions.md
@@ -12,6 +12,7 @@ Users should not need to instantiate `AggregateNode` instances directly, but ins
 `AggregateNode.distinct()`
 
 Returns a new AggregateNode instance that applies the aggregation over distinct values only.
+Throws an error if the aggregate has no arguments, as in `count()`, which aggregates over all rows.
 
 ### where
 

--- a/packages/mosaic/sql/src/ast/aggregate.ts
+++ b/packages/mosaic/sql/src/ast/aggregate.ts
@@ -48,6 +48,9 @@ export class AggregateNode extends ExprNode {
    * @returns A new aggregate node.
    */
   distinct(isDistinct: boolean = true) {
+    if (isDistinct && this.args.length === 0) {
+      throw new Error(`AggregateNode.distinct requires an aggregate argument; ${this.name}() without arguments aggregates over all rows.`);
+    }
     return new AggregateNode(this.name, this.args, isDistinct, this.filter, this.order);
   }
 

--- a/packages/mosaic/sql/test/aggregate.test.ts
+++ b/packages/mosaic/sql/test/aggregate.test.ts
@@ -16,6 +16,10 @@ describe('Aggregate functions', () => {
     await expect(expr).toBeValidExpr('count(DISTINCT "num1")');
   });
 
+  it('reject distinct without an aggregate argument', () => {
+    expect(() => count().distinct()).toThrowError(/requires an aggregate argument/);
+  });
+
   it('support filter', async () => {
     const foo = column('num1');
     await expect(avg(foo).where(gt(foo, 5)))


### PR DESCRIPTION
Fixes #1195. Part of the audit tracked in #1170.

> **Note:** This fix was created by Claude (an agent team ran a binder-error audit of the SQL layer; the fix went through automated implementation, simplification, and adversarial review passes; @domoritz chose the throwing behavior over a silent rewrite).

## What changed

`AggregateNode.distinct()` throws when the aggregate has no argument, with a message saying `count()` without arguments already aggregates over all rows. Previously `count().distinct()` serialized to `count(DISTINCT *)`, which DuckDB rejects at query time; there is no context-free SQL for a distinct row count, so the combination is refused at construction instead of being silently reinterpreted. The constraint is noted in the aggregate-functions API docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEmcoxyFx2BRM5BbmJGFsa
