### PR TITLE
fix: newline-terminate verbatim SQL ending in a line comment

### DIFF
--- a/packages/mosaic/sql/src/visit/codegen/duckdb.ts
+++ b/packages/mosaic/sql/src/visit/codegen/duckdb.ts
@@ -56,6 +56,10 @@ import { SQLCodeGenerator } from './sql.js';
 import { CURRENT_ROW, FOLLOWING, PRECEDING, UNBOUNDED } from '../../ast/window-frame.js';
 import { WINDOW_EXTENT_EXPR } from '../../constants.js';
 
+// an open `--` comment would swallow whatever the serializer appends next;
+// `--` inside a string literal also matches, costing only a harmless newline
+const OPEN_LINE_COMMENT = /--[^\n]*$/;
+
 /**
  * DuckDB SQL dialect visitor for converting AST nodes to DuckDB-compatible SQL.
  */
@@ -414,7 +418,7 @@ export class DuckDBCodeGenerator extends SQLCodeGenerator {
 
   visitVerbatim(node: VerbatimNode): string {
     const { value } = node;
-    return value;
+    return OPEN_LINE_COMMENT.test(value) ? `${value}\n` : value;
   }
 
   visitWhen(node: WhenNode): string {

--- a/packages/mosaic/sql/test/sql-template.test.ts
+++ b/packages/mosaic/sql/test/sql-template.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it } from 'vitest';
 import { stubParam } from './util/stub-param.js';
-import { column, isParamLike, sql } from '../src/index.js';
+import { Query, column, isParamLike, sql } from '../src/index.js';
 import { columns, params } from './util/columns.js';
 
 describe('sql expression', () => {
@@ -53,5 +53,54 @@ describe('sql expression', () => {
 
     param.update(5);
     await expect(expr).toBeValidExpr('"num1" * 5 + 1');
+  });
+});
+
+describe('sql expression with a line comment', () => {
+  it('keeps a following alias and select entry', async () => {
+    const query = Query
+      .from('t1')
+      .select({ y: sql`num1 -- a note`, d: 'txt2' });
+    await expect(query).toBeValidQuery(
+      'SELECT num1 -- a note\n AS "y", "txt2" AS "d" FROM "t1"'
+    );
+  });
+
+  it('keeps a following FROM clause', async () => {
+    const query = Query
+      .from('t1')
+      .select({ d: 'txt2', y: sql`num1 -- a note` });
+    await expect(query).toBeValidQuery(
+      'SELECT "txt2" AS "d", num1 -- a note\n AS "y" FROM "t1"'
+    );
+  });
+
+  it('keeps a following GROUP BY clause', async () => {
+    const query = Query
+      .from('t1')
+      .select('num1')
+      .where(sql`num1 > 5 -- keep positives`)
+      .groupby('num1');
+    await expect(query).toBeValidQuery(
+      'SELECT "num1" FROM "t1" WHERE num1 > 5 -- keep positives\n GROUP BY "num1"'
+    );
+  });
+
+  it('does not add a second newline to a terminated comment', async () => {
+    const query = Query
+      .from('t1')
+      .select({ y: sql`num1 -- a note\n`, d: 'txt2' });
+    await expect(query).toBeValidQuery(
+      'SELECT num1 -- a note\n AS "y", "txt2" AS "d" FROM "t1"'
+    );
+  });
+
+  it('keeps a select entry following a string literal with dashes', async () => {
+    const query = Query
+      .from('t1')
+      .select({ y: sql`txt1 || ' -- not a comment '`, d: 'txt2' });
+    await expect(query).toBeValidQuery(
+      'SELECT txt1 || \' -- not a comment \'\n AS "y", "txt2" AS "d" FROM "t1"'
+    );
   });
 });


### PR DESCRIPTION
Fixes #1201. Part of the audit tracked in #1170.

> **Note:** This fix was created by Claude (an agent team ran a binder-error audit of the SQL layer; the fix went through automated implementation and adversarial review passes).

## What changed

`visitVerbatim` appends a newline when the verbatim text ends inside a `--` comment, so whatever the serializer emits next starts on a fresh line. Every `VerbatimNode` producer (`sql` templates, `verbatim()`, string `CreateQuery` bodies) goes through this visitor, so the one guard covers `SELECT`, `WHERE`, `GROUP BY`, and nested positions. A `--` inside a string literal also triggers it; that costs an unneeded newline and nothing else, and is pinned by a test so a future quote-aware scan has to update it deliberately.

Five binder-backed tests. The `WHERE … -- comment` + `GROUP BY` case asserts the emitted string, because the truncated statement is valid SQL and validation alone cannot catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEmcoxyFx2BRM5BbmJGFsa
