### PR TITLE
fix: match filter pushdown tables by full name path

### DIFF
--- a/packages/mosaic/sql/src/transforms/filter-query.ts
+++ b/packages/mosaic/sql/src/transforms/filter-query.ts
@@ -12,7 +12,9 @@ import { WithClauseNode } from '../ast/with.js';
 /**
  * Perform filter pushdown on a query: clone a query and push a filter into
  * the given base table via a CTE, so every reference to the table sees the
- * filtered rows. Skips scalar subqueries.
+ * filtered rows. Skips scalar subqueries. Throws if the query references the
+ * table under a different name path, as pushing down would otherwise drop the
+ * filter without notice.
  * @param query The query to clone and extend.
  * @param table The base table as a table name or table reference node.
  * @param filter The filter predicate expression to add. May only reference
@@ -33,15 +35,17 @@ export function filterPushdown(
 
   // determine unique name for filtered CTE
   const names = new Set<string>();
-  walk(clone, (node) => {
-    if (isTableRef(node)) {
-      names.add(node.name);
+  const conflicts = new Set<string>();
+  walk(clone, (node, parent) => {
+    if (!isTableRef(node)) return;
+    names.add(node.name);
+    if (parent instanceof ColumnRefNode) {
+      return; // a qualifier names a source, it does not introduce one
+    }
+    if (node.name === tableRef.name && !arrayEquals(node.table, tableRef.table)) {
+      conflicts.add(`${node}`);
     }
   });
-  if (!names.has(tableRef.name)) {
-    // filtered table not present in query, nothing to do
-    return clone;
-  }
   let filteredName = `_${tableRef.name}`;
   while (names.has(filteredName)) {
     filteredName = `_${filteredName}`;
@@ -50,6 +54,7 @@ export function filterPushdown(
   // rename table refs to the filtered CTE, keeping each source visible
   // under its original name so that column qualifiers still bind
   const visibleName = tableRef.name;
+  let rewritten = false;
   walk(clone, (node, parent) => {
     if (node.type === SCALAR_SUBQUERY) {
       return 1; // don't recurse
@@ -58,15 +63,30 @@ export function filterPushdown(
       return; // not a reference to the filtered table
     }
     if (parent instanceof ColumnRefNode) {
-      return; // column qualifiers keep binding to the visible name
+      // a CTE alias can not carry a schema, so qualifiers that spell out the
+      // catalog path collapse to the visible name
+      // @ts-expect-error set read-only property
+      node.table = [visibleName];
+      return;
     }
     // @ts-expect-error set read-only property
     node.table = [filteredName];
+    rewritten = true;
     if (parent instanceof FromClauseNode && !parent.alias) {
       // @ts-expect-error set read-only property
       parent.alias = visibleName;
     }
   });
+  if (!rewritten) {
+    if (conflicts.size) {
+      throw new Error(
+        `Filter pushdown table ${tableRef} does not match `
+        + `${[...conflicts].join(', ')} in the query.`
+      );
+    }
+    // filtered table not present in query, nothing to do
+    return clone;
+  }
 
   // add filtered table as CTE node, after the target CTE if there is one:
   // non-recursive WITH clauses can not use forward references

--- a/packages/mosaic/sql/test/filter-pushdown.test.ts
+++ b/packages/mosaic/sql/test/filter-pushdown.test.ts
@@ -174,4 +174,92 @@ describe('filterPushdown', () => {
       'WITH "_t1" AS (SELECT * FROM "t1" WHERE ("num2" > 2)) SELECT ("num1" / (SELECT count(*) AS "count" FROM "t1")) AS "norm" FROM "_t1" AS "t1"'
     );
   });
+
+  it('updates schema-qualified tables', async () => {
+    const q = Query.select(column('num1', main())).from(main());
+    const f = filterPushdown(q, main(), gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "main"."t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1"'
+    );
+  });
+
+  it('updates schema-qualified tables in joins', async () => {
+    const q = Query
+      .select(column('num1', main()))
+      .from(join(main(), 't2', {
+        on: eq(column('num3', main()), column('num3', 't2'))
+      }));
+    const f = filterPushdown(q, main(), gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "main"."t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1" FROM "_t1" AS "t1" JOIN "t2" ON ("t1"."num3" = "t2"."num3")'
+    );
+  });
+
+  it('preserves same-named sources in subqueries', async () => {
+    const sub = Query
+      .select({ v: column('num2', 't1') })
+      .from(new FromClauseNode(new TableRefNode('t2'), 't1'));
+    const q = Query
+      .select(column('num1', main()), 'v')
+      .from(main(), new FromClauseNode(sub, 's'));
+    const f = filterPushdown(q, main(), gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "main"."t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1", "v" FROM "_t1" AS "t1", (SELECT "t1"."num2" AS "v" FROM "t2" AS "t1") AS "s"'
+    );
+  });
+
+  it('updates schema-qualified tables in subqueries', async () => {
+    const sub = Query.select({ v: column('num2', main()) }).from(main());
+    const q = Query
+      .select(column('num1', main()), 'v')
+      .from(main(), new FromClauseNode(sub, 's'));
+    const f = filterPushdown(q, main(), gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "main"."t1" WHERE ("num2" > 2)) SELECT "t1"."num1" AS "num1", "v" FROM "_t1" AS "t1", (SELECT "t1"."num2" AS "v" FROM "_t1" AS "t1") AS "s"'
+    );
+  });
+
+  it('does nothing given a table used only in a scalar subquery', async () => {
+    const sub = new ScalarSubqueryNode(Query.select({ c: count() }).from('t1'));
+    const q = Query.select({ c: sub }).from('t2');
+    const f = filterPushdown(q, 't1', gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'SELECT (SELECT count(*) AS "c" FROM "t1") AS "c" FROM "t2"'
+    );
+  });
+
+  it('skips scalar subqueries over schema-qualified tables', async () => {
+    const sub = new ScalarSubqueryNode(
+      Query.select({ count: count(column('num1', main())) }).from(main())
+    );
+    const q = Query
+      .select({ norm: div(column('num1', main()), sub) })
+      .from(main());
+    const f = filterPushdown(q, main(), gt('num2', 2));
+    await expect(f).toBeValidQuery(
+      'WITH "_t1" AS (SELECT * FROM "main"."t1" WHERE ("num2" > 2)) SELECT ("t1"."num1" / (SELECT count("main"."t1"."num1") AS "count" FROM "main"."t1")) AS "norm" FROM "_t1" AS "t1"'
+    );
+  });
+
+  it('throws given a table path that does not match the query', () => {
+    const qualified = Query.select('num1').from(main());
+    expect(() => filterPushdown(qualified, 't1', gt('num2', 2)))
+      .toThrowError('Filter pushdown table "t1" does not match "main"."t1" in the query.');
+
+    const bare = Query.select('num1').from('t1');
+    expect(() => filterPushdown(bare, main(), gt('num2', 2)))
+      .toThrowError('Filter pushdown table "main"."t1" does not match "t1" in the query.');
+
+    const bareQualifier = Query.select(column('num1', 't1')).from(main());
+    expect(() => filterPushdown(bareQualifier, 't1', gt('num2', 2)))
+      .toThrowError('Filter pushdown table "t1" does not match "main"."t1" in the query.');
+
+    const pathQualifier = Query.select(column('num1', main())).from('t1');
+    expect(() => filterPushdown(pathQualifier, main(), gt('num2', 2)))
+      .toThrowError('Filter pushdown table "main"."t1" does not match "t1" in the query.');
+  });
 });
+
+function main() {
+  return new TableRefNode(['main', 't1']);
+}


### PR DESCRIPTION
Fixes #1101. Part of the audit tracked in #1170. Stacked on #1199 (same file); retarget to `main` once that merges.

> **Note:** This fix was created by Claude (an agent team ran a binder-error audit of the SQL layer; the fix went through automated implementation and adversarial review passes; @domoritz chose throwing over silent matching for the name/path mismatch).

## What changed

`filterPushdown` had two ideas of what identifies the filtered table: the presence check compared the visible name, the rewrite compared the full path. It now matches on the full path in both places, and the rewrite walk also collapses multi-part column qualifiers that match the filtered table to the visible name (`"main"."t1"."num1"` → `"t1"."num1"`), since a CTE alias cannot carry a schema. Because this happens inside the existing walk, the #1035 scalar-subquery exemption and subquery scoping apply to qualifiers exactly as they do to sources.

Whether a filter was applied is now decided by the rewrite walk itself (did it rename a source?) rather than by a separate presence scan, so the CTE is only emitted when something reads from it; a table that appears only inside a scalar subquery — exempt from pushdown per #1035 — now returns the query untouched instead of carrying a dead CTE. If nothing matched the full path but some reference shares the last segment (pushing `t1` into a query over `main.t1`, or the reverse, in `FROM` or as a column qualifier), the function throws `Filter pushdown table "t1" does not match "main"."t1" in the query.` instead of silently returning unfiltered rows; `mosaic-sql` has no catalog, so it cannot know whether the two name the same table.

Seven binder-backed tests: the two #1101 cases, the throw in all four spellings, a schema-qualified table in a join, a nested subquery over the same table (rewritten consistently in both scopes), a subquery whose own source is a different table under the same alias (its qualifier stays), and the scalar-only no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEmcoxyFx2BRM5BbmJGFsa
