### PR TITLE
fix: Fix sql scale transforms.

### DIFF
--- a/packages/mosaic/sql/src/transforms/scales.ts
+++ b/packages/mosaic/sql/src/transforms/scales.ts
@@ -61,25 +61,25 @@ function scaleLinear(): ScaleTransform<number> {
 function scaleLog({ base = null }: {base?: number | null} = { }): ScaleTransform<number> {
   if (base == null || base === Math.E) {
     return {
-      apply: Math.log,
-      invert: Math.exp,
-      sqlApply: c => ln(c),
-      sqlInvert: c => exp(c)
+      apply: x => Math.sign(x) * Math.log(Math.abs(x)),
+      invert: x => Math.sign(x) * Math.exp(Math.abs(x)),
+      sqlApply: c => (c = asNode(c), mul(sign(c), ln(abs(c)))),
+      sqlInvert: c => (c = asNode(c), mul(sign(c), exp(abs(c))))
     };
   } else if (base === 10) {
     return {
-      apply: Math.log10,
-      invert: x => Math.pow(10, x),
-      sqlApply: c => log(c),
-      sqlInvert: c => pow(10, c)
+      apply: x => Math.sign(x) * Math.log10(Math.abs(x)),
+      invert: x => Math.sign(x) * Math.pow(10, Math.abs(x)),
+      sqlApply: c => (c = asNode(c), mul(sign(c), log(abs(c)))),
+      sqlInvert: c => (c = asNode(c), mul(sign(c), pow(10, abs(c))))
     };
   } else {
     const b = +base;
     return {
-      apply: x => Math.log(x) / Math.log(b),
-      invert: x => Math.pow(b, x),
-      sqlApply: c => div(ln(c), ln(b)),
-      sqlInvert: c => pow(b, c)
+      apply: x => Math.sign(x) * Math.log(Math.abs(x)) / Math.log(b),
+      invert: x => Math.sign(x) * Math.pow(b, Math.abs(x)),
+      sqlApply: c => (c = asNode(c), mul(sign(c), div(ln(abs(c)), ln(b)))),
+      sqlInvert: c => (c = asNode(c), mul(sign(c), pow(b, abs(c))))
     };
   }
 }
@@ -87,10 +87,10 @@ function scaleLog({ base = null }: {base?: number | null} = { }): ScaleTransform
 function scaleSymlog({ constant = 1 } = {}): ScaleTransform<number> {
   const _ = +constant;
   return {
-    apply: x => Math.sign(x) * Math.log1p(Math.abs(x)),
-    invert: x => Math.sign(x) * Math.exp(Math.abs(x) - _),
-    sqlApply: c => (c = asNode(c), mul(sign(c), ln(add(_, abs(c))))),
-    sqlInvert: c => mul(sign(c), sub(exp(abs(c)), _))
+    apply: x => Math.sign(x) * Math.log1p(Math.abs(x / _)),
+    invert: x => Math.sign(x) * Math.expm1(Math.abs(x)) * _,
+    sqlApply: c => (c = asNode(c), mul(sign(c), ln(add(1, abs(div(c, _)))))),
+    sqlInvert: c => mul(sign(c), mul(sub(exp(abs(c)), 1), _))
   };
 }
 

--- a/packages/mosaic/sql/test/bin.test.ts
+++ b/packages/mosaic/sql/test/bin.test.ts
@@ -23,11 +23,11 @@ describe('Binning transforms', () => {
     it('creates non-linear bins', async () => {
       const log10 = scaleTransform<number>({ type: 'log', base: 10 })!;
       await expect(binHistogram('num1', [1, 1000], { steps: 5 }, log10))
-        .toBeValidExpr('(10 ** floor(log("num1")))');
+        .toBeValidExpr('(sign(floor((sign("num1") * log(abs("num1"))))) * (10 ** abs(floor((sign("num1") * log(abs("num1")))))))');
 
       const log2 = scaleTransform<number>({ type: 'log', base: 2 })!;
       await expect(binHistogram('num1', [1, 64], { steps: 10 }, log2))
-        .toBeValidExpr('(2 ** floor((ln("num1") / ln(2))))');
+        .toBeValidExpr('(sign(floor((sign("num1") * (ln(abs("num1")) / ln(2))))) * (2 ** abs(floor((sign("num1") * (ln(abs("num1")) / ln(2)))))))');
     });
 
     it('handles degenerate span', async () => {

--- a/packages/mosaic/sql/test/scales.test.ts
+++ b/packages/mosaic/sql/test/scales.test.ts
@@ -1,0 +1,107 @@
+import { expect, describe, it } from 'vitest';
+import { scaleTransform } from '../src/index.js';
+
+function transformExp(base: number) {
+  return base === 10 ? (x: number) => Math.pow(10, x)
+    : base === Math.E ? Math.exp
+    : (x: number) => Math.pow(base, x);
+}
+
+function transformLog(base: number) {
+  return base === Math.E ? Math.log
+    : base === 10 && Math.log10
+    || (base = Math.log(base), x => Math.log(x) / base);
+}
+
+function wrap(f: (x: number) => number) {
+  return (x: number) => Math.sign(x) * f(Math.abs(x));
+}
+
+function transformSqrt(x: number) {
+  return Math.sign(x) * Math.sqrt(Math.abs(x));
+}
+
+function transformSquare(x: number) {
+  return Math.sign(x) * x * x;
+}
+
+function transformPow(e: number) {
+  return (x: number) => Math.sign(x) * Math.pow(Math.abs(x), e);
+}
+
+function transformSymlog(c: number) {
+  return (x: number) => Math.sign(x) * Math.log1p(Math.abs(x / c));
+}
+
+function transformSymexp(c: number) {
+  return (x: number) => Math.sign(x) * Math.expm1(Math.abs(x)) * c;
+}
+
+describe('scaleTransform', () => {
+  it('supports linear scale', () => {
+    const values = [-100, -50, -25, -10, -5, 0, 5, 10, 25, 50, 100];
+    const s = scaleTransform<number>({ type: 'linear' });
+    for (const v of values) {
+      expect(s.apply(v)).toBe(v);
+      expect(s.invert(v)).toBe(v);
+      expect(s.invert(s.apply(v))).toBe(v);
+    }
+  });
+
+  it('supports log scale', () => {
+    const values = [-100, -50, -25, -10, -5, 5, 10, 25, 50, 100];
+    const bases = [2, Math.E, 10];
+    for (const b of bases) {
+      const s = scaleTransform<number>({ type: 'log', base: b });
+      const f = wrap(transformLog(b));
+      const i = wrap(transformExp(b));
+      for (const v of values) {
+        expect(s.apply(v)).toBeCloseTo(f(v), 9);
+        expect(s.invert(v)).toBeCloseTo(i(v), 9);
+        expect(s.invert(s.apply(v))).toBeCloseTo(v, 9);
+      }
+    }
+  });
+
+  it('supports sqrt scale', () => {
+    const values = [-100, -50, -25, -10, -5, 0, 5, 10, 25, 50, 100];
+    const s = scaleTransform<number>({ type: 'sqrt' });
+    const f = transformSqrt;
+    const i = transformSquare;
+    for (const v of values) {
+      expect(s.apply(v)).toBe(f(v));
+      expect(s.invert(v)).toBe(i(v));
+      expect(s.invert(s.apply(v))).toBeCloseTo(v, 9);
+    }
+  });
+
+  it('supports pow scale', () => {
+    const values = [-100, -50, -25, -10, -5, 0, 5, 10, 25, 50, 100];
+    const exponents = [1, 1/3, 1/10];
+    for (const e of exponents) {
+      const s = scaleTransform<number>({ type: 'pow', exponent: e });
+      const f = transformPow(e);
+      const i = transformPow(1 / e);
+      for (const v of values) {
+        expect(s.apply(v)).toBe(f(v));
+        expect(s.invert(v)).toBe(i(v));
+        expect(s.invert(s.apply(v))).toBeCloseTo(v, 9);
+      }
+    }
+  });
+
+  it('supports symlog scale', () => {
+    const values = [-100, -50, -25, -10, -5, 0, 5, 10, 25, 50, 100];
+    const constants = [1, 2, 3];
+    for (const c of constants) {
+      const s = scaleTransform<number>({ type: 'symlog', constant: c });
+      const f = transformSymlog(c);
+      const i = transformSymexp(c);
+      for (const v of values) {
+        expect(s.apply(v)).toBe(f(v));
+        expect(s.invert(v)).toBe(i(v));
+        expect(s.invert(s.apply(v))).toBeCloseTo(v, 9);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Fix SQL scale transforms:

- Update log scale transforms to support negative domains.
- Update symlog scale transforms to use correct equations.
- Add tests for scale transform and invert functions.

Close #1059 (this PR supercedes it).