### PR TITLE
feat(go-server)!: expose typed command payloads

### DIFF
--- a/docs/api/core/connectors.md
+++ b/docs/api/core/connectors.md
@@ -11,6 +11,29 @@ The _query_ argument is an object that may include the following properties:
 
 Once instantiated, register a connector with the coordinator using the [`coordinator.databaseConnector()`](coordinator#databaseconnector) method.
 
+## Application fields
+
+A custom connector can attach application-owned fields to the final outgoing command:
+
+```js
+import { Coordinator, restConnector } from '@uwdata/mosaic-core';
+
+const transport = restConnector({ uri: 'http://localhost:3000/' });
+const fields = { requestTag: ['dashboard', 42], trace: 'example' };
+const connector = {
+  query({ type, sql, ...options }) {
+    return transport.query({ ...options, ...fields, type, sql });
+  }
+};
+const coordinator = new Coordinator(connector);
+```
+
+The same wrapper works with `socketConnector({ uri: 'ws://localhost:3000/' })`, attaching fields to each message. The field names and JSON values in this example are application choices; Mosaic defines no metadata key or schema. Existing command fields retain their protocol meaning.
+
+Attach fields in the connector because query consolidation can discard options passed to `coordinator.query`. The client cache is keyed by SQL and can bypass the connector entirely. If application fields change result or authorization scope, isolate coordinator/cache/consolidation state for each scope or disable the relevant reuse; changing fields on a shared connector does not partition that state.
+
+Programs embedding the [Go server](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go#application-command-fields) can inspect the full request payload through `Command.Raw()` in their command authorizer. Its README describes payload copies, HTTP GET behavior, and the `WithMaxMessageBytes` option.
+
 ## socketConnector
 
 `socketConnector(uri)`

--- a/docs/api/core/connectors.md
+++ b/docs/api/core/connectors.md
@@ -19,7 +19,7 @@ A custom connector can attach application-owned fields to the final outgoing com
 import { Coordinator, restConnector } from '@uwdata/mosaic-core';
 
 const transport = restConnector({ uri: 'http://localhost:3000/' });
-const fields = { requestTag: ['dashboard', 42], trace: 'example' };
+const fields = { project: 'dashboard', labels: ['interactive'] };
 const connector = {
   query({ type, sql, ...options }) {
     return transport.query({ ...options, ...fields, type, sql });
@@ -32,17 +32,17 @@ The same wrapper works with `socketConnector({ uri: 'ws://localhost:3000/' })`, 
 
 Attach fields in the connector because query consolidation can discard options passed to `coordinator.query`. The client cache is keyed by SQL and can bypass the connector entirely. If application fields change result or authorization scope, isolate coordinator/cache/consolidation state for each scope or disable the relevant reuse; changing fields on a shared connector does not partition that state.
 
-Programs embedding the [Go server](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go#application-command-fields) can inspect the full request payload through `Command.Raw()` in their command authorizer. Its README describes payload copies, HTTP GET behavior, and the `WithMaxMessageBytes` option.
+Programs embedding the [Go server](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go#application-command-fields) choose their payload type with `Authorizer[T]` and receive it through `Command[T].Payload()`. The server decodes the complete command envelope into the application's type without choosing a metadata field or schema. Its README includes a typed Go example, payload ownership and HTTP GET behavior, and the `WithMaxMessageBytes` option.
 
 ## socketConnector
 
-`socketConnector(uri)`
+`socketConnector({ uri })`
 
 Create a new Web Socket connector to a DuckDB [data server](../duckdb/data-server) at the given _uri_ (default `"ws://localhost:3000/"`).
 
 ## restConnector
 
-`restConnector(uri)`
+`restConnector({ uri })`
 
 Create a new HTTP rest connector to a DuckDB [data server](../duckdb/data-server) at the given _uri_ (default `"http://localhost:3000/"`).
 

--- a/docs/api/core/connectors.md
+++ b/docs/api/core/connectors.md
@@ -11,38 +11,15 @@ The _query_ argument is an object that may include the following properties:
 
 Once instantiated, register a connector with the coordinator using the [`coordinator.databaseConnector()`](coordinator#databaseconnector) method.
 
-## Application fields
-
-A custom connector can attach application-owned fields to the final outgoing command:
-
-```js
-import { Coordinator, restConnector } from '@uwdata/mosaic-core';
-
-const transport = restConnector({ uri: 'http://localhost:3000/' });
-const fields = { project: 'dashboard', labels: ['interactive'] };
-const connector = {
-  query({ type, sql, ...options }) {
-    return transport.query({ ...options, ...fields, type, sql });
-  }
-};
-const coordinator = new Coordinator(connector);
-```
-
-The same wrapper works with `socketConnector({ uri: 'ws://localhost:3000/' })`, attaching fields to each message. The field names and JSON values in this example are application choices; Mosaic defines no metadata key or schema. Existing command fields retain their protocol meaning.
-
-Attach fields in the connector because query consolidation can discard options passed to `coordinator.query`. The client cache is keyed by SQL and can bypass the connector entirely. If application fields change result or authorization scope, isolate coordinator/cache/consolidation state for each scope or disable the relevant reuse; changing fields on a shared connector does not partition that state.
-
-Programs embedding the [Go server](https://github.com/uwdata/mosaic/tree/main/packages/server/duckdb-server-go#application-command-fields) choose their payload type with `Authorizer[T]` and receive it through `Command[T].Payload()`. The server decodes the complete command envelope into the application's type without choosing a metadata field or schema. Its README includes a typed Go example, payload ownership and HTTP GET behavior, and the `WithMaxMessageBytes` option.
-
 ## socketConnector
 
-`socketConnector({ uri })`
+`socketConnector(uri)`
 
 Create a new Web Socket connector to a DuckDB [data server](../duckdb/data-server) at the given _uri_ (default `"ws://localhost:3000/"`).
 
 ## restConnector
 
-`restConnector({ uri })`
+`restConnector(uri)`
 
 Create a new HTTP rest connector to a DuckDB [data server](../duckdb/data-server) at the given _uri_ (default `"http://localhost:3000/"`).
 

--- a/packages/server/duckdb-server-go/README.md
+++ b/packages/server/duckdb-server-go/README.md
@@ -66,7 +66,7 @@ aborts the connection. Extensions are trusted native code, so load only trusted 
 
 Programs embedding `pkg/server` should authenticate with standard HTTP middleware around the handler returned by
 `server.New`, then use `server.WithAuthorizer` only for command-aware policy. `AuthorizeRequest` runs once before POST
-decoding or WebSocket upgrade and returns a `CommandAuthorizer` called for every decoded command, including each
+decoding or WebSocket upgrade and returns a `CommandAuthorizer[T]` called for every decoded command, including each
 WebSocket message, before policy validation or execution. If it reads `r.Body`, it must restore it; both
 authorizers must be concurrency-safe. Outer middleware must decide whether CORS preflight `OPTIONS` requests may reach
 the server.
@@ -79,13 +79,37 @@ credentials.
 
 ### Application Command Fields
 
-Custom connectors may add application fields containing arbitrary JSON values. Mosaic does not define a metadata key, schema, nesting shape, or namespace. The server decodes its existing `type`, `sql`, and `name` fields and preserves the complete envelope for the embedding application.
+Custom connectors may add application fields containing arbitrary JSON values. Mosaic does not define a metadata key, schema, nesting shape, or namespace. Choose an application payload type with `Authorizer[T]` or `AuthorizerFunc[T]`; `WithAuthorizer` infers that type, while `New` and the other server options remain non-generic.
 
-In a `CommandAuthorizer`, `command.Raw()` returns a fresh `json.RawMessage` containing the exact POST body as presented to the handler, or the individual WebSocket payload after decoding and decompression. Whitespace, escapes, key order, duplicate keys, and number spelling are preserved. Applications can decode their fields into their own types without conversion through `float64`. Mutating the returned slice cannot change the command or later `Raw()` calls.
+After decoding and validating its existing `type`, `sql`, and `name` fields, the server uses `encoding/json.Unmarshal` to decode the complete envelope into a fresh `T` for the command authorizer. `command.Payload()` returns that typed value. Your type can contain your own fields, nesting, maps, slices, and number types, or implement `UnmarshalJSON` for custom decoding. Use `struct{}` when no application fields are needed, or `json.RawMessage` to retain the JSON value, including duplicate keys, key order, escapes, and numeric spelling; normal JSON decoding skips surrounding whitespace. No application fields are converted through `float64` unless your chosen type uses that representation, such as `any`.
 
-`command.Type()` and `command.SQL()` are authoritative for the command that executes; do not re-derive them from `Raw()`. Existing Go JSON decoding rules for command fields, including case-insensitive key matching and null values, remain in effect. Application fields are untrusted input: their meaning and authorization policy belong to the embedder, and they do not automatically set trusted headers, catalogs, schemas, or permissions.
+`command.Type()` and `command.SQL()` are authoritative for the command that executes; do not re-derive them from the application payload. Existing Go JSON decoding rules for command fields, including case-insensitive key matching and null values, remain in effect. The decoded payload belongs to the application and may be mutable; `Payload()` does not deep-copy it. Mutating it cannot rewrite the command type or SQL. Each command starts with a fresh zero `T`, without reusing decoded maps, slices, or pointers from another request or WebSocket message. Custom unmarshaler implementations are responsible for their own sharing and retention.
 
-For HTTP GET, `Raw()` returns nil. Inspect `r.URL.Query()` or `r.URL.RawQuery` in `AuthorizeRequest` and capture the relevant values in the returned command authorizer. The server neither synthesizes a JSON body nor rejects extra query parameters.
+For HTTP GET, the server skips payload decoding and `Payload()` returns the zero value of `T`. Choose a pointer type such as `*Fields` for an explicit nil case, and inspect `r.URL.Query()` or `r.URL.RawQuery` in `AuthorizeRequest` to capture application parameters. The server neither synthesizes a JSON body nor rejects extra query parameters.
+
+For example, an application can limit commands to its `dashboard` project, with GET parameters as a fallback:
+
+```go
+type Fields struct {
+	Project string `json:"project"`
+}
+
+authorizer := server.AuthorizerFunc[*Fields](func(r *http.Request) (server.CommandAuthorizer[*Fields], error) {
+	getProject := r.URL.Query().Get("project")
+	return func(ctx context.Context, command server.Command[*Fields]) error {
+		project := getProject
+		if fields := command.Payload(); fields != nil {
+			project = fields.Project
+		}
+		if project != "dashboard" || command.Type() == server.CommandExec {
+			return server.ErrPermissionDenied
+		}
+		return nil
+	}, nil
+})
+```
+
+The field name and policy above are application choices. Application fields are untrusted input: real authorization must also use authenticated identity, and fields do not automatically set trusted headers, catalogs, schemas, or permissions. The compiled [`ExampleNew`](pkg/server/example_test.go) combines typed payloads with middleware-provided identity. A payload that cannot decode into `T` is rejected before the command authorizer runs, using sanitized `ErrInvalidCommand` handling: HTTP 400 or a recoverable WebSocket `bad_request`, not a session close.
 
 Attach application fields to the final outgoing command in a connector wrapper:
 
@@ -93,7 +117,7 @@ Attach application fields to the final outgoing command in a connector wrapper:
 import { Coordinator, restConnector } from '@uwdata/mosaic-core';
 
 const transport = restConnector({ uri: 'http://localhost:3000/' });
-const fields = { requestTag: ['dashboard', 42], trace: 'example' };
+const fields = { project: 'dashboard', labels: ['interactive'] };
 const connector = {
   query({ type, sql, ...options }) {
     return transport.query({ ...options, ...fields, type, sql });
@@ -113,9 +137,9 @@ handler, err := server.New(db,
 )
 ```
 
-The limit applies to POST bodies and decompressed WebSocket messages after request authorization and before command authorization or execution. It does not separately limit application fields. Without the option, POST bodies remain unbounded and WebSocket messages retain their existing 32 KiB limit. Oversized POST bodies receive HTTP 413; oversized WebSocket messages close the session with code 1009, including compressed messages that expand past the limit. Request authorizers that read the body must restore it and enforce any limits needed for their own reads.
+The limit applies to POST bodies and decompressed WebSocket messages after request authorization and before payload decoding, command authorization, or execution. It does not separately limit application fields. Without the option, POST bodies remain unbounded and WebSocket messages retain their existing 32 KiB limit. Oversized POST bodies receive HTTP 413 and log a warning with the configured limit, without the payload; oversized WebSocket messages close the session with code 1009, including compressed messages that expand past the limit. Request authorizers that read the body must restore it and enforce any limits needed for their own reads.
 
-POST now requires one complete command object with optional surrounding JSON whitespace, matching WebSocket decoding. Trailing data and a second JSON value are rejected, whereas the previous POST decoder ignored them. JSON decoding failures return HTTP 400 or close a WebSocket with code 1007. Successfully decoded commands that fail required-field validation or authorization produce command errors; authorization denial leaves a healthy WebSocket session available for later commands. Existing SQL policy validation and restricted-`exec` enforcement still apply.
+POST requires one complete command object with optional surrounding JSON whitespace, matching WebSocket decoding. Trailing data and additional JSON values are rejected. Protocol JSON decoding failures return HTTP 400 or close a WebSocket with code 1007. Successfully decoded commands that fail required-field validation, application payload decoding, or authorization produce command errors and leave a healthy WebSocket session available for later commands. Existing SQL policy validation and restricted-`exec` enforcement still apply.
 
 ### Function Policies
 

--- a/packages/server/duckdb-server-go/README.md
+++ b/packages/server/duckdb-server-go/README.md
@@ -79,17 +79,7 @@ credentials.
 
 ### Application Command Fields
 
-Custom connectors may add application fields containing arbitrary JSON values. Mosaic does not define a metadata key, schema, nesting shape, or namespace. Choose an application payload type with `Authorizer[T]` or `AuthorizerFunc[T]`; `WithAuthorizer` infers that type, while `New` and the other server options remain non-generic.
-
-To migrate an authorizer that needs no application fields, change `AuthorizerFunc(...)` to `AuthorizerFunc[struct{}](...)` and use `CommandAuthorizer[struct{}]` and `Command[struct{}]` in its signatures. The type argument on `AuthorizerFunc` is required; `WithAuthorizer(authorizer)` infers it.
-
-After decoding and validating its existing `type`, `sql`, and `name` fields, the server uses `encoding/json.Unmarshal` to decode the complete envelope into a fresh `T` for the command authorizer. `command.Payload()` returns that typed value. Your type can contain your own fields, nesting, maps, slices, and number types, or implement `UnmarshalJSON` for custom decoding. Use `struct{}` when no application fields are needed, or `json.RawMessage` to retain the JSON value, including duplicate keys, key order, escapes, and numeric spelling; normal JSON decoding skips surrounding whitespace. No application fields are converted through `float64` unless your chosen type uses that representation, such as `any`.
-
-The built-in `struct{}` type skips application decoding. A custom decoder using `DisallowUnknownFields` must account for protocol keys such as `type`, `sql`, and `name`, because it receives the whole envelope, not a metadata-only object.
-
-`command.Type()` and `command.SQL()` are authoritative for the command that executes; do not re-derive them from the application payload. Existing Go JSON decoding rules for command fields, including case-insensitive key matching and null values, remain in effect. The decoded payload belongs to the application and may be mutable; `Payload()` does not deep-copy it. Mutating it cannot rewrite the command type or SQL. Each command starts with a fresh zero `T`, without reusing decoded maps, slices, or pointers from another request or WebSocket message. Custom unmarshaler implementations are responsible for their own sharing and retention.
-
-For HTTP GET, the server skips payload decoding and `Payload()` returns the zero value of `T`. Choose a pointer type such as `*Fields` for an explicit nil case, and inspect `r.URL.Query()` or `r.URL.RawQuery` in `AuthorizeRequest` to capture application parameters. The server neither synthesizes a JSON body nor rejects extra query parameters.
+Application fields can be siblings of `type` and `sql` or nested, for example under `meta`. Mosaic defines no metadata schema. Choose the complete envelope's Go type with `Authorizer[T]` or `AuthorizerFunc[T]`; `command.Payload()` returns it. `WithAuthorizer` infers `T`, while `New` stays non-generic.
 
 For example, an application can limit commands to its `dashboard` project, with GET parameters as a fallback:
 
@@ -111,39 +101,24 @@ authorizer := server.AuthorizerFunc[*Fields](func(r *http.Request) (server.Comma
 		return nil
 	}, nil
 })
-```
 
-The field name and policy above are application choices. Application fields are untrusted input: real authorization must also use authenticated identity, and fields do not automatically set trusted headers, catalogs, schemas, or permissions. The compiled [`ExampleNew`](pkg/server/example_test.go) combines typed payloads with middleware-provided identity. A payload that cannot decode into `T` is rejected before the command authorizer runs, using sanitized `ErrInvalidCommand` handling: HTTP 400 or a recoverable WebSocket `bad_request`, not a session close. Decode failures log a warning with the error type and, for `json.UnmarshalTypeError`, the field, offset, and target type. Error text and payload values are not logged, since custom errors and numeric overflow errors can contain application data.
-
-Attach application fields to the final outgoing command in a connector wrapper:
-
-```js
-import { Coordinator, restConnector } from '@uwdata/mosaic-core';
-
-const transport = restConnector({ uri: 'http://localhost:3000/' });
-const fields = { project: 'dashboard', labels: ['interactive'] };
-const connector = {
-  query({ type, sql, ...options }) {
-    return transport.query({ ...options, ...fields, type, sql });
-  }
-};
-const coordinator = new Coordinator(connector);
-```
-
-The same wrapper works with `socketConnector({ uri: 'ws://localhost:3000/' })`. Query consolidation can discard options passed to `coordinator.query`, and the SQL-keyed client cache can bypass the connector. If application fields change result or authorization scope, isolate coordinator/cache/consolidation state for each scope or disable the relevant reuse. Changing fields on a shared connector does not partition that state.
-
-Configure a limit on the entire command payload with `server.WithMaxMessageBytes(n)`, where `n` must be positive:
-
-```go
 handler, err := server.New(db,
 	server.WithAuthorizer(authorizer),
 	server.WithMaxMessageBytes(1<<20),
 )
 ```
 
-The limit applies to POST bodies and decompressed WebSocket messages after request authorization and before payload decoding, command authorization, or execution. It does not separately limit application fields. Without the option, POST bodies remain unbounded and WebSocket messages retain their existing 32 KiB limit. Oversized POST bodies receive HTTP 413 and log a warning with the configured limit, without the payload; oversized WebSocket messages close the session with code 1009, including compressed messages that expand past the limit. Request authorizers that read the body must restore it and enforce any limits needed for their own reads.
+Each POST or WebSocket command decodes into a fresh `T` using `encoding/json`. `Payload()` returns that value without copying; mutations cannot change the authoritative `Type()` or `SQL()`. Custom decoders are responsible for their own sharing and must account for protocol keys (`type`, `sql`, `name`) when rejecting unknown fields.
 
-POST requires one complete command object with optional surrounding JSON whitespace, matching WebSocket decoding. Trailing data and additional JSON values are rejected. Protocol JSON decoding failures return HTTP 400 or close a WebSocket with code 1007. Successfully decoded commands that fail required-field validation, application payload decoding, or authorization produce command errors and leave a healthy WebSocket session available for later commands. Existing SQL policy validation and restricted-`exec` enforcement still apply.
+Use structs, maps, or custom `UnmarshalJSON` implementations as needed. `json.RawMessage` preserves JSON value bytes, not surrounding whitespace. If no application fields are needed, `struct{}` skips application decoding; existing authorizers can migrate to `AuthorizerFunc[struct{}]`, `CommandAuthorizer[struct{}]`, and `Command[struct{}]`.
+
+GET skips JSON decoding and supplies the zero value of `T` (`nil` for pointers); capture query parameters in `AuthorizeRequest`. Payload decoding failures reject the command before command authorization with HTTP 400 or a recoverable WebSocket `bad_request`, and log a warning without payload values.
+
+Application fields are untrusted: combine them with authenticated identity, as shown in the compiled [`ExampleNew`](pkg/server/example_test.go). Client caching can bypass the connector, and consolidation can discard query options. If fields affect results or access, isolate coordinator/cache/consolidation state per scope or disable that reuse.
+
+`WithMaxMessageBytes(n)` requires a positive byte limit for entire POST bodies and decompressed WebSocket messages, applied after request authorization and before decoding. Defaults are unbounded POST bodies and 32 KiB WebSocket messages. Exceeding the limit returns HTTP 413 or closes the WebSocket with code 1009. Request authorizers reading the body must enforce their own limits and restore it.
+
+POST and WebSocket messages require one complete command object with optional surrounding whitespace; trailing data is rejected. Protocol decoding failures return HTTP 400 or close the WebSocket with code 1007. Validation and authorization errors leave a healthy WebSocket session open.
 
 ### Function Policies
 

--- a/packages/server/duckdb-server-go/README.md
+++ b/packages/server/duckdb-server-go/README.md
@@ -81,7 +81,11 @@ credentials.
 
 Custom connectors may add application fields containing arbitrary JSON values. Mosaic does not define a metadata key, schema, nesting shape, or namespace. Choose an application payload type with `Authorizer[T]` or `AuthorizerFunc[T]`; `WithAuthorizer` infers that type, while `New` and the other server options remain non-generic.
 
+To migrate an authorizer that needs no application fields, change `AuthorizerFunc(...)` to `AuthorizerFunc[struct{}](...)` and use `CommandAuthorizer[struct{}]` and `Command[struct{}]` in its signatures. The type argument on `AuthorizerFunc` is required; `WithAuthorizer(authorizer)` infers it.
+
 After decoding and validating its existing `type`, `sql`, and `name` fields, the server uses `encoding/json.Unmarshal` to decode the complete envelope into a fresh `T` for the command authorizer. `command.Payload()` returns that typed value. Your type can contain your own fields, nesting, maps, slices, and number types, or implement `UnmarshalJSON` for custom decoding. Use `struct{}` when no application fields are needed, or `json.RawMessage` to retain the JSON value, including duplicate keys, key order, escapes, and numeric spelling; normal JSON decoding skips surrounding whitespace. No application fields are converted through `float64` unless your chosen type uses that representation, such as `any`.
+
+The built-in `struct{}` type skips application decoding. A custom decoder using `DisallowUnknownFields` must account for protocol keys such as `type`, `sql`, and `name`, because it receives the whole envelope, not a metadata-only object.
 
 `command.Type()` and `command.SQL()` are authoritative for the command that executes; do not re-derive them from the application payload. Existing Go JSON decoding rules for command fields, including case-insensitive key matching and null values, remain in effect. The decoded payload belongs to the application and may be mutable; `Payload()` does not deep-copy it. Mutating it cannot rewrite the command type or SQL. Each command starts with a fresh zero `T`, without reusing decoded maps, slices, or pointers from another request or WebSocket message. Custom unmarshaler implementations are responsible for their own sharing and retention.
 
@@ -109,7 +113,7 @@ authorizer := server.AuthorizerFunc[*Fields](func(r *http.Request) (server.Comma
 })
 ```
 
-The field name and policy above are application choices. Application fields are untrusted input: real authorization must also use authenticated identity, and fields do not automatically set trusted headers, catalogs, schemas, or permissions. The compiled [`ExampleNew`](pkg/server/example_test.go) combines typed payloads with middleware-provided identity. A payload that cannot decode into `T` is rejected before the command authorizer runs, using sanitized `ErrInvalidCommand` handling: HTTP 400 or a recoverable WebSocket `bad_request`, not a session close.
+The field name and policy above are application choices. Application fields are untrusted input: real authorization must also use authenticated identity, and fields do not automatically set trusted headers, catalogs, schemas, or permissions. The compiled [`ExampleNew`](pkg/server/example_test.go) combines typed payloads with middleware-provided identity. A payload that cannot decode into `T` is rejected before the command authorizer runs, using sanitized `ErrInvalidCommand` handling: HTTP 400 or a recoverable WebSocket `bad_request`, not a session close. Decode failures log a warning with the error type and, for `json.UnmarshalTypeError`, the field, offset, and target type. Error text and payload values are not logged, since custom errors and numeric overflow errors can contain application data.
 
 Attach application fields to the final outgoing command in a connector wrapper:
 

--- a/packages/server/duckdb-server-go/README.md
+++ b/packages/server/duckdb-server-go/README.md
@@ -77,6 +77,46 @@ errors are logged and returned as sanitized 500 responses. Authorization can all
 and exact SQL, but cannot rewrite SQL or sandbox the shared process, filesystem, network, extensions, catalogs, or
 credentials.
 
+### Application Command Fields
+
+Custom connectors may add application fields containing arbitrary JSON values. Mosaic does not define a metadata key, schema, nesting shape, or namespace. The server decodes its existing `type`, `sql`, and `name` fields and preserves the complete envelope for the embedding application.
+
+In a `CommandAuthorizer`, `command.Raw()` returns a fresh `json.RawMessage` containing the exact POST body as presented to the handler, or the individual WebSocket payload after decoding and decompression. Whitespace, escapes, key order, duplicate keys, and number spelling are preserved. Applications can decode their fields into their own types without conversion through `float64`. Mutating the returned slice cannot change the command or later `Raw()` calls.
+
+`command.Type()` and `command.SQL()` are authoritative for the command that executes; do not re-derive them from `Raw()`. Existing Go JSON decoding rules for command fields, including case-insensitive key matching and null values, remain in effect. Application fields are untrusted input: their meaning and authorization policy belong to the embedder, and they do not automatically set trusted headers, catalogs, schemas, or permissions.
+
+For HTTP GET, `Raw()` returns nil. Inspect `r.URL.Query()` or `r.URL.RawQuery` in `AuthorizeRequest` and capture the relevant values in the returned command authorizer. The server neither synthesizes a JSON body nor rejects extra query parameters.
+
+Attach application fields to the final outgoing command in a connector wrapper:
+
+```js
+import { Coordinator, restConnector } from '@uwdata/mosaic-core';
+
+const transport = restConnector({ uri: 'http://localhost:3000/' });
+const fields = { requestTag: ['dashboard', 42], trace: 'example' };
+const connector = {
+  query({ type, sql, ...options }) {
+    return transport.query({ ...options, ...fields, type, sql });
+  }
+};
+const coordinator = new Coordinator(connector);
+```
+
+The same wrapper works with `socketConnector({ uri: 'ws://localhost:3000/' })`. Query consolidation can discard options passed to `coordinator.query`, and the SQL-keyed client cache can bypass the connector. If application fields change result or authorization scope, isolate coordinator/cache/consolidation state for each scope or disable the relevant reuse. Changing fields on a shared connector does not partition that state.
+
+Configure a limit on the entire command payload with `server.WithMaxMessageBytes(n)`, where `n` must be positive:
+
+```go
+handler, err := server.New(db,
+	server.WithAuthorizer(authorizer),
+	server.WithMaxMessageBytes(1<<20),
+)
+```
+
+The limit applies to POST bodies and decompressed WebSocket messages after request authorization and before command authorization or execution. It does not separately limit application fields. Without the option, POST bodies remain unbounded and WebSocket messages retain their existing 32 KiB limit. Oversized POST bodies receive HTTP 413; oversized WebSocket messages close the session with code 1009, including compressed messages that expand past the limit. Request authorizers that read the body must restore it and enforce any limits needed for their own reads.
+
+POST now requires one complete command object with optional surrounding JSON whitespace, matching WebSocket decoding. Trailing data and a second JSON value are rejected, whereas the previous POST decoder ignored them. JSON decoding failures return HTTP 400 or close a WebSocket with code 1007. Successfully decoded commands that fail required-field validation or authorization produce command errors; authorization denial leaves a healthy WebSocket session available for later commands. Existing SQL policy validation and restricted-`exec` enforcement still apply.
+
 ### Function Policies
 
 Use an allowlist when the server should accept only reviewed functions and operators. An explicitly empty value enables

--- a/packages/server/duckdb-server-go/pkg/server/authorization.go
+++ b/packages/server/duckdb-server-go/pkg/server/authorization.go
@@ -88,8 +88,14 @@ func WithAuthorizer[T any](authorizer Authorizer[T]) Option {
 			}
 			return func(ctx context.Context, params queryParams) error {
 				var payload T
-				if params.raw != nil {
+				if _, empty := any(&payload).(*struct{}); !empty && params.raw != nil {
 					if err := json.Unmarshal(params.raw, &payload); err != nil {
+						attrs := []any{"error_type", fmt.Sprintf("%T", err)}
+						var typeErr *json.UnmarshalTypeError
+						if errors.As(err, &typeErr) {
+							attrs = append(attrs, "field", typeErr.Field, "offset", typeErr.Offset, "target_type", typeErr.Type.String())
+						}
+						cfg.logger.Warn("server: failed to decode command payload", attrs...)
 						return fmt.Errorf("%w: decode command payload: %w", ErrInvalidCommand, err)
 					}
 				}

--- a/packages/server/duckdb-server-go/pkg/server/authorization.go
+++ b/packages/server/duckdb-server-go/pkg/server/authorization.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 )
@@ -26,10 +27,11 @@ const (
 type Command struct {
 	typ CommandType
 	sql string
+	raw string
 }
 
-func newCommand(typ CommandType, sql string) Command {
-	return Command{typ: typ, sql: sql}
+func newCommand(typ CommandType, sql, raw string) Command {
+	return Command{typ: typ, sql: sql, raw: raw}
 }
 
 func (c Command) Type() CommandType {
@@ -38,6 +40,16 @@ func (c Command) Type() CommandType {
 
 func (c Command) SQL() string {
 	return c.sql
+}
+
+// Raw returns an independent copy of the complete request payload after transport
+// decoding, or nil for HTTP GET. Applications interpret their own fields; Type
+// and SQL are authoritative for the command that executes.
+func (c Command) Raw() json.RawMessage {
+	if c.raw == "" {
+		return nil
+	}
+	return json.RawMessage(c.raw)
 }
 
 // CommandAuthorizer authorizes one decoded and validated command from a request.

--- a/packages/server/duckdb-server-go/pkg/server/authorization.go
+++ b/packages/server/duckdb-server-go/pkg/server/authorization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 )
 
@@ -22,56 +23,79 @@ const (
 	CommandExec  CommandType = "exec"
 )
 
-// Command is the immutable command information presented for authorization.
-// Commands are created by the server only after request decoding and validation.
-type Command struct {
-	typ CommandType
-	sql string
-	raw string
+// Command exposes the authoritative type and SQL alongside an application-owned
+// payload decoded from the complete command envelope.
+type Command[T any] struct {
+	typ     CommandType
+	sql     string
+	payload T
 }
 
-func newCommand(typ CommandType, sql, raw string) Command {
-	return Command{typ: typ, sql: sql, raw: raw}
-}
-
-func (c Command) Type() CommandType {
+func (c Command[T]) Type() CommandType {
 	return c.typ
 }
 
-func (c Command) SQL() string {
+func (c Command[T]) SQL() string {
 	return c.sql
 }
 
-// Raw returns an independent copy of the complete request payload after transport
-// decoding, or nil for HTTP GET. Applications interpret their own fields; Type
-// and SQL are authoritative for the command that executes.
-func (c Command) Raw() json.RawMessage {
-	if c.raw == "" {
-		return nil
-	}
-	return json.RawMessage(c.raw)
+// Payload returns the application's decoded value, or the zero value of T for
+// HTTP GET. It may contain mutable data; mutations cannot change Type or SQL.
+func (c Command[T]) Payload() T {
+	return c.payload
 }
 
 // CommandAuthorizer authorizes one decoded and validated command from a request.
 // Returning a non-nil error denies the command. Unexpected errors are sanitized
 // as internal authorization failures.
-type CommandAuthorizer func(context.Context, Command) error
+type CommandAuthorizer[T any] func(context.Context, Command[T]) error
 
 // Authorizer creates the command authorizer used for a single HTTP request or
 // WebSocket session. AuthorizeRequest is called before a POST body is decoded
 // or a WebSocket is upgraded. It should normally inspect the request line,
 // headers, and context. If it reads r.Body, it must restore the body before
 // returning so the server can decode it.
-type Authorizer interface {
-	AuthorizeRequest(*http.Request) (CommandAuthorizer, error)
+type Authorizer[T any] interface {
+	AuthorizeRequest(*http.Request) (CommandAuthorizer[T], error)
 }
 
-type AuthorizerFunc func(*http.Request) (CommandAuthorizer, error)
+type AuthorizerFunc[T any] func(*http.Request) (CommandAuthorizer[T], error)
 
-func (f AuthorizerFunc) AuthorizeRequest(r *http.Request) (CommandAuthorizer, error) {
+func (f AuthorizerFunc[T]) AuthorizeRequest(r *http.Request) (CommandAuthorizer[T], error) {
 	if f == nil {
 		return nil, errNilAuthorizerFunc
 	}
 
 	return f(r)
+}
+
+type requestAuthorizer func(*http.Request) (commandAuthorizer, error)
+type commandAuthorizer func(context.Context, queryParams) error
+
+// WithAuthorizer decodes each complete JSON envelope into a fresh T before
+// command authorization. Payload decoding failures reject the command with
+// ErrInvalidCommand; HTTP GET skips decoding and uses the zero value of T.
+func WithAuthorizer[T any](authorizer Authorizer[T]) Option {
+	return optionFunc(func(cfg *config) error {
+		if authorizer == nil || isNilValue(authorizer) {
+			return errNilAuthorizer
+		}
+
+		cfg.authorizer = func(r *http.Request) (commandAuthorizer, error) {
+			authorize, err := authorizer.AuthorizeRequest(r)
+			if err != nil || authorize == nil {
+				return nil, err
+			}
+			return func(ctx context.Context, params queryParams) error {
+				var payload T
+				if params.raw != nil {
+					if err := json.Unmarshal(params.raw, &payload); err != nil {
+						return fmt.Errorf("%w: decode command payload: %w", ErrInvalidCommand, err)
+					}
+				}
+				return authorize(ctx, Command[T]{typ: *params.Type, sql: *params.SQL, payload: payload})
+			}, nil
+		}
+		return nil
+	})
 }

--- a/packages/server/duckdb-server-go/pkg/server/authorization_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/authorization_test.go
@@ -57,8 +57,8 @@ func TestCommandDenialPrecedesExecutor(t *testing.T) {
 		},
 	}
 
-	handler := mustHandler(t, spy, WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
-		return func(context.Context, Command) error {
+	handler := mustHandler(t, spy, WithAuthorizer(AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
+		return func(context.Context, Command[json.RawMessage]) error {
 			return ErrPermissionDenied
 		}, nil
 	})))
@@ -89,8 +89,8 @@ func TestCommandAuthorizationRunsImmediatelyBeforeExecutor(t *testing.T) {
 		},
 	}
 
-	handler := mustHandler(t, spy, WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
-		return func(_ context.Context, command Command) error {
+	handler := mustHandler(t, spy, WithAuthorizer(AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
+		return func(_ context.Context, command Command[json.RawMessage]) error {
 			appendEvent("authorize")
 			require.Equal(t, CommandArrow, command.Type())
 			require.Equal(t, sql, command.SQL())
@@ -120,9 +120,9 @@ func TestCanceledRequestContextReachesAuthorizationAndExecutor(t *testing.T) {
 		},
 	}
 
-	handler := mustHandler(t, spy, WithAuthorizer(AuthorizerFunc(func(r *http.Request) (CommandAuthorizer, error) {
+	handler := mustHandler(t, spy, WithAuthorizer(AuthorizerFunc[json.RawMessage](func(r *http.Request) (CommandAuthorizer[json.RawMessage], error) {
 		requestContextErr = r.Context().Err()
-		return func(ctx context.Context, _ Command) error {
+		return func(ctx context.Context, _ Command[json.RawMessage]) error {
 			commandContextErr = ctx.Err()
 			return nil
 		}, nil
@@ -142,6 +142,12 @@ func TestCanceledRequestContextReachesAuthorizationAndExecutor(t *testing.T) {
 
 func TestAuthorizerHandlesConcurrentRequests(t *testing.T) {
 	const requestCount = 32
+	type fields struct {
+		SQL         string `json:"sql"`
+		Application struct {
+			Request int `json:"request"`
+		} `json:"application"`
+	}
 
 	var requestCalls atomic.Int32
 	var commandCalls atomic.Int32
@@ -154,17 +160,18 @@ func TestAuthorizerHandlesConcurrentRequests(t *testing.T) {
 		},
 	}
 
-	handler := mustHandler(t, spy, WithAuthorizer(AuthorizerFunc(func(r *http.Request) (CommandAuthorizer, error) {
+	handler := mustHandler(t, spy, WithAuthorizer(AuthorizerFunc[*fields](func(r *http.Request) (CommandAuthorizer[*fields], error) {
 		requestCalls.Add(1)
-		expected := r.Context().Value(authorizationContextKey{}).(string)
-		return func(_ context.Context, command Command) error {
+		expected := r.Context().Value(authorizationContextKey{}).(int)
+		return func(_ context.Context, command Command[*fields]) error {
 			commandCalls.Add(1)
-			raw := command.Raw()
-			if string(raw) != expected {
+			payload := command.Payload()
+			if payload.Application.Request != expected || payload.SQL != command.SQL() {
 				return ErrInvalidCommand
 			}
-			clear(raw)
-			if string(command.Raw()) != expected {
+			payload.Application.Request = -1
+			payload.SQL = "changed"
+			if command.SQL() != fmt.Sprintf("SELECT %d", expected) {
 				return ErrInvalidCommand
 			}
 			return nil
@@ -178,7 +185,7 @@ func TestAuthorizerHandlesConcurrentRequests(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			body := fmt.Sprintf(`{"type":"arrow","sql":"SELECT %d","application":{"request":%d}}`, i, i)
-			ctx := context.WithValue(t.Context(), authorizationContextKey{}, body)
+			ctx := context.WithValue(t.Context(), authorizationContextKey{}, i)
 			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)).WithContext(ctx)
 			res := httptest.NewRecorder()
 			handler.ServeHTTP(res, req)
@@ -238,11 +245,11 @@ func TestHTTPAuthorizerReceivesExactValidatedCommandAndRequestContext(t *testing
 			var requestCalls atomic.Int32
 			var commandCalls atomic.Int32
 
-			authorizer := AuthorizerFunc(func(r *http.Request) (CommandAuthorizer, error) {
+			authorizer := AuthorizerFunc[json.RawMessage](func(r *http.Request) (CommandAuthorizer[json.RawMessage], error) {
 				requestCalls.Add(1)
 				require.Equal(t, identity, r.Context().Value(authorizationContextKey{}))
 
-				return func(ctx context.Context, command Command) error {
+				return func(ctx context.Context, command Command[json.RawMessage]) error {
 					commandCalls.Add(1)
 					require.Equal(t, identity, ctx.Value(authorizationContextKey{}))
 					require.Equal(t, CommandArrow, command.Type())
@@ -318,8 +325,8 @@ func TestHTTPCommandAuthorizationStatusMapping(t *testing.T) {
 			t.Run(tt.name+"/"+method, func(t *testing.T) {
 				var logs bytes.Buffer
 				var commandCalls atomic.Int32
-				authorizer := AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
-					return func(context.Context, Command) error {
+				authorizer := AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
+					return func(context.Context, Command[json.RawMessage]) error {
 						commandCalls.Add(1)
 						return tt.authErr
 					}, nil
@@ -362,31 +369,31 @@ func TestHTTPAuthorizerConfigurationFailsClosed(t *testing.T) {
 	db := setupTestDB(t)
 
 	t.Run("nil configured authorizer", func(t *testing.T) {
-		_, err := New(db, WithAuthorizer(nil))
+		_, err := New(db, WithAuthorizer[json.RawMessage](nil))
 		require.Error(t, err)
 	})
 
 	t.Run("nil function adapter", func(t *testing.T) {
-		_, err := New(db, WithAuthorizer(AuthorizerFunc(nil)))
+		_, err := New(db, WithAuthorizer(AuthorizerFunc[json.RawMessage](nil)))
 		require.Error(t, err)
 	})
 
 	tests := []struct {
 		name       string
-		authorizer Authorizer
+		authorizer Authorizer[json.RawMessage]
 		wantStatus int
 		secret     string
 	}{
 		{
 			name: "request rejected as unauthenticated",
-			authorizer: AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
+			authorizer: AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
 				return nil, ErrUnauthenticated
 			}),
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
 			name: "request authorizer error is sanitized",
-			authorizer: AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
+			authorizer: AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
 				return nil, errors.New("identity provider exposed secret-session-cookie")
 			}),
 			wantStatus: http.StatusInternalServerError,
@@ -394,7 +401,7 @@ func TestHTTPAuthorizerConfigurationFailsClosed(t *testing.T) {
 		},
 		{
 			name: "missing command authorizer",
-			authorizer: AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
+			authorizer: AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
 				return nil, nil
 			}),
 			wantStatus: http.StatusInternalServerError,
@@ -419,8 +426,8 @@ func TestHTTPAuthorizerConfigurationFailsClosed(t *testing.T) {
 
 func TestHTTPValidationPrecedesCommandAuthorization(t *testing.T) {
 	var commandCalls atomic.Int32
-	authorizer := AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
-		return func(context.Context, Command) error {
+	authorizer := AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
+		return func(context.Context, Command[json.RawMessage]) error {
 			commandCalls.Add(1)
 			return nil
 		}, nil
@@ -437,8 +444,8 @@ func TestHTTPValidationPrecedesCommandAuthorization(t *testing.T) {
 }
 
 func TestGenericAuthorizationDoesNotBypassRestrictedExec(t *testing.T) {
-	allow := WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
-		return func(context.Context, Command) error { return nil }, nil
+	allow := WithAuthorizer(AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
+		return func(context.Context, Command[json.RawMessage]) error { return nil }, nil
 	}))
 
 	t.Run("function policy", func(t *testing.T) {
@@ -488,34 +495,34 @@ func TestGenericAuthorizationDoesNotBypassRestrictedExec(t *testing.T) {
 func TestWebSocketRequestAuthorizationRejectsBeforeUpgrade(t *testing.T) {
 	tests := []struct {
 		name       string
-		result     func() (CommandAuthorizer, error)
+		result     func() (CommandAuthorizer[json.RawMessage], error)
 		wantStatus int
 		secret     string
 	}{
 		{
 			name: "unauthenticated",
-			result: func() (CommandAuthorizer, error) {
+			result: func() (CommandAuthorizer[json.RawMessage], error) {
 				return nil, ErrUnauthenticated
 			},
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
 			name: "permission denied",
-			result: func() (CommandAuthorizer, error) {
+			result: func() (CommandAuthorizer[json.RawMessage], error) {
 				return nil, ErrPermissionDenied
 			},
 			wantStatus: http.StatusForbidden,
 		},
 		{
 			name: "missing command authorizer",
-			result: func() (CommandAuthorizer, error) {
+			result: func() (CommandAuthorizer[json.RawMessage], error) {
 				return nil, nil
 			},
 			wantStatus: http.StatusInternalServerError,
 		},
 		{
 			name: "unexpected failure is sanitized",
-			result: func() (CommandAuthorizer, error) {
+			result: func() (CommandAuthorizer[json.RawMessage], error) {
 				return nil, errors.New("identity service leaked websocket-secret")
 			},
 			wantStatus: http.StatusInternalServerError,
@@ -525,7 +532,7 @@ func TestWebSocketRequestAuthorizationRejectsBeforeUpgrade(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			authorizer := AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
+			authorizer := AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
 				return tt.result()
 			})
 			handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(authorizer))
@@ -563,13 +570,13 @@ func TestWebSocketAuthorizesEveryMessageAndKeepsConnectionAfterDenial(t *testing
 
 	db := setupTestDB(t)
 	observations := make(chan observation, 2)
-	commands := make(chan Command, 2)
+	commands := make(chan Command[json.RawMessage], 2)
 	var requestCalls atomic.Int32
 	var commandCalls atomic.Int32
-	authorizer := AuthorizerFunc(func(r *http.Request) (CommandAuthorizer, error) {
+	authorizer := AuthorizerFunc[json.RawMessage](func(r *http.Request) (CommandAuthorizer[json.RawMessage], error) {
 		requestCalls.Add(1)
 		requestIdentity := r.Context().Value(authorizationContextKey{})
-		return func(ctx context.Context, command Command) error {
+		return func(ctx context.Context, command Command[json.RawMessage]) error {
 			call := commandCalls.Add(1)
 			commands <- command
 			observations <- observation{
@@ -618,8 +625,8 @@ func TestWebSocketAuthorizesEveryMessageAndKeepsConnectionAfterDenial(t *testing
 
 	require.Equal(t, int32(1), requestCalls.Load())
 	require.Equal(t, int32(2), commandCalls.Load())
-	require.Equal(t, deniedPayload, string((<-commands).Raw()))
-	require.Equal(t, allowedPayload, string((<-commands).Raw()))
+	require.Equal(t, deniedPayload, string((<-commands).Payload()))
+	require.Equal(t, allowedPayload, string((<-commands).Payload()))
 	first := <-observations
 	second := <-observations
 	require.Equal(t, observation{
@@ -672,8 +679,8 @@ func TestWebSocketCommandAuthorizationErrorMapping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var logs synchronizedBuffer
 			handler := mustHandler(t, failOnCallExecutor{t},
-				WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
-					return func(context.Context, Command) error { return tt.err }, nil
+				WithAuthorizer(AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
+					return func(context.Context, Command[json.RawMessage]) error { return tt.err }, nil
 				})),
 				WithLogger(slog.New(slog.NewJSONHandler(&logs, nil))),
 			)

--- a/packages/server/duckdb-server-go/pkg/server/authorization_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/authorization_test.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
 	"github.com/stretchr/testify/require"
 
@@ -153,21 +154,32 @@ func TestAuthorizerHandlesConcurrentRequests(t *testing.T) {
 		},
 	}
 
-	handler := mustHandler(t, spy, WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
+	handler := mustHandler(t, spy, WithAuthorizer(AuthorizerFunc(func(r *http.Request) (CommandAuthorizer, error) {
 		requestCalls.Add(1)
-		return func(context.Context, Command) error {
+		expected := r.Context().Value(authorizationContextKey{}).(string)
+		return func(_ context.Context, command Command) error {
 			commandCalls.Add(1)
+			raw := command.Raw()
+			if string(raw) != expected {
+				return ErrInvalidCommand
+			}
+			clear(raw)
+			if string(command.Raw()) != expected {
+				return ErrInvalidCommand
+			}
 			return nil
 		}, nil
 	})))
 
 	statuses := make(chan int, requestCount)
 	var wg sync.WaitGroup
-	for range requestCount {
+	for i := range requestCount {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"type":"arrow","sql":"SELECT 1"}`))
+			body := fmt.Sprintf(`{"type":"arrow","sql":"SELECT %d","application":{"request":%d}}`, i, i)
+			ctx := context.WithValue(t.Context(), authorizationContextKey{}, body)
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)).WithContext(ctx)
 			res := httptest.NewRecorder()
 			handler.ServeHTTP(res, req)
 			statuses <- res.Code
@@ -551,6 +563,7 @@ func TestWebSocketAuthorizesEveryMessageAndKeepsConnectionAfterDenial(t *testing
 
 	db := setupTestDB(t)
 	observations := make(chan observation, 2)
+	commands := make(chan Command, 2)
 	var requestCalls atomic.Int32
 	var commandCalls atomic.Int32
 	authorizer := AuthorizerFunc(func(r *http.Request) (CommandAuthorizer, error) {
@@ -558,6 +571,7 @@ func TestWebSocketAuthorizesEveryMessageAndKeepsConnectionAfterDenial(t *testing
 		requestIdentity := r.Context().Value(authorizationContextKey{})
 		return func(ctx context.Context, command Command) error {
 			call := commandCalls.Add(1)
+			commands <- command
 			observations <- observation{
 				requestIdentity: requestIdentity,
 				commandIdentity: ctx.Value(authorizationContextKey{}),
@@ -585,10 +599,8 @@ func TestWebSocketAuthorizesEveryMessageAndKeepsConnectionAfterDenial(t *testing
 		require.NoError(t, conn.CloseNow())
 	})
 
-	require.NoError(t, wsjson.Write(server.ctx, conn, map[string]any{
-		"type": CommandExec,
-		"sql":  deniedSQL,
-	}))
+	deniedPayload := fmt.Sprintf(`{"type":"exec","sql":%q,"label":[42,null]}`, deniedSQL)
+	require.NoError(t, conn.Write(server.ctx, websocket.MessageText, []byte(deniedPayload)))
 	var denied struct {
 		Error string `json:"error"`
 		Code  string `json:"code"`
@@ -598,16 +610,16 @@ func TestWebSocketAuthorizesEveryMessageAndKeepsConnectionAfterDenial(t *testing
 	require.Equal(t, "forbidden", denied.Code)
 
 	// A command denial is an application response, not a connection failure.
-	require.NoError(t, wsjson.Write(server.ctx, conn, map[string]any{
-		"type": CommandArrow,
-		"sql":  allowedSQL,
-	}))
+	allowedPayload := fmt.Sprintf(`{"type":"arrow","sql":%q,"label":{"value":"next"}}`, allowedSQL)
+	require.NoError(t, conn.Write(server.ctx, websocket.MessageText, []byte(allowedPayload)))
 	_, payload, err := conn.Read(server.ctx)
 	require.NoError(t, err)
 	require.Equal(t, []map[string]any{{"value": float64(9)}}, arrowRows(t, payload))
 
 	require.Equal(t, int32(1), requestCalls.Load())
 	require.Equal(t, int32(2), commandCalls.Load())
+	require.Equal(t, deniedPayload, string((<-commands).Raw()))
+	require.Equal(t, allowedPayload, string((<-commands).Raw()))
 	first := <-observations
 	second := <-observations
 	require.Equal(t, observation{

--- a/packages/server/duckdb-server-go/pkg/server/example_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/example_test.go
@@ -15,17 +15,25 @@ func ExampleNew() {
 	// Callers must supply a real *query.DB; nil is illustrative only.
 	var db *query.DB
 
-	authorizer := server.AuthorizerFunc(func(r *http.Request) (server.CommandAuthorizer, error) {
+	type fields struct {
+		Project string `json:"project"`
+	}
+	authorizer := server.AuthorizerFunc[*fields](func(r *http.Request) (server.CommandAuthorizer[*fields], error) {
 		identity, ok := r.Context().Value(identityKey{}).(string)
 		if !ok {
 			return nil, server.ErrUnauthenticated
 		}
 
-		return func(ctx context.Context, command server.Command) error {
+		getProject := r.URL.Query().Get("project")
+		return func(ctx context.Context, command server.Command[*fields]) error {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			if identity != "reader" || command.Type() == server.CommandExec {
+			project := getProject
+			if payload := command.Payload(); payload != nil {
+				project = payload.Project
+			}
+			if identity != "reader" || project != "dashboard" || command.Type() == server.CommandExec {
 				return server.ErrPermissionDenied
 			}
 			return nil

--- a/packages/server/duckdb-server-go/pkg/server/metadata_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/metadata_test.go
@@ -27,6 +27,21 @@ type applicationPayload struct {
 	Attributes map[string]string `json:"attributes"`
 }
 
+func TestCommandWorkspaceProjectPayload(t *testing.T) {
+	type fields struct {
+		WorkspaceID uint64 `json:"workspaceId"`
+		ProjectID   uint64 `json:"projectId"`
+	}
+	const message = `{"type":"json","sql":"SELECT 1","workspaceId":123,"projectId":456}`
+	want := fields{WorkspaceID: 123, ProjectID: 456}
+	t.Run("struct", func(t *testing.T) {
+		testCommandPayload(t, http.MethodPost, message, want)
+	})
+	t.Run("pointer", func(t *testing.T) {
+		testCommandPayload(t, http.MethodPost, message, &want)
+	})
+}
+
 func TestCommandTypedPayload(t *testing.T) {
 	payloads := []string{
 		`{"type":"json","sql":"SELECT 1","projectId":9007199254740993,"tags":["one"],"attributes":{"name":"first"},"unrelated":[false,null,1e400]}`,
@@ -171,20 +186,39 @@ func TestCommandPayloadTypes(t *testing.T) {
 
 func testCommandPayload[T any](t *testing.T, method, payload string, want T) {
 	t.Helper()
-	var calls int
-	handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(AuthorizerFunc[T](func(*http.Request) (CommandAuthorizer[T], error) {
-		return func(_ context.Context, command Command[T]) error {
-			calls++
-			require.Equal(t, CommandJSON, command.Type())
-			require.Equal(t, "SELECT 1", command.SQL())
-			require.Equal(t, want, command.Payload())
-			return ErrPermissionDenied
-		}, nil
-	})))
-	res := httptest.NewRecorder()
-	handler.ServeHTTP(res, httptest.NewRequest(method, "/?type=json&sql=SELECT+1", strings.NewReader(payload)))
-	require.Equal(t, http.StatusForbidden, res.Code, res.Body.String())
-	require.Equal(t, 1, calls)
+	transports := []string{"HTTP"}
+	if method == http.MethodPost {
+		transports = append(transports, "WebSocket")
+	}
+	for _, transport := range transports {
+		t.Run(transport, func(t *testing.T) {
+			var calls atomic.Int32
+			handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(AuthorizerFunc[T](func(*http.Request) (CommandAuthorizer[T], error) {
+				return func(_ context.Context, command Command[T]) error {
+					calls.Add(1)
+					require.Equal(t, CommandJSON, command.Type())
+					require.Equal(t, "SELECT 1", command.SQL())
+					require.Equal(t, want, command.Payload())
+					return ErrPermissionDenied
+				}, nil
+			})))
+			if transport == "HTTP" {
+				res := httptest.NewRecorder()
+				handler.ServeHTTP(res, httptest.NewRequest(method, "/?type=json&sql=SELECT+1", strings.NewReader(payload)))
+				require.Equal(t, http.StatusForbidden, res.Code, res.Body.String())
+			} else {
+				server := newWebSocketTestServer(t, handler)
+				conn, _, err := server.dial(nil)
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, conn.CloseNow()) })
+				require.NoError(t, conn.Write(server.ctx, websocket.MessageText, []byte(payload)))
+				var response map[string]string
+				require.NoError(t, wsjson.Read(server.ctx, conn, &response))
+				require.Equal(t, "forbidden", response["code"])
+			}
+			require.Equal(t, int32(1), calls.Load())
+		})
+	}
 }
 
 func TestCommandPayloadDecodeErrors(t *testing.T) {

--- a/packages/server/duckdb-server-go/pkg/server/metadata_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/metadata_test.go
@@ -1,0 +1,286 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandRawEnvelope(t *testing.T) {
+	payloads := []string{
+		`{"type":"json","sql":"SELECT 1"}`,
+		" \n" + `{"type":"json","sql":"SELECT 1","label":"a\u0062","list":[true,false,null,{},[]],"object":{"n":9007199254740993},"number":1e400}` + "\t\r\n",
+		`{"type":"json","sql":"SELECT 1","metadata":null,"metadata":[1,"two"],"raw":false,"label":42,"label":{"x":1}}`,
+		`{"type":"exec","TYPE":"json","sql":"SELECT 0","SQL":"SELECT 1","name":"custom"}`,
+	}
+
+	for _, transport := range []string{"HTTP", "WebSocket"} {
+		t.Run(transport, func(t *testing.T) {
+			commands := make(chan Command, len(payloads))
+			sqls := make(chan string, len(payloads))
+			executor := &spyCommandExecutor{
+				failOnCallExecutor: failOnCallExecutor{t},
+				queryJSON: func(_ context.Context, sql string, _ []string) (json.RawMessage, error) {
+					sqls <- sql
+					return json.RawMessage(`[]`), nil
+				},
+			}
+			handler := mustHandler(t, executor, WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
+				return func(_ context.Context, command Command) error {
+					commands <- command
+					clear(command.Raw())
+					return nil
+				}, nil
+			})))
+
+			var conn *websocket.Conn
+			ctx := t.Context()
+			if transport == "WebSocket" {
+				server := newWebSocketTestServer(t, handler)
+				ctx = server.ctx
+				var err error
+				conn, _, err = server.dial(nil)
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, conn.CloseNow()) })
+			}
+			for _, payload := range payloads {
+				if conn == nil {
+					res := httptest.NewRecorder()
+					handler.ServeHTTP(res, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload)))
+					require.Equal(t, http.StatusOK, res.Code, res.Body.String())
+				} else {
+					require.NoError(t, conn.Write(ctx, websocket.MessageText, []byte(payload)))
+					_, response, err := conn.Read(ctx)
+					require.NoError(t, err)
+					require.JSONEq(t, `[]`, string(response))
+				}
+			}
+
+			require.Len(t, commands, len(payloads))
+			require.Len(t, sqls, len(payloads))
+			for _, payload := range payloads {
+				command := <-commands
+				require.Equal(t, CommandJSON, command.Type())
+				require.Equal(t, "SELECT 1", command.SQL())
+				require.Equal(t, command.SQL(), <-sqls)
+				require.Equal(t, payload, string(command.Raw()))
+				clear(command.Raw())
+				require.Equal(t, payload, string(command.Raw()))
+			}
+		})
+	}
+}
+
+func TestCommandRawGET(t *testing.T) {
+	var seen Command
+	handler := mustHandler(t, failOnCallExecutor{t}, WithMaxMessageBytes(1), WithAuthorizer(AuthorizerFunc(func(r *http.Request) (CommandAuthorizer, error) {
+		require.Equal(t, []string{"one", "two"}, r.URL.Query()["label"])
+		return func(_ context.Context, command Command) error {
+			seen = command
+			return ErrPermissionDenied
+		}, nil
+	})))
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/?type=json&sql=SELECT+1&label=one&label=two", nil)
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusForbidden, res.Code)
+	require.Equal(t, CommandJSON, seen.Type())
+	require.Equal(t, "SELECT 1", seen.SQL())
+	require.Nil(t, seen.Raw())
+}
+
+func TestCommandPayloadErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		close   bool
+	}{
+		{"empty", "", true},
+		{"malformed", `{`, true},
+		{"trailing data", `{"type":"json","sql":"SELECT 1"} trailing`, true},
+		{"second value", `{"type":"json","sql":"SELECT 1"} {}`, true},
+		{"array", `[]`, true},
+		{"wrong sql type", `{"type":"json","sql":42}`, true},
+		{"wrong name type", `{"type":"json","sql":"SELECT 1","name":{}}`, true},
+		{"missing sql", `{"type":"json"}`, false},
+		{"null sql", `{"type":"json","sql":"SELECT 1","sql":null}`, false},
+		{"unknown type", `{"type":"other","sql":"SELECT 1"}`, false},
+		{"null", `null`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var commandCalls atomic.Int32
+			handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
+				return func(context.Context, Command) error {
+					commandCalls.Add(1)
+					return ErrPermissionDenied
+				}, nil
+			})))
+			res := httptest.NewRecorder()
+			handler.ServeHTTP(res, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tt.payload)))
+			require.Equal(t, http.StatusBadRequest, res.Code, res.Body.String())
+			require.Zero(t, commandCalls.Load())
+
+			server := newWebSocketTestServer(t, handler)
+			conn, _, err := server.dial(nil)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				if err := conn.CloseNow(); !errors.Is(err, net.ErrClosed) {
+					require.NoError(t, err)
+				}
+			})
+			require.NoError(t, conn.Write(server.ctx, websocket.MessageText, []byte(tt.payload)))
+			_, response, err := conn.Read(server.ctx)
+			if tt.close {
+				require.Equal(t, websocket.StatusInvalidFramePayloadData, websocket.CloseStatus(err), "%v", err)
+			} else {
+				require.NoError(t, err)
+				var rejection map[string]string
+				require.NoError(t, json.Unmarshal(response, &rejection))
+				require.Equal(t, "bad_request", rejection["code"])
+			}
+			require.Zero(t, commandCalls.Load())
+			if !tt.close {
+				require.NoError(t, conn.Write(server.ctx, websocket.MessageText, []byte(`{"type":"json","sql":"SELECT 1"}`)))
+				var rejection map[string]string
+				require.NoError(t, wsjson.Read(server.ctx, conn, &rejection))
+				require.Equal(t, "forbidden", rejection["code"])
+				require.Equal(t, int32(1), commandCalls.Load())
+			}
+		})
+	}
+}
+
+func TestCommandMessageLimits(t *testing.T) {
+	tests := []struct {
+		name       string
+		limit      int64
+		size       int
+		compressed bool
+	}{
+		{"default exact", 0, 32768, false},
+		{"default over", 0, 32769, false},
+		{"configured exact", 128, 128, false},
+		{"configured over", 128, 129, false},
+		{"larger than default", 65536, 65536, false},
+		{"compressed exact", 128, 128, true},
+		{"compressed over", 128, 129, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := `{"type":"json","sql":"SELECT 1","payload":""}`
+			payload = strings.Replace(payload, `"payload":""`, `"payload":"`+strings.Repeat("x", tt.size-len(payload))+`"`, 1)
+			commands := make(chan Command, 2)
+			var executorCalls atomic.Int32
+			var expectedCalls int32
+			executor := &spyCommandExecutor{
+				failOnCallExecutor: failOnCallExecutor{t},
+				queryJSON: func(context.Context, string, []string) (json.RawMessage, error) {
+					executorCalls.Add(1)
+					return json.RawMessage(`[]`), nil
+				},
+			}
+			var requestCalls atomic.Int32
+			opts := []Option{WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
+				requestCalls.Add(1)
+				return func(_ context.Context, command Command) error {
+					commands <- command
+					return nil
+				}, nil
+			}))}
+			if tt.limit > 0 {
+				opts = append(opts, WithMaxMessageBytes(tt.limit))
+			}
+			handler := mustHandler(t, executor, opts...)
+			res := httptest.NewRecorder()
+			handler.ServeHTTP(res, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload)))
+			if tt.limit > 0 && int64(tt.size) > tt.limit {
+				require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
+				require.Empty(t, commands)
+			} else {
+				require.Equal(t, http.StatusOK, res.Code, res.Body.String())
+				require.Len(t, commands, 1)
+				require.Equal(t, payload, string((<-commands).Raw()))
+				expectedCalls++
+			}
+
+			server := newWebSocketTestServer(t, handler)
+			dialOptions := &websocket.DialOptions{}
+			if tt.compressed {
+				dialOptions.CompressionMode = websocket.CompressionContextTakeover
+				dialOptions.CompressionThreshold = 1
+			}
+			conn, upgrade, err := server.dial(dialOptions)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				if err := conn.CloseNow(); !errors.Is(err, net.ErrClosed) {
+					require.NoError(t, err)
+				}
+			})
+			if tt.compressed {
+				require.Contains(t, upgrade.Header.Get("Sec-WebSocket-Extensions"), "permessage-deflate")
+			}
+			require.NoError(t, conn.Write(server.ctx, websocket.MessageText, []byte(payload)))
+			_, response, err := conn.Read(server.ctx)
+			wsLimit := tt.limit
+			if wsLimit == 0 {
+				wsLimit = 32768
+			}
+			if int64(tt.size) > wsLimit {
+				require.Equal(t, websocket.StatusMessageTooBig, websocket.CloseStatus(err), "%v", err)
+				require.Empty(t, commands)
+			} else {
+				require.NoError(t, err)
+				require.JSONEq(t, `[]`, string(response))
+				require.Len(t, commands, 1)
+				require.Equal(t, payload, string((<-commands).Raw()))
+				expectedCalls++
+			}
+			require.Equal(t, int32(2), requestCalls.Load())
+			require.Equal(t, expectedCalls, executorCalls.Load())
+		})
+	}
+}
+
+func TestHTTPMessageLimitFollowsRequestAuthorization(t *testing.T) {
+	const payload = `{"type":"json","sql":"SELECT 1","application":[null,42]}`
+	for _, tt := range []struct {
+		name   string
+		denied bool
+	}{{"restore body", false}, {"reject request", true}} {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := mustHandler(t, failOnCallExecutor{t}, WithMaxMessageBytes(1), WithAuthorizer(AuthorizerFunc(func(r *http.Request) (CommandAuthorizer, error) {
+				if tt.denied {
+					return nil, ErrUnauthenticated
+				}
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				require.Equal(t, payload, string(body))
+				r.Body = io.NopCloser(strings.NewReader(string(body)))
+				return func(context.Context, Command) error {
+					t.Error("unexpected command authorization")
+					return ErrPermissionDenied
+				}, nil
+			})))
+			res := httptest.NewRecorder()
+			handler.ServeHTTP(res, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload)))
+			if tt.denied {
+				require.Equal(t, http.StatusUnauthorized, res.Code)
+			} else {
+				require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
+			}
+		})
+	}
+}

--- a/packages/server/duckdb-server-go/pkg/server/metadata_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/metadata_test.go
@@ -33,7 +33,7 @@ func TestCommandWorkspaceProjectPayload(t *testing.T) {
 		ProjectID   uint64 `json:"projectId"`
 	}
 	t.Run("siblings", func(t *testing.T) {
-		const message = `{"type":"json","sql":"SELECT 1","workspaceId":123,"projectId":456}`
+		const message = `{"type":"arrow","sql":"SELECT 1","workspaceId":123,"projectId":456}`
 		want := fields{WorkspaceID: 123, ProjectID: 456}
 		t.Run("struct", func(t *testing.T) {
 			testCommandPayload(t, http.MethodPost, message, want)
@@ -46,7 +46,7 @@ func TestCommandWorkspaceProjectPayload(t *testing.T) {
 		type payload struct {
 			Meta fields `json:"meta"`
 		}
-		const message = `{"type":"json","sql":"SELECT 1","meta":{"workspaceId":123,"projectId":456}}`
+		const message = `{"type":"arrow","sql":"SELECT 1","meta":{"workspaceId":123,"projectId":456}}`
 		want := payload{Meta: fields{WorkspaceID: 123, ProjectID: 456}}
 		t.Run("struct", func(t *testing.T) {
 			testCommandPayload(t, http.MethodPost, message, want)
@@ -59,8 +59,8 @@ func TestCommandWorkspaceProjectPayload(t *testing.T) {
 
 func TestCommandTypedPayload(t *testing.T) {
 	payloads := []string{
-		`{"type":"json","sql":"SELECT 1","projectId":9007199254740993,"tags":["one"],"attributes":{"name":"first"},"unrelated":[false,null,1e400]}`,
-		`{"type":"json","sql":"SELECT 2","projectId":9007199254740995}`,
+		`{"type":"arrow","sql":"SELECT 1","projectId":9007199254740993,"tags":["one"],"attributes":{"name":"first"},"unrelated":[false,null,1e400]}`,
+		`{"type":"arrow","sql":"SELECT 2","projectId":9007199254740995}`,
 	}
 	for _, transport := range []string{"HTTP", "WebSocket"} {
 		t.Run(transport, func(t *testing.T) {
@@ -68,9 +68,9 @@ func TestCommandTypedPayload(t *testing.T) {
 			sqls := make(chan string, len(payloads))
 			executor := &spyCommandExecutor{
 				failOnCallExecutor: failOnCallExecutor{t},
-				queryJSON: func(_ context.Context, sql string, _ []string) (json.RawMessage, error) {
+				queryArrow: func(_ context.Context, sql string, _ []string) ([]byte, error) {
 					sqls <- sql
-					return json.RawMessage(`[]`), nil
+					return []byte("result"), nil
 				},
 			}
 			handler := mustHandler(t, executor, WithAuthorizer(AuthorizerFunc[*applicationPayload](func(*http.Request) (CommandAuthorizer[*applicationPayload], error) {
@@ -102,14 +102,14 @@ func TestCommandTypedPayload(t *testing.T) {
 					require.NoError(t, conn.Write(ctx, websocket.MessageText, []byte(payload)))
 					_, response, err := conn.Read(ctx)
 					require.NoError(t, err)
-					require.JSONEq(t, `[]`, string(response))
+					require.Equal(t, []byte("result"), response)
 				}
 			}
 			require.Len(t, commands, len(payloads))
 			require.Len(t, sqls, len(payloads))
 			first, second := <-commands, <-commands
-			require.Equal(t, CommandJSON, first.Type())
-			require.Equal(t, CommandJSON, second.Type())
+			require.Equal(t, CommandArrow, first.Type())
+			require.Equal(t, CommandArrow, second.Type())
 			require.Equal(t, "SELECT 1", first.SQL())
 			require.Equal(t, "SELECT 2", second.SQL())
 			require.Equal(t, first.SQL(), <-sqls)
@@ -152,7 +152,7 @@ func (p *countedPayload) UnmarshalJSON([]byte) error {
 }
 
 func TestCommandDecoderRunsOncePerMessage(t *testing.T) {
-	const payload = `{"type":"json","sql":"SELECT 1"}`
+	const payload = `{"type":"arrow","sql":"SELECT 1"}`
 	testCommandPayload(t, http.MethodPost, payload, countedPayload(1))
 	testCommandPayload(t, http.MethodGet, "", countedPayload(0))
 	var calls atomic.Int32
@@ -187,15 +187,15 @@ func TestCommandPayloadTypes(t *testing.T) {
 		testCommandPayload(t, http.MethodGet, "", customPayload(""))
 	})
 	t.Run("custom decoder", func(t *testing.T) {
-		testCommandPayload(t, http.MethodPost, `{"type":"json","sql":"SELECT 1","application":"custom"}`, customPayload("CUSTOM"))
+		testCommandPayload(t, http.MethodPost, `{"type":"arrow","sql":"SELECT 1","application":"custom"}`, customPayload("CUSTOM"))
 	})
 	t.Run("map", func(t *testing.T) {
-		testCommandPayload(t, http.MethodPost, `{"type":"json","sql":"SELECT 1","application":[null,1e400]}`, map[string]json.RawMessage{
-			"type": json.RawMessage(`"json"`), "sql": json.RawMessage(`"SELECT 1"`), "application": json.RawMessage(`[null,1e400]`),
+		testCommandPayload(t, http.MethodPost, `{"type":"arrow","sql":"SELECT 1","application":[null,1e400]}`, map[string]json.RawMessage{
+			"type": json.RawMessage(`"arrow"`), "sql": json.RawMessage(`"SELECT 1"`), "application": json.RawMessage(`[null,1e400]`),
 		})
 	})
 	t.Run("no application fields", func(t *testing.T) {
-		testCommandPayload(t, http.MethodPost, `{"type":"json","sql":"SELECT 1","application":[null,1e400]}`, struct{}{})
+		testCommandPayload(t, http.MethodPost, `{"type":"arrow","sql":"SELECT 1","application":[null,1e400]}`, struct{}{})
 	})
 }
 
@@ -211,7 +211,7 @@ func testCommandPayload[T any](t *testing.T, method, payload string, want T) {
 			handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(AuthorizerFunc[T](func(*http.Request) (CommandAuthorizer[T], error) {
 				return func(_ context.Context, command Command[T]) error {
 					calls.Add(1)
-					require.Equal(t, CommandJSON, command.Type())
+					require.Equal(t, CommandArrow, command.Type())
 					require.Equal(t, "SELECT 1", command.SQL())
 					require.Equal(t, want, command.Payload())
 					return ErrPermissionDenied
@@ -219,7 +219,7 @@ func testCommandPayload[T any](t *testing.T, method, payload string, want T) {
 			})))
 			if transport == "HTTP" {
 				res := httptest.NewRecorder()
-				handler.ServeHTTP(res, httptest.NewRequest(method, "/?type=json&sql=SELECT+1", strings.NewReader(payload)))
+				handler.ServeHTTP(res, httptest.NewRequest(method, "/?type=arrow&sql=SELECT+1", strings.NewReader(payload)))
 				require.Equal(t, http.StatusForbidden, res.Code, res.Body.String())
 			} else {
 				server := newWebSocketTestServer(t, handler)
@@ -238,16 +238,16 @@ func testCommandPayload[T any](t *testing.T, method, payload string, want T) {
 
 func TestCommandPayloadDecodeErrors(t *testing.T) {
 	for _, payload := range []string{
-		`{"type":"json","sql":"SELECT 1","projectId":"private-value"}`,
-		`{"type":"json","sql":"SELECT 1","projectId":18446744073709551616}`,
-		`{"type":"json","sql":"SELECT 1","tags":{}}`,
+		`{"type":"arrow","sql":"SELECT 1","projectId":"private-value"}`,
+		`{"type":"arrow","sql":"SELECT 1","projectId":18446744073709551616}`,
+		`{"type":"arrow","sql":"SELECT 1","tags":{}}`,
 	} {
 		t.Run(payload, func(t *testing.T) {
-			testCommandPayloadDecodeError[*applicationPayload](t, payload, `{"type":"json","sql":"SELECT 1"}`)
+			testCommandPayloadDecodeError[*applicationPayload](t, payload, `{"type":"arrow","sql":"SELECT 1"}`)
 		})
 	}
 	t.Run("custom decoder", func(t *testing.T) {
-		testCommandPayloadDecodeError[customPayload](t, `{"type":"json","sql":"SELECT 1"}`, `{"type":"json","sql":"SELECT 1","application":"valid"}`)
+		testCommandPayloadDecodeError[customPayload](t, `{"type":"arrow","sql":"SELECT 1"}`, `{"type":"arrow","sql":"SELECT 1","application":"valid"}`)
 	})
 }
 
@@ -295,10 +295,10 @@ func testCommandPayloadDecodeError[T any](t *testing.T, invalid, valid string) {
 
 func TestCommandRawMessagePayload(t *testing.T) {
 	payloads := []string{
-		`{"type":"json","sql":"SELECT 1"}`,
-		" \n" + `{"type":"json","sql":"SELECT 1","label":"a\u0062","list":[true,false,null,{},[]],"object":{"n":9007199254740993},"number":1e400}` + "\t\r\n",
-		`{"type":"json","sql":"SELECT 1","metadata":null,"metadata":[1,"two"],"raw":false,"label":42,"label":{"x":1}}`,
-		`{"type":"exec","TYPE":"json","sql":"SELECT 0","SQL":"SELECT 1","name":"custom"}`,
+		`{"type":"arrow","sql":"SELECT 1"}`,
+		" \n" + `{"type":"arrow","sql":"SELECT 1","label":"a\u0062","list":[true,false,null,{},[]],"object":{"n":9007199254740993},"number":1e400}` + "\t\r\n",
+		`{"type":"arrow","sql":"SELECT 1","metadata":null,"metadata":[1,"two"],"raw":false,"label":42,"label":{"x":1}}`,
+		`{"type":"exec","TYPE":"arrow","sql":"SELECT 0","SQL":"SELECT 1","name":"custom"}`,
 	}
 
 	for _, transport := range []string{"HTTP", "WebSocket"} {
@@ -307,9 +307,9 @@ func TestCommandRawMessagePayload(t *testing.T) {
 			sqls := make(chan string, len(payloads))
 			executor := &spyCommandExecutor{
 				failOnCallExecutor: failOnCallExecutor{t},
-				queryJSON: func(_ context.Context, sql string, _ []string) (json.RawMessage, error) {
+				queryArrow: func(_ context.Context, sql string, _ []string) ([]byte, error) {
 					sqls <- sql
-					return json.RawMessage(`[]`), nil
+					return []byte("result"), nil
 				},
 			}
 			handler := mustHandler(t, executor, WithAuthorizer(AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
@@ -338,7 +338,7 @@ func TestCommandRawMessagePayload(t *testing.T) {
 					require.NoError(t, conn.Write(ctx, websocket.MessageText, []byte(payload)))
 					_, response, err := conn.Read(ctx)
 					require.NoError(t, err)
-					require.JSONEq(t, `[]`, string(response))
+					require.Equal(t, []byte("result"), response)
 				}
 			}
 
@@ -346,12 +346,12 @@ func TestCommandRawMessagePayload(t *testing.T) {
 			require.Len(t, sqls, len(payloads))
 			for _, payload := range payloads {
 				command := <-commands
-				require.Equal(t, CommandJSON, command.Type())
+				require.Equal(t, CommandArrow, command.Type())
 				require.Equal(t, "SELECT 1", command.SQL())
 				require.Equal(t, command.SQL(), <-sqls)
 				require.Equal(t, strings.TrimSpace(payload), string(command.Payload()))
 				clear(command.Payload())
-				require.Equal(t, CommandJSON, command.Type())
+				require.Equal(t, CommandArrow, command.Type())
 				require.Equal(t, "SELECT 1", command.SQL())
 			}
 		})
@@ -368,11 +368,11 @@ func TestCommandRawMessageGET(t *testing.T) {
 		}, nil
 	})))
 	res := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/?type=json&sql=SELECT+1&label=one&label=two", nil)
+	req := httptest.NewRequest(http.MethodGet, "/?type=arrow&sql=SELECT+1&label=one&label=two", nil)
 	handler.ServeHTTP(res, req)
 
 	require.Equal(t, http.StatusForbidden, res.Code)
-	require.Equal(t, CommandJSON, seen.Type())
+	require.Equal(t, CommandArrow, seen.Type())
 	require.Equal(t, "SELECT 1", seen.SQL())
 	require.Nil(t, seen.Payload())
 }
@@ -385,13 +385,14 @@ func TestCommandPayloadErrors(t *testing.T) {
 	}{
 		{"empty", "", true},
 		{"malformed", `{`, true},
-		{"trailing data", `{"type":"json","sql":"SELECT 1"} trailing`, true},
-		{"second value", `{"type":"json","sql":"SELECT 1"} {}`, true},
+		{"trailing data", `{"type":"arrow","sql":"SELECT 1"} trailing`, true},
+		{"second value", `{"type":"arrow","sql":"SELECT 1"} {}`, true},
 		{"array", `[]`, true},
-		{"wrong sql type", `{"type":"json","sql":42}`, true},
-		{"wrong name type", `{"type":"json","sql":"SELECT 1","name":{}}`, true},
-		{"missing sql", `{"type":"json"}`, false},
-		{"null sql", `{"type":"json","sql":"SELECT 1","sql":null}`, false},
+		{"wrong sql type", `{"type":"arrow","sql":42}`, true},
+		{"wrong name type", `{"type":"arrow","sql":"SELECT 1","name":{}}`, true},
+		{"missing sql", `{"type":"arrow"}`, false},
+		{"null sql", `{"type":"arrow","sql":"SELECT 1","sql":null}`, false},
+		{"removed json type", `{"type":"json","sql":"SELECT 1"}`, false},
 		{"unknown type", `{"type":"other","sql":"SELECT 1"}`, false},
 		{"null", `null`, false},
 	}
@@ -429,7 +430,7 @@ func TestCommandPayloadErrors(t *testing.T) {
 			}
 			require.Zero(t, commandCalls.Load())
 			if !tt.close {
-				require.NoError(t, conn.Write(server.ctx, websocket.MessageText, []byte(`{"type":"json","sql":"SELECT 1"}`)))
+				require.NoError(t, conn.Write(server.ctx, websocket.MessageText, []byte(`{"type":"arrow","sql":"SELECT 1"}`)))
 				var rejection map[string]string
 				require.NoError(t, wsjson.Read(server.ctx, conn, &rejection))
 				require.Equal(t, "forbidden", rejection["code"])
@@ -456,16 +457,16 @@ func TestCommandMessageLimits(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			payload := `{"type":"json","sql":"SELECT 1","payload":""}`
+			payload := `{"type":"arrow","sql":"SELECT 1","payload":""}`
 			payload = strings.Replace(payload, `"payload":""`, `"payload":"`+strings.Repeat("x", tt.size-len(payload))+`"`, 1)
 			commands := make(chan Command[json.RawMessage], 2)
 			var executorCalls atomic.Int32
 			var expectedCalls int32
 			executor := &spyCommandExecutor{
 				failOnCallExecutor: failOnCallExecutor{t},
-				queryJSON: func(context.Context, string, []string) (json.RawMessage, error) {
+				queryArrow: func(context.Context, string, []string) ([]byte, error) {
 					executorCalls.Add(1)
-					return json.RawMessage(`[]`), nil
+					return []byte("result"), nil
 				},
 			}
 			var requestCalls atomic.Int32
@@ -519,7 +520,7 @@ func TestCommandMessageLimits(t *testing.T) {
 				require.Empty(t, commands)
 			} else {
 				require.NoError(t, err)
-				require.JSONEq(t, `[]`, string(response))
+				require.Equal(t, []byte("result"), response)
 				require.Len(t, commands, 1)
 				require.Equal(t, payload, string((<-commands).Payload()))
 				expectedCalls++
@@ -531,7 +532,7 @@ func TestCommandMessageLimits(t *testing.T) {
 }
 
 func TestHTTPMessageLimitFollowsRequestAuthorization(t *testing.T) {
-	const payload = `{"type":"json","sql":"SELECT 1","application":[null,42]}`
+	const payload = `{"type":"arrow","sql":"SELECT 1","application":[null,42]}`
 	for _, tt := range []struct {
 		name   string
 		denied bool

--- a/packages/server/duckdb-server-go/pkg/server/metadata_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/metadata_test.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -17,7 +19,187 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCommandRawEnvelope(t *testing.T) {
+type applicationPayload struct {
+	Type       string            `json:"type"`
+	SQL        string            `json:"sql"`
+	ProjectID  uint64            `json:"projectId"`
+	Tags       []string          `json:"tags"`
+	Attributes map[string]string `json:"attributes"`
+}
+
+func TestCommandTypedPayload(t *testing.T) {
+	payloads := []string{
+		`{"type":"json","sql":"SELECT 1","projectId":9007199254740993,"tags":["one"],"attributes":{"name":"first"},"unrelated":[false,null,1e400]}`,
+		`{"type":"json","sql":"SELECT 2","projectId":9007199254740995}`,
+	}
+	for _, transport := range []string{"HTTP", "WebSocket"} {
+		t.Run(transport, func(t *testing.T) {
+			commands := make(chan Command[*applicationPayload], len(payloads))
+			sqls := make(chan string, len(payloads))
+			executor := &spyCommandExecutor{
+				failOnCallExecutor: failOnCallExecutor{t},
+				queryJSON: func(_ context.Context, sql string, _ []string) (json.RawMessage, error) {
+					sqls <- sql
+					return json.RawMessage(`[]`), nil
+				},
+			}
+			handler := mustHandler(t, executor, WithAuthorizer(AuthorizerFunc[*applicationPayload](func(*http.Request) (CommandAuthorizer[*applicationPayload], error) {
+				return func(_ context.Context, command Command[*applicationPayload]) error {
+					fields := command.Payload()
+					fields.Type = "exec"
+					fields.SQL = "DROP TABLE important"
+					commands <- command
+					return nil
+				}, nil
+			})))
+			var conn *websocket.Conn
+			ctx := t.Context()
+			if transport == "WebSocket" {
+				server := newWebSocketTestServer(t, handler)
+				ctx = server.ctx
+				var err error
+				conn, _, err = server.dial(nil)
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, conn.CloseNow()) })
+			}
+			for _, payload := range payloads {
+				if conn == nil {
+					res := httptest.NewRecorder()
+					handler.ServeHTTP(res, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload)))
+					require.Equal(t, http.StatusOK, res.Code, res.Body.String())
+				} else {
+					require.NoError(t, conn.Write(ctx, websocket.MessageText, []byte(payload)))
+					_, response, err := conn.Read(ctx)
+					require.NoError(t, err)
+					require.JSONEq(t, `[]`, string(response))
+				}
+			}
+			require.Len(t, commands, len(payloads))
+			require.Len(t, sqls, len(payloads))
+			first, second := <-commands, <-commands
+			require.Equal(t, CommandJSON, first.Type())
+			require.Equal(t, CommandJSON, second.Type())
+			require.Equal(t, "SELECT 1", first.SQL())
+			require.Equal(t, "SELECT 2", second.SQL())
+			require.Equal(t, first.SQL(), <-sqls)
+			require.Equal(t, second.SQL(), <-sqls)
+			require.Equal(t, uint64(9007199254740993), first.Payload().ProjectID)
+			require.Equal(t, uint64(9007199254740995), second.Payload().ProjectID)
+			require.Equal(t, []string{"one"}, first.Payload().Tags)
+			require.Equal(t, map[string]string{"name": "first"}, first.Payload().Attributes)
+			first.Payload().ProjectID = 0
+			first.Payload().Tags[0] = "changed"
+			first.Payload().Attributes["name"] = "changed"
+			require.Equal(t, uint64(9007199254740995), second.Payload().ProjectID)
+			require.Nil(t, second.Payload().Tags)
+			require.Nil(t, second.Payload().Attributes)
+		})
+	}
+}
+
+type customPayload string
+
+func (p *customPayload) UnmarshalJSON(data []byte) error {
+	var fields struct {
+		Application *string `json:"application"`
+	}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	if fields.Application == nil {
+		return errors.New("missing private-application-field")
+	}
+	*p = customPayload(strings.ToUpper(*fields.Application))
+	return nil
+}
+
+func TestCommandPayloadTypes(t *testing.T) {
+	t.Run("pointer GET", func(t *testing.T) {
+		testCommandPayload(t, http.MethodGet, "", (*applicationPayload)(nil))
+	})
+	t.Run("struct GET", func(t *testing.T) {
+		testCommandPayload(t, http.MethodGet, "", applicationPayload{})
+	})
+	t.Run("custom GET skips decoder", func(t *testing.T) {
+		testCommandPayload(t, http.MethodGet, "", customPayload(""))
+	})
+	t.Run("custom decoder", func(t *testing.T) {
+		testCommandPayload(t, http.MethodPost, `{"type":"json","sql":"SELECT 1","application":"custom"}`, customPayload("CUSTOM"))
+	})
+	t.Run("map", func(t *testing.T) {
+		testCommandPayload(t, http.MethodPost, `{"type":"json","sql":"SELECT 1","application":[null,1e400]}`, map[string]json.RawMessage{
+			"type": json.RawMessage(`"json"`), "sql": json.RawMessage(`"SELECT 1"`), "application": json.RawMessage(`[null,1e400]`),
+		})
+	})
+	t.Run("no application fields", func(t *testing.T) {
+		testCommandPayload(t, http.MethodPost, `{"type":"json","sql":"SELECT 1","application":[null,1e400]}`, struct{}{})
+	})
+}
+
+func testCommandPayload[T any](t *testing.T, method, payload string, want T) {
+	t.Helper()
+	var calls int
+	handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(AuthorizerFunc[T](func(*http.Request) (CommandAuthorizer[T], error) {
+		return func(_ context.Context, command Command[T]) error {
+			calls++
+			require.Equal(t, CommandJSON, command.Type())
+			require.Equal(t, "SELECT 1", command.SQL())
+			require.Equal(t, want, command.Payload())
+			return ErrPermissionDenied
+		}, nil
+	})))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(method, "/?type=json&sql=SELECT+1", strings.NewReader(payload)))
+	require.Equal(t, http.StatusForbidden, res.Code, res.Body.String())
+	require.Equal(t, 1, calls)
+}
+
+func TestCommandPayloadDecodeErrors(t *testing.T) {
+	for _, payload := range []string{
+		`{"type":"json","sql":"SELECT 1","projectId":"private-value"}`,
+		`{"type":"json","sql":"SELECT 1","projectId":18446744073709551616}`,
+		`{"type":"json","sql":"SELECT 1","tags":{}}`,
+	} {
+		t.Run(payload, func(t *testing.T) {
+			testCommandPayloadDecodeError[*applicationPayload](t, payload, `{"type":"json","sql":"SELECT 1"}`)
+		})
+	}
+	t.Run("custom decoder", func(t *testing.T) {
+		testCommandPayloadDecodeError[customPayload](t, `{"type":"json","sql":"SELECT 1"}`, `{"type":"json","sql":"SELECT 1","application":"valid"}`)
+	})
+}
+
+func testCommandPayloadDecodeError[T any](t *testing.T, invalid, valid string) {
+	t.Helper()
+	var calls atomic.Int32
+	handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(AuthorizerFunc[T](func(*http.Request) (CommandAuthorizer[T], error) {
+		return func(context.Context, Command[T]) error {
+			calls.Add(1)
+			return ErrPermissionDenied
+		}, nil
+	})))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(invalid)))
+	require.Equal(t, http.StatusBadRequest, res.Code)
+	require.Equal(t, "Bad Request\n", res.Body.String())
+	require.Zero(t, calls.Load())
+
+	server := newWebSocketTestServer(t, handler)
+	conn, _, err := server.dial(nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.CloseNow()) })
+	require.NoError(t, conn.Write(server.ctx, websocket.MessageText, []byte(invalid)))
+	var response map[string]string
+	require.NoError(t, wsjson.Read(server.ctx, conn, &response))
+	require.Equal(t, map[string]string{"code": "bad_request", "error": "Bad Request"}, response)
+	require.Zero(t, calls.Load())
+	require.NoError(t, conn.Write(server.ctx, websocket.MessageText, []byte(valid)))
+	require.NoError(t, wsjson.Read(server.ctx, conn, &response))
+	require.Equal(t, "forbidden", response["code"])
+	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestCommandRawMessagePayload(t *testing.T) {
 	payloads := []string{
 		`{"type":"json","sql":"SELECT 1"}`,
 		" \n" + `{"type":"json","sql":"SELECT 1","label":"a\u0062","list":[true,false,null,{},[]],"object":{"n":9007199254740993},"number":1e400}` + "\t\r\n",
@@ -27,7 +209,7 @@ func TestCommandRawEnvelope(t *testing.T) {
 
 	for _, transport := range []string{"HTTP", "WebSocket"} {
 		t.Run(transport, func(t *testing.T) {
-			commands := make(chan Command, len(payloads))
+			commands := make(chan Command[json.RawMessage], len(payloads))
 			sqls := make(chan string, len(payloads))
 			executor := &spyCommandExecutor{
 				failOnCallExecutor: failOnCallExecutor{t},
@@ -36,10 +218,9 @@ func TestCommandRawEnvelope(t *testing.T) {
 					return json.RawMessage(`[]`), nil
 				},
 			}
-			handler := mustHandler(t, executor, WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
-				return func(_ context.Context, command Command) error {
+			handler := mustHandler(t, executor, WithAuthorizer(AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
+				return func(_ context.Context, command Command[json.RawMessage]) error {
 					commands <- command
-					clear(command.Raw())
 					return nil
 				}, nil
 			})))
@@ -74,19 +255,20 @@ func TestCommandRawEnvelope(t *testing.T) {
 				require.Equal(t, CommandJSON, command.Type())
 				require.Equal(t, "SELECT 1", command.SQL())
 				require.Equal(t, command.SQL(), <-sqls)
-				require.Equal(t, payload, string(command.Raw()))
-				clear(command.Raw())
-				require.Equal(t, payload, string(command.Raw()))
+				require.Equal(t, strings.TrimSpace(payload), string(command.Payload()))
+				clear(command.Payload())
+				require.Equal(t, CommandJSON, command.Type())
+				require.Equal(t, "SELECT 1", command.SQL())
 			}
 		})
 	}
 }
 
-func TestCommandRawGET(t *testing.T) {
-	var seen Command
-	handler := mustHandler(t, failOnCallExecutor{t}, WithMaxMessageBytes(1), WithAuthorizer(AuthorizerFunc(func(r *http.Request) (CommandAuthorizer, error) {
+func TestCommandRawMessageGET(t *testing.T) {
+	var seen Command[json.RawMessage]
+	handler := mustHandler(t, failOnCallExecutor{t}, WithMaxMessageBytes(1), WithAuthorizer(AuthorizerFunc[json.RawMessage](func(r *http.Request) (CommandAuthorizer[json.RawMessage], error) {
 		require.Equal(t, []string{"one", "two"}, r.URL.Query()["label"])
-		return func(_ context.Context, command Command) error {
+		return func(_ context.Context, command Command[json.RawMessage]) error {
 			seen = command
 			return ErrPermissionDenied
 		}, nil
@@ -98,7 +280,7 @@ func TestCommandRawGET(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, res.Code)
 	require.Equal(t, CommandJSON, seen.Type())
 	require.Equal(t, "SELECT 1", seen.SQL())
-	require.Nil(t, seen.Raw())
+	require.Nil(t, seen.Payload())
 }
 
 func TestCommandPayloadErrors(t *testing.T) {
@@ -122,8 +304,8 @@ func TestCommandPayloadErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var commandCalls atomic.Int32
-			handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
-				return func(context.Context, Command) error {
+			handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
+				return func(context.Context, Command[json.RawMessage]) error {
 					commandCalls.Add(1)
 					return ErrPermissionDenied
 				}, nil
@@ -182,7 +364,7 @@ func TestCommandMessageLimits(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			payload := `{"type":"json","sql":"SELECT 1","payload":""}`
 			payload = strings.Replace(payload, `"payload":""`, `"payload":"`+strings.Repeat("x", tt.size-len(payload))+`"`, 1)
-			commands := make(chan Command, 2)
+			commands := make(chan Command[json.RawMessage], 2)
 			var executorCalls atomic.Int32
 			var expectedCalls int32
 			executor := &spyCommandExecutor{
@@ -193,9 +375,9 @@ func TestCommandMessageLimits(t *testing.T) {
 				},
 			}
 			var requestCalls atomic.Int32
-			opts := []Option{WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
+			opts := []Option{WithAuthorizer(AuthorizerFunc[json.RawMessage](func(*http.Request) (CommandAuthorizer[json.RawMessage], error) {
 				requestCalls.Add(1)
-				return func(_ context.Context, command Command) error {
+				return func(_ context.Context, command Command[json.RawMessage]) error {
 					commands <- command
 					return nil
 				}, nil
@@ -212,7 +394,7 @@ func TestCommandMessageLimits(t *testing.T) {
 			} else {
 				require.Equal(t, http.StatusOK, res.Code, res.Body.String())
 				require.Len(t, commands, 1)
-				require.Equal(t, payload, string((<-commands).Raw()))
+				require.Equal(t, payload, string((<-commands).Payload()))
 				expectedCalls++
 			}
 
@@ -245,7 +427,7 @@ func TestCommandMessageLimits(t *testing.T) {
 				require.NoError(t, err)
 				require.JSONEq(t, `[]`, string(response))
 				require.Len(t, commands, 1)
-				require.Equal(t, payload, string((<-commands).Raw()))
+				require.Equal(t, payload, string((<-commands).Payload()))
 				expectedCalls++
 			}
 			require.Equal(t, int32(2), requestCalls.Load())
@@ -261,7 +443,7 @@ func TestHTTPMessageLimitFollowsRequestAuthorization(t *testing.T) {
 		denied bool
 	}{{"restore body", false}, {"reject request", true}} {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := mustHandler(t, failOnCallExecutor{t}, WithMaxMessageBytes(1), WithAuthorizer(AuthorizerFunc(func(r *http.Request) (CommandAuthorizer, error) {
+			handler := mustHandler(t, failOnCallExecutor{t}, WithMaxMessageBytes(1), WithAuthorizer(AuthorizerFunc[json.RawMessage](func(r *http.Request) (CommandAuthorizer[json.RawMessage], error) {
 				if tt.denied {
 					return nil, ErrUnauthenticated
 				}
@@ -269,7 +451,7 @@ func TestHTTPMessageLimitFollowsRequestAuthorization(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, payload, string(body))
 				r.Body = io.NopCloser(strings.NewReader(string(body)))
-				return func(context.Context, Command) error {
+				return func(context.Context, Command[json.RawMessage]) error {
 					t.Error("unexpected command authorization")
 					return ErrPermissionDenied
 				}, nil
@@ -283,4 +465,18 @@ func TestHTTPMessageLimitFollowsRequestAuthorization(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHTTPMessageLimitLogsLimit(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	handler := mustHandler(t, failOnCallExecutor{t}, WithMaxMessageBytes(1), WithLogger(logger))
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"secret":"private-payload"}`)))
+	require.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
+	var record map[string]any
+	require.NoError(t, json.Unmarshal(logs.Bytes(), &record))
+	require.Equal(t, "WARN", record["level"])
+	require.Equal(t, float64(1), record["limit"])
+	require.NotContains(t, logs.String(), "private-payload")
 }

--- a/packages/server/duckdb-server-go/pkg/server/metadata_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/metadata_test.go
@@ -32,13 +32,28 @@ func TestCommandWorkspaceProjectPayload(t *testing.T) {
 		WorkspaceID uint64 `json:"workspaceId"`
 		ProjectID   uint64 `json:"projectId"`
 	}
-	const message = `{"type":"json","sql":"SELECT 1","workspaceId":123,"projectId":456}`
-	want := fields{WorkspaceID: 123, ProjectID: 456}
-	t.Run("struct", func(t *testing.T) {
-		testCommandPayload(t, http.MethodPost, message, want)
+	t.Run("siblings", func(t *testing.T) {
+		const message = `{"type":"json","sql":"SELECT 1","workspaceId":123,"projectId":456}`
+		want := fields{WorkspaceID: 123, ProjectID: 456}
+		t.Run("struct", func(t *testing.T) {
+			testCommandPayload(t, http.MethodPost, message, want)
+		})
+		t.Run("pointer", func(t *testing.T) {
+			testCommandPayload(t, http.MethodPost, message, &want)
+		})
 	})
-	t.Run("pointer", func(t *testing.T) {
-		testCommandPayload(t, http.MethodPost, message, &want)
+	t.Run("nested meta", func(t *testing.T) {
+		type payload struct {
+			Meta fields `json:"meta"`
+		}
+		const message = `{"type":"json","sql":"SELECT 1","meta":{"workspaceId":123,"projectId":456}}`
+		want := payload{Meta: fields{WorkspaceID: 123, ProjectID: 456}}
+		t.Run("struct", func(t *testing.T) {
+			testCommandPayload(t, http.MethodPost, message, want)
+		})
+		t.Run("pointer", func(t *testing.T) {
+			testCommandPayload(t, http.MethodPost, message, &want)
+		})
 	})
 }
 

--- a/packages/server/duckdb-server-go/pkg/server/metadata_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/metadata_test.go
@@ -46,6 +46,7 @@ func TestCommandTypedPayload(t *testing.T) {
 			handler := mustHandler(t, executor, WithAuthorizer(AuthorizerFunc[*applicationPayload](func(*http.Request) (CommandAuthorizer[*applicationPayload], error) {
 				return func(_ context.Context, command Command[*applicationPayload]) error {
 					fields := command.Payload()
+					require.NotNil(t, fields)
 					fields.Type = "exec"
 					fields.SQL = "DROP TABLE important"
 					commands <- command
@@ -113,6 +114,38 @@ func (p *customPayload) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+type countedPayload int
+
+func (p *countedPayload) UnmarshalJSON([]byte) error {
+	*p++
+	return nil
+}
+
+func TestCommandDecoderRunsOncePerMessage(t *testing.T) {
+	const payload = `{"type":"json","sql":"SELECT 1"}`
+	testCommandPayload(t, http.MethodPost, payload, countedPayload(1))
+	testCommandPayload(t, http.MethodGet, "", countedPayload(0))
+	var calls atomic.Int32
+	handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(AuthorizerFunc[countedPayload](func(*http.Request) (CommandAuthorizer[countedPayload], error) {
+		return func(_ context.Context, command Command[countedPayload]) error {
+			calls.Add(1)
+			require.Equal(t, countedPayload(1), command.Payload())
+			return ErrPermissionDenied
+		}, nil
+	})))
+	server := newWebSocketTestServer(t, handler)
+	conn, _, err := server.dial(nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.CloseNow()) })
+	for range 2 {
+		require.NoError(t, conn.Write(server.ctx, websocket.MessageText, []byte(payload)))
+		var response map[string]string
+		require.NoError(t, wsjson.Read(server.ctx, conn, &response))
+		require.Equal(t, "forbidden", response["code"])
+	}
+	require.Equal(t, int32(2), calls.Load())
+}
+
 func TestCommandPayloadTypes(t *testing.T) {
 	t.Run("pointer GET", func(t *testing.T) {
 		testCommandPayload(t, http.MethodGet, "", (*applicationPayload)(nil))
@@ -172,17 +205,29 @@ func TestCommandPayloadDecodeErrors(t *testing.T) {
 func testCommandPayloadDecodeError[T any](t *testing.T, invalid, valid string) {
 	t.Helper()
 	var calls atomic.Int32
+	var logs synchronizedBuffer
 	handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(AuthorizerFunc[T](func(*http.Request) (CommandAuthorizer[T], error) {
 		return func(context.Context, Command[T]) error {
 			calls.Add(1)
 			return ErrPermissionDenied
 		}, nil
-	})))
+	})), WithLogger(slog.New(slog.NewJSONHandler(&logs, nil))))
 	res := httptest.NewRecorder()
 	handler.ServeHTTP(res, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(invalid)))
 	require.Equal(t, http.StatusBadRequest, res.Code)
 	require.Equal(t, "Bad Request\n", res.Body.String())
 	require.Zero(t, calls.Load())
+	var diagnostic map[string]any
+	require.NoError(t, json.Unmarshal(logs.Bytes(), &diagnostic))
+	require.Equal(t, "WARN", diagnostic["level"])
+	require.Contains(t, diagnostic, "error_type")
+	require.NotContains(t, string(logs.Bytes()), "private-")
+	require.NotContains(t, string(logs.Bytes()), "18446744073709551616")
+	if diagnostic["error_type"] == "*json.UnmarshalTypeError" {
+		require.NotEmpty(t, diagnostic["field"])
+		require.NotEmpty(t, diagnostic["target_type"])
+		require.Greater(t, diagnostic["offset"], float64(0))
+	}
 
 	server := newWebSocketTestServer(t, handler)
 	conn, _, err := server.dial(nil)

--- a/packages/server/duckdb-server-go/pkg/server/options.go
+++ b/packages/server/duckdb-server-go/pkg/server/options.go
@@ -58,6 +58,7 @@ type config struct {
 	cors               CORSOptions
 	corsProtection     *http.CrossOriginProtection
 	websocket          WebSocketOptions
+	maxMessageBytes    int64
 }
 
 func defaultConfig() config {
@@ -110,6 +111,19 @@ func WithAuthorizer(authorizer Authorizer) Option {
 			return errNilAuthorizer
 		}
 		cfg.authorizer = authorizer
+		return nil
+	})
+}
+
+// WithMaxMessageBytes limits POST bodies and decompressed WebSocket messages to
+// n bytes, which must be positive. Omitting it leaves POST bodies unbounded and
+// retains the WebSocket library's 32 KiB limit.
+func WithMaxMessageBytes(n int64) Option {
+	return optionFunc(func(cfg *config) error {
+		if n <= 0 {
+			return errors.New("server: maximum message bytes must be positive")
+		}
+		cfg.maxMessageBytes = n
 		return nil
 	})
 }

--- a/packages/server/duckdb-server-go/pkg/server/options.go
+++ b/packages/server/duckdb-server-go/pkg/server/options.go
@@ -53,7 +53,7 @@ type WebSocketOptions struct {
 
 type config struct {
 	logger             *slog.Logger
-	authorizer         Authorizer
+	authorizer         requestAuthorizer
 	schemaMatchHeaders []string
 	cors               CORSOptions
 	corsProtection     *http.CrossOriginProtection
@@ -101,16 +101,6 @@ func WithLogger(logger *slog.Logger) Option {
 			configured = slog.Default()
 		}
 		cfg.logger = configured
-		return nil
-	})
-}
-
-func WithAuthorizer(authorizer Authorizer) Option {
-	return optionFunc(func(cfg *config) error {
-		if authorizer == nil || isNilValue(authorizer) {
-			return errNilAuthorizer
-		}
-		cfg.authorizer = authorizer
 		return nil
 	})
 }

--- a/packages/server/duckdb-server-go/pkg/server/options_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/options_test.go
@@ -15,6 +15,13 @@ func TestNewRejectsInvalidConfiguration(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestWithMaxMessageBytesRejectsNonpositiveLimits(t *testing.T) {
+	for _, limit := range []int64{-1, 0} {
+		_, err := applyOptions([]Option{WithMaxMessageBytes(limit)})
+		require.ErrorContains(t, err, "must be positive")
+	}
+}
+
 func TestWithCORSRejectsInvalidConfiguration(t *testing.T) {
 	tests := []Option{
 		WithCORS(CORSOptions{AllowedOrigins: []string{"app.example"}}),

--- a/packages/server/duckdb-server-go/pkg/server/security_test.go
+++ b/packages/server/duckdb-server-go/pkg/server/security_test.go
@@ -146,9 +146,9 @@ func TestCORSPreflightBypassesAuthorization(t *testing.T) {
 	var requestCalls atomic.Int32
 	handler := mustHandler(t, failOnCallExecutor{t},
 		WithCORS(CORSOptions{AllowedOrigins: []string{"https://app.example"}}),
-		WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
+		WithAuthorizer(AuthorizerFunc[struct{}](func(*http.Request) (CommandAuthorizer[struct{}], error) {
 			requestCalls.Add(1)
-			return func(context.Context, Command) error { return nil }, nil
+			return func(context.Context, Command[struct{}]) error { return nil }, nil
 		})),
 	)
 	res := httptest.NewRecorder()
@@ -299,9 +299,9 @@ func TestCrossOriginProtection(t *testing.T) {
 
 func TestCrossOriginGETExecRejectedBeforeAuthorizationAndExecution(t *testing.T) {
 	var requestCalls atomic.Int32
-	handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
+	handler := mustHandler(t, failOnCallExecutor{t}, WithAuthorizer(AuthorizerFunc[struct{}](func(*http.Request) (CommandAuthorizer[struct{}], error) {
 		requestCalls.Add(1)
-		return func(context.Context, Command) error { return nil }, nil
+		return func(context.Context, Command[struct{}]) error { return nil }, nil
 	})))
 	values := make(url.Values)
 	values.Set("type", string(CommandExec))
@@ -376,9 +376,9 @@ func TestWebSocketOriginPolicyPrecedesAuthorization(t *testing.T) {
 			var requestCalls atomic.Int32
 			handler := mustHandler(t, failOnCallExecutor{t},
 				WithWebSocket(tt.options),
-				WithAuthorizer(AuthorizerFunc(func(*http.Request) (CommandAuthorizer, error) {
+				WithAuthorizer(AuthorizerFunc[struct{}](func(*http.Request) (CommandAuthorizer[struct{}], error) {
 					requestCalls.Add(1)
-					return func(context.Context, Command) error { return nil }, nil
+					return func(context.Context, Command[struct{}]) error { return nil }, nil
 				})),
 			)
 			server := newWebSocketTestServer(t, handler)

--- a/packages/server/duckdb-server-go/pkg/server/server.go
+++ b/packages/server/duckdb-server-go/pkg/server/server.go
@@ -20,7 +20,7 @@ type queryParams struct {
 	Type *CommandType `json:"type"`
 	SQL  *string      `json:"sql"`
 	Name *string      `json:"name"`
-	raw  string
+	raw  []byte
 }
 
 type commandResponse struct {
@@ -51,7 +51,7 @@ type handler struct {
 	db                 commandExecutor
 	schemaMatchHeaders []string
 	logger             *slog.Logger
-	authorizer         Authorizer
+	authorizer         requestAuthorizer
 	httpHandler        http.Handler
 	websocketOptions   WebSocketOptions
 	maxMessageBytes    int64
@@ -97,12 +97,12 @@ func (s *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.httpHandler.ServeHTTP(w, r)
 }
 
-func (s *handler) commandAuthorizer(r *http.Request) (CommandAuthorizer, error) {
+func (s *handler) commandAuthorizer(r *http.Request) (commandAuthorizer, error) {
 	if s.authorizer == nil {
 		return nil, nil
 	}
 
-	authorize, err := s.authorizer.AuthorizeRequest(r)
+	authorize, err := s.authorizer(r)
 	if err != nil {
 		return nil, &authorizationError{err: err}
 	}
@@ -172,7 +172,7 @@ func (s *handler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 // A returned error closes the connection. Command errors are written to the
 // client and return nil so the session survives them.
-func (s *handler) handleWebSocketMessage(ctx context.Context, conn *websocket.Conn, allowedSchemas []string, authorize CommandAuthorizer) error {
+func (s *handler) handleWebSocketMessage(ctx context.Context, conn *websocket.Conn, allowedSchemas []string, authorize commandAuthorizer) error {
 	_, raw, err := conn.Read(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to read websocket message: %w", err)
@@ -185,7 +185,7 @@ func (s *handler) handleWebSocketMessage(ctx context.Context, conn *websocket.Co
 			conn.Close(websocket.StatusInvalidFramePayloadData, "failed to unmarshal JSON"),
 		)
 	}
-	params.raw = string(raw)
+	params.raw = raw
 
 	response, err := s.execCommand(ctx, params, allowedSchemas, authorize)
 	if err != nil {
@@ -240,6 +240,7 @@ func (s *handler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			var sizeErr *http.MaxBytesError
 			if errors.As(err, &sizeErr) {
+				s.logger.Warn("server: request body exceeds message limit", "limit", sizeErr.Limit)
 				http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
 				return
 			}
@@ -247,7 +248,7 @@ func (s *handler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		params.raw = string(raw)
+		params.raw = raw
 
 	case http.MethodGet:
 		q := r.URL.Query()
@@ -286,32 +287,31 @@ func (s *handler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *handler) execCommand(ctx context.Context, params queryParams, allowedSchemas []string, authorize CommandAuthorizer) (commandResponse, error) {
+func (s *handler) execCommand(ctx context.Context, params queryParams, allowedSchemas []string, authorize commandAuthorizer) (commandResponse, error) {
 	if err := params.Validate(s.logger); err != nil {
 		return commandResponse{}, err
 	}
 	response := commandResponses[*params.Type]
 	var err error
 
-	command := newCommand(*params.Type, *params.SQL, params.raw)
 	if authorize != nil {
-		if err = authorize(ctx, command); err != nil {
+		if err = authorize(ctx, params); err != nil {
 			return commandResponse{}, &authorizationError{err: err}
 		}
 	}
 
-	switch command.Type() {
+	switch *params.Type {
 	case CommandExec:
 		if len(s.schemaMatchHeaders) > 0 {
 			return commandResponse{}, query.ErrExecWithValidation
 		}
-		err = s.db.Exec(ctx, command.SQL())
+		err = s.db.Exec(ctx, *params.SQL)
 
 	case CommandArrow:
-		response.data, err = s.db.QueryArrow(ctx, command.SQL(), allowedSchemas)
+		response.data, err = s.db.QueryArrow(ctx, *params.SQL, allowedSchemas)
 
 	default:
-		return commandResponse{}, fmt.Errorf("server: no executor for command type %q", command.Type())
+		return commandResponse{}, fmt.Errorf("server: no executor for command type %q", *params.Type)
 	}
 
 	return response, err

--- a/packages/server/duckdb-server-go/pkg/server/server.go
+++ b/packages/server/duckdb-server-go/pkg/server/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -19,6 +20,7 @@ type queryParams struct {
 	Type *CommandType `json:"type"`
 	SQL  *string      `json:"sql"`
 	Name *string      `json:"name"`
+	raw  string
 }
 
 type commandResponse struct {
@@ -52,6 +54,7 @@ type handler struct {
 	authorizer         Authorizer
 	httpHandler        http.Handler
 	websocketOptions   WebSocketOptions
+	maxMessageBytes    int64
 }
 
 // New constructs a Mosaic HTTP and WebSocket handler backed by db. Omitting
@@ -76,6 +79,7 @@ func newHandler(db commandExecutor, cfg config) *handler {
 		logger:             cfg.logger,
 		authorizer:         cfg.authorizer,
 		websocketOptions:   cfg.websocket,
+		maxMessageBytes:    cfg.maxMessageBytes,
 	}
 
 	s.httpHandler = newCORSHandler(cfg.cors, cfg.corsProtection, http.HandlerFunc(s.handleHTTP))
@@ -143,6 +147,10 @@ func (s *handler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if s.maxMessageBytes > 0 {
+		conn.SetReadLimit(s.maxMessageBytes)
+	}
+
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
@@ -165,11 +173,19 @@ func (s *handler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 // A returned error closes the connection. Command errors are written to the
 // client and return nil so the session survives them.
 func (s *handler) handleWebSocketMessage(ctx context.Context, conn *websocket.Conn, allowedSchemas []string, authorize CommandAuthorizer) error {
-	var params queryParams
-	err := wsjson.Read(ctx, conn, &params)
+	_, raw, err := conn.Read(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to read websocket message: %w", err)
 	}
+
+	var params queryParams
+	if err = json.Unmarshal(raw, &params); err != nil {
+		return errors.Join(
+			fmt.Errorf("failed to decode websocket message: %w", err),
+			conn.Close(websocket.StatusInvalidFramePayloadData, "failed to unmarshal JSON"),
+		)
+	}
+	params.raw = string(raw)
 
 	response, err := s.execCommand(ctx, params, allowedSchemas, authorize)
 	if err != nil {
@@ -214,12 +230,24 @@ func (s *handler) handleHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodPost:
-		err := json.NewDecoder(r.Body).Decode(&params)
+		if s.maxMessageBytes > 0 {
+			r.Body = http.MaxBytesReader(w, r.Body, s.maxMessageBytes)
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err == nil {
+			err = json.Unmarshal(raw, &params)
+		}
 		if err != nil {
+			var sizeErr *http.MaxBytesError
+			if errors.As(err, &sizeErr) {
+				http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+				return
+			}
 			s.logger.Error("server: failed to decode request body", "error", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		params.raw = string(raw)
 
 	case http.MethodGet:
 		q := r.URL.Query()
@@ -265,7 +293,7 @@ func (s *handler) execCommand(ctx context.Context, params queryParams, allowedSc
 	response := commandResponses[*params.Type]
 	var err error
 
-	command := newCommand(*params.Type, *params.SQL)
+	command := newCommand(*params.Type, *params.SQL, params.raw)
 	if authorize != nil {
 		if err = authorize(ctx, command); err != nil {
 			return commandResponse{}, &authorizationError{err: err}


### PR DESCRIPTION
Custom connectors can already send application-owned fields, but the Go server discards them before command authorization. Make `Command[T]`, `CommandAuthorizer[T]`, and `Authorizer[T]` generic so applications receive their own decoded payload type directly through `command.Payload()`. `WithAuthorizer` binds and infers the type; `New` and unrelated options stay non-generic. Mosaic defines no metadata key, schema, or value shape.

Decode the complete POST or decompressed WebSocket envelope into a fresh application value after protocol validation and before command authorization. Applications can use structs, maps, custom unmarshaling, or `json.RawMessage`. `Type()` and `SQL()` remain authoritative and cannot be rewritten by mutating the payload. GET skips JSON decoding and returns the zero value of `T`; `*MyFields` provides an explicit nil case. Application decode errors are sanitized HTTP 400/recoverable WebSocket command errors.

Add `WithMaxMessageBytes` for whole POST bodies and decompressed WebSocket messages, preserving existing limits when omitted. POST now rejects trailing input and multiple JSON values, matching WebSocket framing. Keep focused Go API documentation in the package README. Public connector documentation is deferred until the pattern is validated; `docs/api/core/connectors.md` remains unchanged.

Implements the metadata capability in #1214 with the [typed API revision requested during review](https://github.com/uwdata/mosaic/pull/1215#issuecomment-5575375519), superseding its raw-only accessor design. This intentionally changes the Go authorizer signatures. Execution context and cleanup hooks remain deferred, so this PR does not close the issue.

Validation:

- Go tests and race tests across the full Go server module with `-tags=duckdb_arrow`, including typed/custom decoding, GET, payload isolation, error mapping, and HTTP/WebSocket limits.
- Go build, vet, and `golangci-lint run ./...` (zero issues).
- `pnpm docs:build` and a compiled typed Go consumer example.
- Original transport commit: `pnpm lint` (existing warnings) and `pnpm test` (591 tests passed); the typed revision changes Go and documentation only.
- `git diff --check`.
