### PR TITLE
fix(core): reject the in-flight socket request on close

### DIFF
--- a/packages/mosaic/core/src/connectors/socket.ts
+++ b/packages/mosaic/core/src/connectors/socket.ts
@@ -59,9 +59,11 @@ export class SocketConnector implements Connector {
       },
 
       close() {
+        const request = c._request;
         c._connected = false;
         c._request = null;
         c._ws = null;
+        if (request) request.reject('Socket closed');
         while (c._queue.length) {
           c._queue.shift()!.reject('Socket closed');
         }

--- a/packages/mosaic/core/src/connectors/socket.ts
+++ b/packages/mosaic/core/src/connectors/socket.ts
@@ -59,11 +59,10 @@ export class SocketConnector implements Connector {
       },
 
       close() {
-        const request = c._request;
         c._connected = false;
+        c._request?.reject('Socket closed');
         c._request = null;
         c._ws = null;
-        if (request) request.reject('Socket closed');
         while (c._queue.length) {
           c._queue.shift()!.reject('Socket closed');
         }

--- a/packages/mosaic/core/test/socket-connector.test.ts
+++ b/packages/mosaic/core/test/socket-connector.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SocketConnector } from '../src/connectors/socket.js';
+
+type Listener = (event?: unknown) => void;
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  binaryType = 'blob';
+  sent: string[] = [];
+  private listeners = new Map<string, Listener>();
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, fn: Listener) {
+    this.listeners.set(type, fn);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  emit(type: string, event?: unknown) {
+    this.listeners.get(type)?.(event);
+  }
+}
+
+describe('SocketConnector', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('rejects the in-flight and queued requests when the socket closes', async () => {
+    const connector = new SocketConnector({ uri: 'ws://test/' });
+    const active = connector.query({ type: 'exec', sql: 'SELECT 1' });
+    const queued = connector.query({ type: 'exec', sql: 'SELECT 2' });
+    const socket = FakeWebSocket.instances[0];
+    socket.emit('open');
+    expect(socket.sent).toHaveLength(1);
+
+    socket.emit('close');
+    await expect(active).rejects.toBe('Socket closed');
+    await expect(queued).rejects.toBe('Socket closed');
+    expect(connector.connected).toBe(false);
+
+    connector.query({ type: 'exec', sql: 'SELECT 3' });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+});

--- a/packages/mosaic/core/test/socket-connector.test.ts
+++ b/packages/mosaic/core/test/socket-connector.test.ts
@@ -1,52 +1,19 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, expect, it, vi } from 'vitest';
 import { SocketConnector } from '../src/connectors/socket.js';
 
-type Listener = (event?: unknown) => void;
+afterEach(() => vi.unstubAllGlobals());
 
-class FakeWebSocket {
-  static instances: FakeWebSocket[] = [];
-  binaryType = 'blob';
-  sent: string[] = [];
-  private listeners = new Map<string, Listener>();
-
-  constructor(public url: string) {
-    FakeWebSocket.instances.push(this);
-  }
-
-  addEventListener(type: string, fn: Listener) {
-    this.listeners.set(type, fn);
-  }
-
-  send(data: string) {
-    this.sent.push(data);
-  }
-
-  emit(type: string, event?: unknown) {
-    this.listeners.get(type)?.(event);
-  }
-}
-
-describe('SocketConnector', () => {
-  beforeEach(() => {
-    FakeWebSocket.instances = [];
-    vi.stubGlobal('WebSocket', FakeWebSocket);
+it('rejects the in-flight and queued requests when the socket closes', async () => {
+  const listeners: Record<string, (event?: unknown) => void> = {};
+  vi.stubGlobal('WebSocket', class {
+    addEventListener(type: string, fn: (event?: unknown) => void) { listeners[type] = fn; }
+    send() {}
   });
-  afterEach(() => vi.unstubAllGlobals());
-
-  it('rejects the in-flight and queued requests when the socket closes', async () => {
-    const connector = new SocketConnector({ uri: 'ws://test/' });
-    const active = connector.query({ type: 'exec', sql: 'SELECT 1' });
-    const queued = connector.query({ type: 'exec', sql: 'SELECT 2' });
-    const socket = FakeWebSocket.instances[0];
-    socket.emit('open');
-    expect(socket.sent).toHaveLength(1);
-
-    socket.emit('close');
-    await expect(active).rejects.toBe('Socket closed');
-    await expect(queued).rejects.toBe('Socket closed');
-    expect(connector.connected).toBe(false);
-
-    connector.query({ type: 'exec', sql: 'SELECT 3' });
-    expect(FakeWebSocket.instances).toHaveLength(2);
-  });
+  const connector = new SocketConnector();
+  const active = connector.query({ type: 'exec', sql: 'SELECT 1' });
+  const queued = connector.query({ type: 'exec', sql: 'SELECT 2' });
+  listeners.open();
+  listeners.close();
+  await expect(active).rejects.toBe('Socket closed');
+  await expect(queued).rejects.toBe('Socket closed');
 });


### PR DESCRIPTION
`SocketConnector`'s `close` handler set `_request = null` without rejecting it, so a query whose WebSocket dropped mid-flight hung forever; only queued requests were rejected with `'Socket closed'`. This rejects the active request the same way, before clearing it.

Split out of #1224 at review request so the fix lands independently of the preagg work. The test uses a minimal fake `WebSocket` to drive `open`/`close` and asserts both the active and queued promises reject and that a later query lazily opens a new socket.