### PR TITLE
fix: run exec statements through the duckdb-wasm query api

### DIFF
--- a/packages/mosaic/core/src/connectors/wasm.ts
+++ b/packages/mosaic/core/src/connectors/wasm.ts
@@ -77,8 +77,11 @@ export class DuckDBWASMConnector implements Connector {
   async query(query: ConnectorQueryRequest): Promise<unknown> {
     const { type, sql } = query;
     const con = await this.getConnection();
-    const result = await getArrowIPC(con, sql);
-    return type === 'exec' ? undefined : decodeIPC(result, this._ipc);
+    if (type === 'exec') {
+      await con.query(sql);
+    } else {
+      return decodeIPC(await getArrowIPC(con, sql), this._ipc);
+    }
   }
 }
 


### PR DESCRIPTION
The WASM connector ran every request through the Arrow IPC bypass, so an `exec` statement materialized a result it then threw away. Exec now goes through duckdb-wasm's own `query` call and only `arrow` requests take the bypass and decode, so the two paths read as what they are.

This is a clarity fix rather than a performance one: exec carries DDL, so the discarded result was tiny.

Closes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ryhKLCmz1r5zgdq3VU2D2
