### PR TITLE
fix!: require the query type and reject a missing one with 400

### DIFF
--- a/docs/api/core/connectors.md
+++ b/docs/api/core/connectors.md
@@ -3,10 +3,10 @@
 Database connectors issue query requests to a backing data source.
 
 A connector instance should expose a `query(query)` method that returns a Promise.
-The _query_ argument is an object that may include the following properties:
+The _query_ argument is an object with the following properties:
 
 - _sql_: The SQL query to evaluate.
-- _type_: The query format type, either `"exec"` (no return value) or `"arrow"`.
+- _type_: The query format type, either `"exec"` (no return value) or `"arrow"`. This property is required; servers reject a request without it.
 - Any additional connector-specific options.
 
 Once instantiated, register a connector with the coordinator using the [`coordinator.databaseConnector()`](coordinator#databaseconnector) method.

--- a/docs/api/duckdb/data-server.md
+++ b/docs/api/duckdb/data-server.md
@@ -22,8 +22,10 @@ The following _options_ are supported:
 
 Once launched, the data server will accept HTTP POST requests containing JSON content that consists of a single object with the following properties:
 
-- _type_: The type of query. The type `"exec"` indicates that the provided query should be run with no return value. The `"arrow"` type indicates that the result table should be returned as Arrow IPC bytes.
+- _type_: The type of query (required). The type `"exec"` indicates that the provided query should be run with no return value. The `"arrow"` type indicates that the result table should be returned as Arrow IPC bytes.
 - _sql_: The SQL query string to issue to DuckDB.
+
+A request without a _type_ is rejected with HTTP status 400 and the message `missing required 'type' parameter`; the other Mosaic DuckDB servers respond the same way.
 
 ### Examples
 

--- a/packages/mosaic/core/src/connectors/Connector.ts
+++ b/packages/mosaic/core/src/connectors/Connector.ts
@@ -2,14 +2,14 @@ import type { Table } from '@uwdata/flechette';
 
 export interface ConnectorQueryRequest {
   /** The query type. */
-  type?: string;
+  type: string;
   /** A SQL query string. */
   sql: string;
 }
 
 export interface ArrowQueryRequest extends ConnectorQueryRequest {
   /** The query type. */
-  type?: 'arrow';
+  type: 'arrow';
 }
 
 export interface ExecQueryRequest extends ConnectorQueryRequest {

--- a/packages/server/duckdb-server-rust/src/interfaces.rs
+++ b/packages/server/duckdb-server-rust/src/interfaces.rs
@@ -50,7 +50,7 @@ impl IntoResponse for QueryResponse {
 #[derive(Debug)]
 pub enum AppError {
     Error(anyhow::Error),
-    BadRequest,
+    BadRequest(&'static str),
 }
 
 impl IntoResponse for AppError {
@@ -64,7 +64,7 @@ impl IntoResponse for AppError {
                 )
                     .into_response()
             }
-            AppError::BadRequest => (StatusCode::BAD_REQUEST).into_response(),
+            AppError::BadRequest(message) => (StatusCode::BAD_REQUEST, message).into_response(),
         }
     }
 }

--- a/packages/server/duckdb-server-rust/src/query.rs
+++ b/packages/server/duckdb-server-rust/src/query.rs
@@ -11,7 +11,7 @@ pub async fn handle(state: &AppState, params: QueryParams) -> Result<QueryRespon
                 let buffer = state.db.get_arrow(sql).await?;
                 Ok(QueryResponse::Arrow(buffer))
             } else {
-                Err(AppError::BadRequest)
+                Err(AppError::BadRequest("missing required 'sql' parameter"))
             }
         }
         Some(Command::Exec) => {
@@ -19,9 +19,9 @@ pub async fn handle(state: &AppState, params: QueryParams) -> Result<QueryRespon
                 state.db.execute(sql).await?;
                 Ok(QueryResponse::Empty)
             } else {
-                Err(AppError::BadRequest)
+                Err(AppError::BadRequest("missing required 'sql' parameter"))
             }
         }
-        None => Err(AppError::BadRequest),
+        None => Err(AppError::BadRequest("missing required 'type' parameter")),
     }
 }

--- a/packages/server/duckdb-server-rust/src/test.rs
+++ b/packages/server/duckdb-server-rust/src/test.rs
@@ -80,6 +80,29 @@ async fn query_arrow() -> Result<()> {
     assert_foo_batch(&body)
 }
 
+#[tokio::test]
+async fn missing_type_is_bad_request() -> Result<()> {
+    let app = app::app(None, None)?;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_vec(
+                    &json!({"sql": "select 1 as foo"}),
+                )?))?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await?.to_bytes();
+    assert_eq!(body, "missing required 'type' parameter");
+    Ok(())
+}
+
 fn assert_foo_batch(bytes: &[u8]) -> Result<()> {
     let mut reader = FileReader::try_new(std::io::Cursor::new(bytes), None)?;
     let actual_batch = reader.next().unwrap()?;

--- a/packages/server/duckdb-server-rust/src/websocket.rs
+++ b/packages/server/duckdb-server-rust/src/websocket.rs
@@ -19,10 +19,10 @@ pub async fn handle(mut socket: WebSocket, state: Arc<AppState>) {
                     let response = handle_message(text, &state).await;
                     if match response {
                         Err(error) => match error {
-                            AppError::BadRequest => {
+                            AppError::BadRequest(message) => {
                                 socket
                                     .send(Message::Text(
-                                        json!({"error": "Bad request"}).to_string().into(),
+                                        json!({"error": message}).to_string().into(),
                                     ))
                                     .await
                             }

--- a/packages/server/duckdb-server/pkg/server.py
+++ b/packages/server/duckdb-server/pkg/server.py
@@ -11,6 +11,8 @@ from socketify import App, CompressOptions, OpCode
 from pkg.query import get_arrow_bytes
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     import duckdb
     from duckdb import DuckDBPyConnection as Con
     from socketify import Request as Req
@@ -75,7 +77,7 @@ class HTTPHandler(Handler):
 def handle_query(
     handler: Handler,
     con: duckdb.DuckDBPyConnection,
-    query: _QueryParams,
+    query: Mapping[str, Any],
 ) -> None:
     logger.debug(f"{query=}")
 

--- a/packages/server/duckdb-server/pkg/server.py
+++ b/packages/server/duckdb-server/pkg/server.py
@@ -32,7 +32,7 @@ class _QueryParams(TypedDict):
 class Handler(Protocol):
     def done(self) -> None: ...
     def arrow(self, buffer: bytes) -> None: ...
-    def error(self, error: Any) -> None: ...
+    def error(self, error: Any, status: int = 500) -> None: ...
 
 
 class SocketHandler(Handler):
@@ -51,7 +51,7 @@ class SocketHandler(Handler):
         ok = self.ws.send(buffer, OpCode.BINARY)
         self.check(ok)
 
-    def error(self, error: object) -> None:
+    def error(self, error: object, status: int = 500) -> None:
         ok = self.ws.send({"error": str(error)}, OpCode.TEXT)
         self.check(ok)
 
@@ -67,8 +67,8 @@ class HTTPHandler(Handler):
         self.res.write_header("Content-Type", "application/octet-stream")
         self.res.end(buffer)
 
-    def error(self, error: object) -> None:
-        self.res.write_status(500)
+    def error(self, error: object, status: int = 500) -> None:
+        self.res.write_status(status)
         self.res.end(str(error))
 
 
@@ -81,8 +81,12 @@ def handle_query(
 
     start = time.time()
 
+    command = query.get("type")
+    if command is None:
+        handler.error("missing required 'type' parameter", 400)
+        return
+
     sql = query["sql"]
-    command = query["type"]
 
     try:
         if command == "exec":
@@ -92,8 +96,7 @@ def handle_query(
             buffer = get_arrow_bytes(con, sql)
             handler.arrow(buffer)
         else:
-            msg = f"Unknown command {command}"
-            raise ValueError(msg)
+            handler.error(f"Unknown command {command}", 400)
     except Exception as e:
         logger.exception("Error processing query")
         handler.error(e)

--- a/packages/server/duckdb-server/pkg/tests/test_server.py
+++ b/packages/server/duckdb-server/pkg/tests/test_server.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 import duckdb
 
-from pkg.server import _QueryParams, handle_query
+from pkg.server import handle_query
 
 
 class RecordingHandler:
@@ -20,8 +20,6 @@ class RecordingHandler:
 
 def test_missing_type_is_bad_request() -> None:
     handler = RecordingHandler()
-    query = cast("_QueryParams", {"sql": "SELECT 1"})
-
-    handle_query(handler, duckdb.connect(), query)
+    handle_query(handler, duckdb.connect(), {"sql": "SELECT 1"})  # pyright: ignore[reportArgumentType]  # ty: ignore[invalid-argument-type, missing-typed-dict-key]
 
     assert handler.errors == [("missing required 'type' parameter", 400)]

--- a/packages/server/duckdb-server/pkg/tests/test_server.py
+++ b/packages/server/duckdb-server/pkg/tests/test_server.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import duckdb
+
+from pkg.server import _QueryParams, handle_query
+
+
+class RecordingHandler:
+    def __init__(self) -> None:
+        self.errors: list[tuple[str, int]] = []
+
+    def done(self) -> None: ...
+    def arrow(self, buffer: bytes) -> None: ...
+
+    def error(self, error: Any, status: int = 500) -> None:
+        self.errors.append((str(error), status))
+
+
+def test_missing_type_is_bad_request() -> None:
+    handler = RecordingHandler()
+    query = cast("_QueryParams", {"sql": "SELECT 1"})
+
+    handle_query(handler, duckdb.connect(), query)
+
+    assert handler.errors == [("missing required 'type' parameter", 400)]

--- a/packages/server/duckdb-server/pkg/tests/test_server.py
+++ b/packages/server/duckdb-server/pkg/tests/test_server.py
@@ -20,6 +20,6 @@ class RecordingHandler:
 
 def test_missing_type_is_bad_request() -> None:
     handler = RecordingHandler()
-    handle_query(handler, duckdb.connect(), {"sql": "SELECT 1"})  # pyright: ignore[reportArgumentType]  # ty: ignore[invalid-argument-type, missing-typed-dict-key]
+    handle_query(handler, duckdb.connect(), {"sql": "SELECT 1"})
 
     assert handler.errors == [("missing required 'type' parameter", 400)]

--- a/packages/server/duckdb/src/data-server.js
+++ b/packages/server/duckdb/src/data-server.js
@@ -76,7 +76,11 @@ export function queryHandler(db) {
     }
 
     try {
-      const { sql, type = 'arrow' } = query;
+      const { sql, type } = query;
+      if (type == null) {
+        res.error(`missing required 'type' parameter`, 400);
+        return;
+      }
       console.log(`> ${String(type).toUpperCase()}${sql ? ` ${sql}` : ''}`);
 
       // process query and return result
@@ -115,7 +119,7 @@ function httpResponse(res) {
     error(err, code) {
       console.error(err);
       res.writeHead(code);
-      res.end();
+      res.end(String(err));
     }
   }
 }

--- a/packages/server/duckdb/test/data-server.test.js
+++ b/packages/server/duckdb/test/data-server.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { db } from './db.js';
+import { queryHandler } from '../src/index.js';
+
+describe('queryHandler', () => {
+  it('rejects a request with no type', async () => {
+    const errors = [];
+    const res = { error: (err, code) => errors.push([String(err), code]) };
+    await queryHandler(db)(res, JSON.stringify({ sql: 'SELECT 1' }));
+    expect(errors).toEqual([[`missing required 'type' parameter`, 400]]);
+  });
+});


### PR DESCRIPTION
A request with no `type` got four different answers: the Node data server defaulted to `arrow`, Go and Rust returned a 400 with and without a message, and the Python server raised a `KeyError` that surfaced as a 500. The connector types also marked `type` as optional, so a client had no way to know it was required.

`type` is now required in the TypeScript request types and every server answers a missing one with `400` and the same body, `missing required 'type' parameter`. Each server has a test for it.

Two smaller alignments came with it. The Node server's HTTP error responses now carry the error text as the body, as the other servers already did; before, the body was empty. And the Rust websocket path now sends the specific bad-request message rather than a fixed "Bad request".

## Breaking change

- `ConnectorQueryRequest.type` and `ArrowQueryRequest.type` are required. Every in-repo caller already set it.
- The Node data server no longer defaults a missing `type` to `arrow`.

A missing `sql` is still handled inconsistently across servers and is left for a follow-up.

Closes #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ryhKLCmz1r5zgdq3VU2D2
