### PR TITLE
feat(core): recover missing automatic preaggregates

### DIFF
--- a/docs/api/core/connectors.md
+++ b/docs/api/core/connectors.md
@@ -25,7 +25,7 @@ Create a new Web Socket connector to a DuckDB [data server](../duckdb/data-serve
 
 Create a new HTTP rest connector to a DuckDB [data server](../duckdb/data-server) at the given _uri_ (default `"http://localhost:3000/"`).
 
-For SELECT and `preagg` requests, JSON error responses of the form `{ error, code }` reject with a `ConnectorError` that preserves the message, code, and HTTP status. A `table_not_found` error may also include `catalog`, `schema`, and `table`; automatic preaggregation uses this reference to [recover missing materializations](coordinator#constructor). Plain-text and malformed SELECT errors, and errors from `exec` requests, keep their generic error behavior.
+SELECT and `preagg` requests preserve structured JSON failures as a `ConnectorError` with `message`, `code`, and HTTP `status`, plus the table reference when supplied for `table_not_found`.
 
 ## wasmConnector
 

--- a/docs/api/core/connectors.md
+++ b/docs/api/core/connectors.md
@@ -25,6 +25,8 @@ Create a new Web Socket connector to a DuckDB [data server](../duckdb/data-serve
 
 Create a new HTTP rest connector to a DuckDB [data server](../duckdb/data-server) at the given _uri_ (default `"http://localhost:3000/"`).
 
+For SELECT and `preagg` requests, JSON error responses of the form `{ error, code }` reject with a `ConnectorError` that preserves the message, code, and HTTP status. A `table_not_found` error may also include `catalog`, `schema`, and `table`; automatic preaggregation uses this reference to [recover missing materializations](coordinator#constructor). Plain-text and malformed SELECT errors, and errors from `exec` requests, keep their generic error behavior.
+
 ## wasmConnector
 
 `wasmConnector(options)`

--- a/docs/api/core/coordinator.md
+++ b/docs/api/core/coordinator.md
@@ -22,7 +22,7 @@ Create a new Mosaic Coordinator to manage all database communication for clients
 * _consolidate_ Boolean flag to enable/disable query consolidation (default `true`).
 * _preagg_: Pre-aggregation options object. The _enabled_ flag (default `true`) determines if pre-aggregation optimizations should be used when possible. The _mode_ option (default `'exec'`) determines how materialized views are created:
   * `'exec'` issues `CREATE TABLE` statements directly. The _schema_ option (default `'mosaic'`) indicates the database schema in which the tables are created.
-  * `'preagg'` sends a `preagg` request and lets the [connector](./connectors) or its server create and name the table. If the server reports that materialized table missing, the coordinator rebuilds it and retries once before falling back to the base query.
+  * `'preagg'` sends a `preagg` request and lets the [connector](./connectors) or its server create and name the table. If the server later reports the materialized table as missing, the coordinator rebuilds it and retries once before falling back to the base query.
 
 ## databaseConnector
 

--- a/docs/api/core/coordinator.md
+++ b/docs/api/core/coordinator.md
@@ -24,6 +24,8 @@ Create a new Mosaic Coordinator to manage all database communication for clients
   * `'exec'` issues `CREATE TABLE` statements directly. The _schema_ option (default `'mosaic'`) indicates the database schema in which the tables are created.
   * `'preagg'` sends a `preagg` request and lets the [connector](./connectors) or its server create and name the table.
 
+In `'preagg'` mode, a SELECT that fails with a structured `table_not_found` error matching its automatic preaggregate triggers one shared rebuild from the retained SELECT. The coordinator clears cached query results and retries once using the returned table name, which may have changed. Failed recovery falls back to the base query. Recovery applies only to live automatic preaggregates; it does not rebuild missing source tables, retry authorization failures, or rewrite application SQL. Resetting preaggregation, replacing the connector, disconnecting the client, or requesting a new client query supersedes a pending recovery.
+
 ## databaseConnector
 
 `coordinator.databaseConnector(connector)`

--- a/docs/api/core/coordinator.md
+++ b/docs/api/core/coordinator.md
@@ -22,9 +22,7 @@ Create a new Mosaic Coordinator to manage all database communication for clients
 * _consolidate_ Boolean flag to enable/disable query consolidation (default `true`).
 * _preagg_: Pre-aggregation options object. The _enabled_ flag (default `true`) determines if pre-aggregation optimizations should be used when possible. The _mode_ option (default `'exec'`) determines how materialized views are created:
   * `'exec'` issues `CREATE TABLE` statements directly. The _schema_ option (default `'mosaic'`) indicates the database schema in which the tables are created.
-  * `'preagg'` sends a `preagg` request and lets the [connector](./connectors) or its server create and name the table.
-
-In `'preagg'` mode, a SELECT that fails with a structured `table_not_found` error matching its automatic preaggregate triggers one shared rebuild from the retained SELECT. The coordinator clears cached query results and retries once using the returned table name, which may have changed. Failed recovery falls back to the base query. Recovery applies only to live automatic preaggregates; it does not rebuild missing source tables, retry authorization failures, or rewrite application SQL. Resetting preaggregation, replacing the connector, disconnecting the client, or requesting a new client query supersedes a pending recovery.
+  * `'preagg'` sends a `preagg` request and lets the [connector](./connectors) or its server create and name the table. If the server reports that materialized table missing, the coordinator rebuilds it and retries once before falling back to the base query.
 
 ## databaseConnector
 

--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -377,11 +377,14 @@ function updateSelection(
       return;
     }
 
+    const superseded = (pending: Promise<unknown>) => client.pending !== pending
+      || !filterGroups.get(selection)?.clients.has(client)
+      || preaggregator.entries.get(client) !== info;
+
     if (info?.ready) {
       const pending = client.pending;
       await info.ready.catch(() => {});
-      // a requestQuery or disconnect during the wait supersedes this update
-      if (client.pending !== pending || !filterGroups.get(selection)?.clients.has(client)) return;
+      if (superseded(pending)) return;
     }
 
     if (info?.result) {
@@ -392,15 +395,14 @@ function updateSelection(
       const result = await pending;
       if (!(result instanceof QueryError)) return;
       if (preaggregator.registry) {
-        if (client.pending !== pending || !filterGroups.get(selection)?.clients.has(client)) return;
+        if (superseded(pending)) return;
         const recovered = await preaggregator.recover(client, info, table, result.cause);
-        if (client.pending !== pending || !filterGroups.get(selection)?.clients.has(client)
-          || preaggregator.entries.get(client) !== info) return;
+        if (superseded(pending)) return;
         if (recovered) {
           const retry = mc.updateClient(client, info.query(active));
-          if (!(await retry instanceof QueryError)) return;
-          if (client.pending !== retry || !filterGroups.get(selection)?.clients.has(client)
-            || preaggregator.entries.get(client) !== info) return;
+          const retried = await retry;
+          if (!(retried instanceof QueryError)) return;
+          if (superseded(retry)) return;
         }
       }
       // if preaggregate update fails, fall through to standard query

--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -378,8 +378,7 @@ function updateSelection(
     }
 
     const superseded = (pending: Promise<unknown>) => client.pending !== pending
-      || !filterGroups.get(selection)?.clients.has(client)
-      || preaggregator.entries.get(client) !== info;
+      || !filterGroups.get(selection)?.clients.has(client);
 
     if (info?.ready) {
       const pending = client.pending;
@@ -398,7 +397,7 @@ function updateSelection(
         if (superseded(pending)) return;
         const recovered = await preaggregator.recover(client, info, table, result.cause);
         if (superseded(pending)) return;
-        if (recovered) {
+        if (recovered && preaggregator.entries.get(client) === info) {
           const retry = mc.updateClient(client, info.query(active));
           const retried = await retry;
           if (!(retried instanceof QueryError)) return;

--- a/packages/mosaic/core/src/Coordinator.ts
+++ b/packages/mosaic/core/src/Coordinator.ts
@@ -387,8 +387,22 @@ function updateSelection(
     if (info?.result) {
       // generate and issue preaggregate update query
       const query = info.query(active);
-      const result = await mc.updateClient(client, query);
+      const table = info.table;
+      const pending = mc.updateClient(client, query);
+      const result = await pending;
       if (!(result instanceof QueryError)) return;
+      if (preaggregator.registry) {
+        if (client.pending !== pending || !filterGroups.get(selection)?.clients.has(client)) return;
+        const recovered = await preaggregator.recover(client, info, table, result.cause);
+        if (client.pending !== pending || !filterGroups.get(selection)?.clients.has(client)
+          || preaggregator.entries.get(client) !== info) return;
+        if (recovered) {
+          const retry = mc.updateClient(client, info.query(active));
+          if (!(await retry instanceof QueryError)) return;
+          if (client.pending !== retry || !filterGroups.get(selection)?.clients.has(client)
+            || preaggregator.entries.get(client) !== info) return;
+        }
+      }
       // if preaggregate update fails, fall through to standard query
       // this safeguards against potential preagg bugs
     }

--- a/packages/mosaic/core/src/connectors/rest.ts
+++ b/packages/mosaic/core/src/connectors/rest.ts
@@ -19,7 +19,7 @@ function isJSONContentType(contentType: string | null): boolean {
   return /^application\/json\s*(;|$)/i.test(contentType?.trim() ?? '');
 }
 
-function errorFromResponseBody(status: number, contentType: string | null, body: string): ConnectorError {
+function errorFromResponseBody(status: number, contentType: string | null, body: string): ConnectorError | null {
   if (isJSONContentType(contentType)) {
     try {
       const err = parseErrorResponse(JSON.parse(body), status);
@@ -28,7 +28,7 @@ function errorFromResponseBody(status: number, contentType: string | null, body:
       // fall through to the generic error
     }
   }
-  return new ConnectorError(body || `Request failed with HTTP status ${status}`, { status });
+  return null;
 }
 
 /**
@@ -71,8 +71,12 @@ export class RestConnector implements Connector {
 
     if (!res.ok) {
       const body = await res.text();
-      if (query.type === 'preagg') {
-        throw errorFromResponseBody(res.status, res.headers.get('Content-Type'), body);
+      if (query.type !== 'exec') {
+        const err = errorFromResponseBody(res.status, res.headers.get('Content-Type'), body);
+        if (err) throw err;
+        if (query.type === 'preagg') {
+          throw new ConnectorError(body || `Request failed with HTTP status ${res.status}`, { status: res.status });
+        }
       }
       throw new Error(`Query failed with HTTP status ${res.status}: ${body}`);
     }

--- a/packages/mosaic/core/src/preagg/PreAggregateRegistry.ts
+++ b/packages/mosaic/core/src/preagg/PreAggregateRegistry.ts
@@ -94,6 +94,12 @@ export class PreAggregateRegistry {
     return !!entry && !!table && !entry.build && entry.tableKey === referenceKey(table);
   }
 
+  invalidate(sql: string, table: TableRefNode): void {
+    // A late failure for an older build must not evict its replacement.
+    if (this.entries.get(sql)?.table === table) this.entries.delete(sql);
+    this.manager.invalidate();
+  }
+
   /**
    * Local refusals (`PreAggregateBusyError`, `PreAggregateSuppressedError`,
    * `PreAggregateModeError`) throw synchronously; server and transport

--- a/packages/mosaic/core/src/preagg/PreAggregator.ts
+++ b/packages/mosaic/core/src/preagg/PreAggregator.ts
@@ -3,7 +3,7 @@ import type { Coordinator } from '../Coordinator.js';
 import type { MosaicClient } from '../MosaicClient.js';
 import type { Selection } from '../Selection.js';
 import type { BinMethod, ClauseSource, IntervalMetadata, SelectionClause } from '../SelectionClause.js';
-import { isAbortError, PreAggregateModeError } from '../connectors/errors.js';
+import { ConnectorError, isAbortError, PreAggregateModeError } from '../connectors/errors.js';
 import { fnv_hash } from '../util/hash.js';
 import { resolvePositional } from '../util/positional.js';
 import { preaggColumns, PreAggColumnsResult } from './preagg-columns.js';
@@ -272,6 +272,18 @@ export class PreAggregator {
 
     entries.set(client, info);
     return info;
+  }
+
+  async recover(client: MosaicClient, info: PreAggregateInfo, table: TableRefNode | null, error: unknown): Promise<boolean> {
+    if (!this.registry || this.entries.get(client) !== info || !table
+      || !(error instanceof ConnectorError) || error.code !== 'table_not_found'
+      || error.catalog !== table.table[0] || error.schema !== table.table[1] || error.table !== table.table[2]) {
+      return false;
+    }
+
+    this.registry.invalidate(info.create.toString(), table);
+    this.materialize(info);
+    return info.result !== null && await info.ready!.then(() => true, () => false);
   }
 
   private isCurrent(info: PreAggregateInfo): boolean {

--- a/packages/mosaic/core/test/coordinator-preagg.test.ts
+++ b/packages/mosaic/core/test/coordinator-preagg.test.ts
@@ -101,6 +101,21 @@ describe('PreAggregator preagg mode', () => {
     expect(mc.preaggregator.registry!.lookup(connector.preaggRequests[0].sql)).toBeInstanceOf(TableRefNode);
   });
 
+  it('delivers a committed value when another source activates during a build', async () => {
+    const connector = new MockPreaggConnector();
+    const mc = preaggCoordinator(connector);
+    const { sel, results } = await aggregateClient(mc);
+
+    sel.update(clausePoint('dim', 'a', { source: {} }));
+    await flush();
+    sel.activate(clausePoint('dim', 'x', { source: {} }));
+    await flush();
+    while (connector.open.length) connector.complete();
+    await sel.pending('value');
+    expect(results).toHaveLength(2);
+    expect(connector.sql().at(-1)).toContain(`WHERE ("active0" IN ('a'))`);
+  });
+
   it('drops a suspended update superseded by requestQuery during the wait', async () => {
     const connector = new MockPreaggConnector();
     const mc = preaggCoordinator(connector);

--- a/packages/mosaic/core/test/preaggregate-recovery.test.ts
+++ b/packages/mosaic/core/test/preaggregate-recovery.test.ts
@@ -135,8 +135,8 @@ describe('PreAggregator recovery', () => {
     expect(connector.sql().at(-1)).toContain('FROM "testData"');
   });
 
-  it.each(['request', 'disconnect', 'reset', 'connector'])('does not resume a recovery superseded by %s', async action => {
-    const { connector, mc, client, sel, source, table } = await setup();
+  it.each(['request', 'disconnect', 'reset', 'connector', 'activate'])('preserves client ownership when %s interrupts recovery', async action => {
+    const { connector, mc, client, sel, source, table, results } = await setup();
     connector.handler = request => request.sql.includes(String(table)) ? Promise.reject(missingTable(table)) : [];
     sel.update(clausePoint('dim', 'b', { source }));
     await flush();
@@ -145,10 +145,16 @@ describe('PreAggregator recovery', () => {
     if (action === 'request') await mc.requestQuery(client, Query.from('other').select('*'));
     else if (action === 'disconnect') mc.disconnect(client);
     else if (action === 'reset') mc.preaggregator.reset();
-    else mc.databaseConnector(new MockPreaggConnector());
-    const issued = connector.requests.length;
-    connector.complete();
+    else if (action === 'connector') mc.databaseConnector(new MockPreaggConnector());
+    else sel.activate(clausePoint('dim', 'x', { source: {} }));
+    const current = mc.databaseConnector() as MockPreaggConnector;
+    while (connector.open.length) connector.complete();
     await sel.pending('value');
-    expect(connector.requests).toHaveLength(issued);
+    if (action === 'request' || action === 'disconnect') {
+      expect(results).toHaveLength(action === 'request' ? 3 : 2);
+    } else {
+      expect(results).toHaveLength(3);
+      expect(current.sql().at(-1)).toBe(`SELECT count(*) AS "measure" FROM "testData" WHERE ("dim" IN ('b'))`);
+    }
   });
 });

--- a/packages/mosaic/core/test/preaggregate-recovery.test.ts
+++ b/packages/mosaic/core/test/preaggregate-recovery.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import type { Table } from '@uwdata/flechette';
+import { createSchema, createTable, loadObjects, Query, TableRefNode } from '@uwdata/mosaic-sql';
+import { clausePoint } from '../src/index.js';
+import { NodeConnector } from '../src/connectors/NodeConnector.js';
+import { ConnectorError } from '../src/connectors/errors.js';
+import type { PreAggregateInfo } from '../src/preagg/PreAggregator.js';
+import { aggregateClient, flush, MockPreaggConnector, preaggCoordinator, preaggResponse } from './util/preagg-connector.js';
+
+function missingTable(table: TableRefNode) {
+  const [catalog, schema, name] = table.table;
+  return new ConnectorError('Materialized table is unavailable', {
+    code: 'table_not_found', catalog, schema, table: name
+  });
+}
+
+async function setup(clientCount = 1) {
+  const connector = new MockPreaggConnector();
+  const mc = preaggCoordinator(connector);
+  mc.manager.cache(true);
+  const first = await aggregateClient(mc);
+  const clients = [first];
+  for (let i = 1; i < clientCount; ++i) clients.push(await aggregateClient(mc, first.sel));
+  const source = {};
+  first.sel.update(clausePoint('dim', 'a', { source }));
+  await flush();
+  connector.complete();
+  await first.sel.pending('value');
+  const info = mc.preaggregator.entries.get(first.client) as PreAggregateInfo;
+  return { connector, mc, ...first, clients, source, info, table: info.table! };
+}
+
+describe('PreAggregator recovery', () => {
+  it.each(['', '_rebuilt'])('rebuilds a dropped DuckDB table and reads its rows (suffix %s)', async suffix => {
+    const db = await NodeConnector.make();
+    let missing: TableRefNode | null = null;
+    const connector = new MockPreaggConnector({
+      handler: async request => {
+        try {
+          return request.type === 'exec' ? await db.query(request)
+            : await db.query({ type: 'arrow', sql: request.sql });
+        } catch (err) {
+          if (missing && request.sql.includes(String(missing))) throw missingTable(missing);
+          throw err;
+        }
+      }
+    });
+    const mc = preaggCoordinator(connector);
+    mc.manager.cache(true);
+    await mc.exec(loadObjects('testData', [{ dim: 'a' }, { dim: 'b' }, { dim: 'b' }]));
+    await mc.exec(createSchema('mosaic_scope_test'));
+    const { client, sel, results } = await aggregateClient(mc);
+    const source = {};
+
+    async function build(suffix = '') {
+      const { sql } = connector.open[0].request;
+      const response = preaggResponse(sql, suffix);
+      const table = new TableRefNode([response.catalog, response.schema, response.table]);
+      await db.query({ type: 'exec', sql: String(createTable(table, sql, { temp: false })) });
+      connector.complete(suffix);
+      return table;
+    }
+
+    sel.update(clausePoint('dim', 'a', { source }));
+    await flush();
+    const table = await build();
+    await sel.pending('value');
+    expect((results.at(-1) as Table).toArray()).toEqual([{ measure: 1 }]);
+
+    await db.query({ type: 'exec', sql: `DROP TABLE ${table}` });
+    missing = table;
+    sel.update(clausePoint('dim', 'b', { source }));
+    await expect.poll(() => connector.preaggRequests.length).toBe(2);
+    const replacement = await build(suffix);
+    await sel.pending('value');
+
+    expect((mc.preaggregator.entries.get(client) as PreAggregateInfo).table!.table).toEqual(replacement.table);
+    expect(connector.sql().at(-1)).toContain(`FROM ${replacement}`);
+    expect((results.at(-1) as Table).toArray()).toEqual([{ measure: 2 }]);
+    expect(connector.preaggRequests).toHaveLength(2);
+  });
+
+  it.each([false, true])('shares recovery across clients, including late failures (%s)', async late => {
+    const { connector, mc, sel, clients, source, table } = await setup(2);
+    mc.manager.cache(false);
+    let misses = 0;
+    let reject!: (error: Error) => void;
+    connector.handler = request => {
+      if (request.sql.includes(String(table)) && ++misses <= 2) {
+        return late && misses === 2 ? new Promise((_, fail) => { reject = fail; })
+          : Promise.reject(missingTable(table));
+      }
+      return [];
+    };
+
+    sel.update(clausePoint('dim', 'b', { source }));
+    await flush();
+    expect(connector.preaggRequests).toHaveLength(2);
+    connector.complete();
+    await flush();
+    if (late) reject(missingTable(table));
+    await sel.pending('value');
+    expect(connector.preaggRequests).toHaveLength(2);
+    for (const { results } of clients) expect(results).toHaveLength(3);
+  });
+
+  it.each(['build', 'query'])('falls back without another rebuild when the recovery %s fails', async failure => {
+    const { connector, sel, source, table } = await setup();
+    connector.handler = request => request.sql.includes(String(table))
+      ? Promise.reject(missingTable(table)) : [];
+    sel.update(clausePoint('dim', 'b', { source }));
+    await flush();
+    if (failure === 'build') connector.fail(new Error('build failed'));
+    else connector.complete();
+    await sel.pending('value');
+    expect(connector.preaggRequests).toHaveLength(2);
+    expect(connector.sql().at(-1)).toBe(`SELECT count(*) AS "measure" FROM "testData" WHERE ("dim" IN ('b'))`);
+  });
+
+  it.each([
+    { code: 'forbidden' },
+    { code: 'unauthenticated' },
+    { catalog: 'other' },
+    { schema: 'other' },
+    { table: 'testData' },
+    { table: undefined },
+    { code: undefined }
+  ])('does not recover an unrelated or unclassified error: %j', async fields => {
+    const { connector, sel, source, table } = await setup();
+    const error = Object.assign(missingTable(table), fields);
+    connector.handler = request => request.sql.includes(String(table)) ? Promise.reject(error) : [];
+    sel.update(clausePoint('dim', 'b', { source }));
+    await sel.pending('value');
+    expect(connector.preaggRequests).toHaveLength(1);
+    expect(connector.sql().at(-1)).toContain('FROM "testData"');
+  });
+
+  it.each(['request', 'disconnect', 'reset', 'connector'])('does not resume a recovery superseded by %s', async action => {
+    const { connector, mc, client, sel, source, table } = await setup();
+    connector.handler = request => request.sql.includes(String(table)) ? Promise.reject(missingTable(table)) : [];
+    sel.update(clausePoint('dim', 'b', { source }));
+    await flush();
+    expect(connector.preaggRequests).toHaveLength(2);
+
+    if (action === 'request') await mc.requestQuery(client, Query.from('other').select('*'));
+    else if (action === 'disconnect') mc.disconnect(client);
+    else if (action === 'reset') mc.preaggregator.reset();
+    else mc.databaseConnector(new MockPreaggConnector());
+    const issued = connector.requests.length;
+    connector.complete();
+    await sel.pending('value');
+    expect(connector.requests).toHaveLength(issued);
+  });
+});

--- a/packages/mosaic/core/test/rest-connector.test.ts
+++ b/packages/mosaic/core/test/rest-connector.test.ts
@@ -40,7 +40,7 @@ describe('RestConnector', () => {
     expect(lastInit(fetch).body).toBe(JSON.stringify({ type: 'preagg', sql: 'SELECT 1' }));
   });
 
-  it('parses JSON error responses for preagg commands', async () => {
+  it.each(['preagg', 'arrow', undefined] as const)('parses JSON error responses for %s requests', async (type) => {
     const connector = new RestConnector({ uri: 'http://test/' });
     stubFetch(new Response(JSON.stringify({
       error: 'Materialized table is unavailable',
@@ -48,7 +48,11 @@ describe('RestConnector', () => {
       catalog: 'memory', schema: 'mosaic_scope_a7', table: 'preagg_c92f'
     }), { status: 404, headers: { 'Content-Type': 'application/json; charset=utf-8' } }));
 
-    const err = await connector.query({ type: 'preagg', sql: 'SELECT 1' }).catch(e => e) as ConnectorError;
+    const request = { sql: 'SELECT 1' };
+    const result = type === 'preagg'
+      ? connector.query({ ...request, type })
+      : connector.query({ ...request, type });
+    const err = await result.catch(e => e) as ConnectorError;
     expect(err).toBeInstanceOf(ConnectorError);
     expect(err).toMatchObject({
       message: 'Materialized table is unavailable',
@@ -69,7 +73,7 @@ describe('RestConnector', () => {
       .rejects.toMatchObject({ status: 400, code: undefined, message: '{"nope": true}' });
   });
 
-  it('keeps legacy errors for ordinary queries', async () => {
+  it('keeps legacy errors for exec requests', async () => {
     const connector = new RestConnector({ uri: 'http://test/' });
     stubFetch(new Response(JSON.stringify({ error: 'x', code: 'forbidden' }), {
       status: 403, headers: { 'Content-Type': 'application/json' }
@@ -77,6 +81,18 @@ describe('RestConnector', () => {
     const err = await connector.query({ type: 'exec', sql: 'SELECT 1' }).catch(e => e) as Error;
     expect(err).not.toBeInstanceOf(ConnectorError);
     expect(err.message).toBe('Query failed with HTTP status 403: {"error":"x","code":"forbidden"}');
+  });
+
+  it.each([
+    ['text/plain', 'missing table'],
+    ['application/json', 'not json'],
+    ['application/json', '{"code":"table_not_found"}']
+  ])('keeps generic SELECT failures for %s: %s', async (contentType, body) => {
+    const connector = new RestConnector({ uri: 'http://test/' });
+    stubFetch(new Response(body, { status: 404, headers: { 'Content-Type': contentType } }));
+    const err = await connector.query({ type: 'arrow', sql: 'SELECT 1' }).catch(e => e) as Error;
+    expect(err).not.toBeInstanceOf(ConnectorError);
+    expect(err.message).toBe(`Query failed with HTTP status 404: ${body}`);
   });
 });
 

--- a/packages/mosaic/core/test/rest-connector.test.ts
+++ b/packages/mosaic/core/test/rest-connector.test.ts
@@ -40,7 +40,11 @@ describe('RestConnector', () => {
     expect(lastInit(fetch).body).toBe(JSON.stringify({ type: 'preagg', sql: 'SELECT 1' }));
   });
 
-  it.each(['preagg', 'arrow', undefined] as const)('parses JSON error responses for %s requests', async (type) => {
+  it.each([
+    ['preagg', (connector: RestConnector) => connector.query({ type: 'preagg', sql: 'SELECT 1' })],
+    ['arrow', (connector: RestConnector) => connector.query({ type: 'arrow', sql: 'SELECT 1' })],
+    ['default', (connector: RestConnector) => connector.query({ sql: 'SELECT 1' })]
+  ] as const)('parses JSON error responses for %s requests', async (_, query) => {
     const connector = new RestConnector({ uri: 'http://test/' });
     stubFetch(new Response(JSON.stringify({
       error: 'Materialized table is unavailable',
@@ -48,11 +52,7 @@ describe('RestConnector', () => {
       catalog: 'memory', schema: 'mosaic_scope_a7', table: 'preagg_c92f'
     }), { status: 404, headers: { 'Content-Type': 'application/json; charset=utf-8' } }));
 
-    const request = { sql: 'SELECT 1' };
-    const result = type === 'preagg'
-      ? connector.query({ ...request, type })
-      : connector.query({ ...request, type });
-    const err = await result.catch(e => e) as ConnectorError;
+    const err = await query(connector).catch(e => e) as ConnectorError;
     expect(err).toBeInstanceOf(ConnectorError);
     expect(err).toMatchObject({
       message: 'Materialized table is unavailable',


### PR DESCRIPTION
Automatic preaggregates currently keep a cached table reference after server eviction or restart and fall back to base queries when it fails. In `preagg` mode, a matching structured `table_not_found` error now invalidates the binding and query cache, shares one rebuild from the retained SELECT, and retries once using the returned table name. Late failures cannot retire a newer binding. A new client query or disconnect supersedes the update; replaced preaggregate metadata skips the retry and lets the pending update fall back to a base query.

REST SELECT errors now preserve `ConnectorError` fields so the coordinator can match the missing table. Recovery is limited to live automatic preaggregates; unrelated tables and authorization errors do not trigger rebuilds. Failed rebuilds or retries use the existing base-query fallback. This relies on the server returning the structured error contract; it adds no server handler or public refresh/registration API.

The rebuild limit is per selection update. Failed builds use the existing one-minute cooldown, but a successful rebuild followed by another server eviction can trigger another rebuild on a later update; throttling that repeated-eviction case remains deferred.

Stacked on #1224, which now includes both REST and Socket client transport. This diff contains only recovery; NodeConnector support and database-backed materialization tests follow in #1233, and the Go HTTP/WebSocket implementation follows in #1234. Integration with #1208 must preserve the recovery guards and cache invalidation within its per-client scheduling model.

Validation: 151 core tests pass at this PR's head, along with the TypeScript build and core test typecheck. Recovery tests query real DuckDB tables through NodeConnector while controlling materialization responses through the existing test connector. They cover shared and late misses, changed table names, failed recovery, unrelated errors, and superseded work.
