### PR TITLE
test(duckdb-server): call get_arrow directly in query test

### DIFF
--- a/packages/server/duckdb-server/pkg/tests/test_query.py
+++ b/packages/server/duckdb-server/pkg/tests/test_query.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from functools import partial
-
 import duckdb
 import pyarrow as pa
 
@@ -14,4 +12,4 @@ def test_query_arrow() -> None:
     my_schema = pa.schema([pa.field("a", pa.int32())])
     table = pa.Table.from_pylist([{"a": 1}], schema=my_schema)
 
-    assert partial(get_arrow, con)("SELECT 1 AS a").read_all() == table
+    assert get_arrow(con, "SELECT 1 AS a").read_all() == table


### PR DESCRIPTION
Follows up on @dangotbanned's suggestion in https://github.com/uwdata/mosaic/pull/1172#issuecomment-5632755964, which was dropped during a rebase of that PR.

All arguments for `get_arrow` are available at the call site, so the `functools.partial` wrapper only obscured a plain call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYsJXNWN6k9MPuzHL73RBC
