### PR TITLE
docs(server): add server protocol spec and conformance gap list

### DIFF
--- a/.github/workflows/server-protocol.yml
+++ b/.github/workflows/server-protocol.yml
@@ -1,0 +1,44 @@
+name: Server Protocol
+
+# Validates the server protocol specification in packages/server/spec.
+# Conformance tests that run each server implementation against the spec
+# will be added here once the test suite exists.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/server/spec/**"
+      - ".github/workflows/server-protocol.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "packages/server/spec/**"
+      - ".github/workflows/server-protocol.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint spec
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22.x"
+          cache: "pnpm"
+          cache-dependency-path: |
+            pnpm-lock.yaml
+
+      - run: pnpm run spec:lint

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -274,7 +274,8 @@ export default defineConfig({
           collapsed: true,
           items: [
             { text: 'DuckDB API', link: '/api/duckdb/duckdb' },
-            { text: 'Data Server', link: '/api/duckdb/data-server' }
+            { text: 'Data Server', link: '/api/duckdb/data-server' },
+            { text: 'Server Protocol', link: '/api/duckdb/server-protocol' }
           ]
         },
       ]

--- a/docs/.vitepress/theme/ServerSpec.vue
+++ b/docs/.vitepress/theme/ServerSpec.vue
@@ -26,7 +26,9 @@ const sources = [
 const { isDark } = useData();
 const container = ref(null);
 const failed = ref(false);
+let scalar = null;
 let app = null;
+let mounted = false;
 
 function loadScalar() {
   if (window.Scalar) return Promise.resolve(window.Scalar);
@@ -40,9 +42,10 @@ function loadScalar() {
 }
 
 // forceDarkModeState is read once at creation, so recreate on theme change.
-function render(Scalar) {
+function render() {
+  if (!mounted || !scalar || !container.value) return;
   app?.destroy();
-  app = Scalar.createApiReference(container.value, {
+  app = scalar.createApiReference(container.value, {
     sources,
     hideClientButton: true,
     hideTestRequestButton: true,
@@ -53,17 +56,23 @@ function render(Scalar) {
   });
 }
 
+watch(isDark, render);
+
 onMounted(async () => {
+  mounted = true;
   try {
-    const Scalar = await loadScalar();
-    render(Scalar);
-    watch(isDark, () => render(Scalar));
+    scalar = await loadScalar();
+    render();
   } catch {
     failed.value = true;
   }
 });
 
-onBeforeUnmount(() => app?.destroy());
+onBeforeUnmount(() => {
+  mounted = false;
+  app?.destroy();
+  app = null;
+});
 </script>
 
 <template>

--- a/docs/.vitepress/theme/ServerSpec.vue
+++ b/docs/.vitepress/theme/ServerSpec.vue
@@ -1,0 +1,95 @@
+<script setup>
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useData } from 'vitepress';
+import { parse } from 'yaml';
+import openapiText from '../../../packages/server/spec/openapi.yaml?raw';
+import asyncapiText from '../../../packages/server/spec/asyncapi.yaml?raw';
+import schemasText from '../../../packages/server/spec/schemas.yaml?raw';
+
+const SCALAR_URL = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.68.0';
+
+// Scalar does not dereference cross-file $refs, so inline schemas.yaml into
+// each document's components.schemas. Mirrors packages/server/spec/index.html.
+const shared = parse(schemasText);
+function inline(doc) {
+  const text = JSON.stringify({ ...doc, components: { ...doc.components, schemas: shared.$defs } })
+    .replaceAll('"./schemas.yaml#/$defs/', '"#/components/schemas/')
+    .replaceAll('"#/$defs/', '"#/components/schemas/');
+  return JSON.parse(text);
+}
+
+const sources = [
+  { title: 'HTTP', slug: 'http', content: inline(parse(openapiText)), default: true },
+  { title: 'WebSocket', slug: 'websocket', content: inline(parse(asyncapiText)) }
+];
+
+const { isDark } = useData();
+const container = ref(null);
+const failed = ref(false);
+let app = null;
+
+function loadScalar() {
+  if (window.Scalar) return Promise.resolve(window.Scalar);
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = SCALAR_URL;
+    script.onload = () => resolve(window.Scalar);
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+}
+
+// forceDarkModeState is read once at creation, so recreate on theme change.
+function render(Scalar) {
+  app?.destroy();
+  app = Scalar.createApiReference(container.value, {
+    sources,
+    hideClientButton: true,
+    hideTestRequestButton: true,
+    hideDarkModeToggle: true,
+    showToolbar: 'never',
+    showDeveloperTools: 'never',
+    forceDarkModeState: isDark.value ? 'dark' : 'light'
+  });
+}
+
+onMounted(async () => {
+  try {
+    const Scalar = await loadScalar();
+    render(Scalar);
+    watch(isDark, () => render(Scalar));
+  } catch {
+    failed.value = true;
+  }
+});
+
+onBeforeUnmount(() => app?.destroy());
+</script>
+
+<template>
+  <div class="server-spec">
+    <div ref="container" />
+    <p v-if="failed" class="server-spec-fallback">
+      The interactive reference could not be loaded. The specification sources are in
+      <a href="https://github.com/uwdata/mosaic/tree/main/packages/server/spec">packages/server/spec</a>.
+    </p>
+  </div>
+</template>
+
+<style>
+.server-spec {
+  min-height: calc(100vh - var(--vp-nav-height));
+}
+
+.server-spec-fallback {
+  padding: 2rem;
+  color: var(--vp-c-text-2);
+}
+
+.server-spec .scalar-app {
+  --scalar-custom-header-height: var(--vp-nav-height);
+  --scalar-background-1: var(--vp-c-bg);
+  --scalar-color-accent: var(--vp-c-brand-1);
+  font-family: var(--vp-font-family-base);
+}
+</style>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -3,6 +3,7 @@ import Example from './Example.vue';
 import LangToggle from './LangToggle.vue';
 import LangError from './LangError.vue';
 import Layout from "./Layout.vue";
+import ServerSpec from './ServerSpec.vue';
 import './custom.css';
 
 const LANG_PARAM = 'lang';
@@ -24,6 +25,7 @@ export default {
     ctx.app.component('Example', Example);
     ctx.app.component('LangToggle', LangToggle);
     ctx.app.component('LangError', LangError);
+    ctx.app.component('ServerSpec', ServerSpec);
 
     if (typeof window === 'undefined') return;
 

--- a/docs/api/duckdb/data-server.md
+++ b/docs/api/duckdb/data-server.md
@@ -27,6 +27,8 @@ Once launched, the data server will accept HTTP POST requests containing JSON co
 
 A request without a _type_ is rejected with HTTP status 400 and the message `missing required 'type' parameter`; the other Mosaic DuckDB servers respond the same way.
 
+The full request, response, and error contract shared by all Mosaic server implementations is documented in the [Server Protocol](./server-protocol) reference.
+
 ### Examples
 
 Launch a data server in Node.js:

--- a/docs/api/duckdb/server-protocol.md
+++ b/docs/api/duckdb/server-protocol.md
@@ -1,0 +1,7 @@
+---
+title: Server Protocol
+layout: page
+sidebar: false
+---
+
+<ServerSpec />

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -46,3 +46,4 @@ Mosaic API Reference.
 
 - [DuckDB API](/api/duckdb/duckdb)
 - [Data Server](/api/duckdb/data-server)
+- [Server Protocol](/api/duckdb/server-protocol)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "server": "cd packages/server/duckdb-server && pnpm run dev",
     "server:rust": "cd packages/server/duckdb-server-rust && cargo run",
     "server:node": "nodemon packages/server/duckdb/bin/run-server.js",
+    "spec:lint": "npx --yes @redocly/cli@2.52.1 lint --config packages/server/spec/redocly.yaml && npx --yes @asyncapi/cli@6.0.2 validate packages/server/spec/asyncapi.yaml --fail-severity=warn",
+    "spec:preview": "vite packages/server/spec --open",
     "dev": "vite"
   },
   "devDependencies": {

--- a/packages/server/spec/CONFORMANCE.md
+++ b/packages/server/spec/CONFORMANCE.md
@@ -19,8 +19,10 @@ Where the servers disagreed, the spec picks one behaviour. Each is revisable.
 | D1 | `type` default | `arrow` when omitted (matches `ArrowQueryRequest.type?` and the Node server). | Python, Rust, Go require it. |
 | D2 | GET parameters | Flat `?type=&sql=`. | Python reads `?query=<json>`; Rust README documents `?query=` but its code reads flat params; Node GET always 400s. |
 | D3 | GET command set | `arrow` only; `exec`/`preagg` over GET are `400 bad_request`. | Rust and Go run `exec` over GET. |
+| D3a | GET read-only SQL | GET `sql` must satisfy `ReadOnlySql` (SELECT/VALUES/set-op/CTE root), verified before execution even with no policy active. Restricting `type` alone is insufficient: `DELETE FROM t RETURNING *` is one statement that returns rows. `POST` `arrow` is deliberately not restricted; revisit if `exec` is ever removed. | No server checks statement kind over GET. Go can reuse its `json_serialize_sql` walker; the others need a parser step. |
 | D4 | Error body | JSON `Error` envelope on every transport and every status, including 405/412/413/415. | Go emits `{code,error}` over WebSocket only; HTTP is plain text everywhere; Rust/Node send empty bodies for some errors. |
-| D5 | Codes for transport-level rejects | 405, 412, 413, 415 carry `code: bad_request`. | Could add dedicated codes; #1218 defines none. |
+| D5 | Codes for transport-level rejects | 405, 412, 413, 415 carry `code: bad_request`; these statuses are listed as exceptions in the `ErrorCode` table and take precedence over the canonical 400. | Could add dedicated codes; #1218 defines none. |
+| D5a | Code vocabulary | Closed: `ErrorCode` is an exhaustive enum and adding a code requires a schema change. Deployment authorizers map onto the standard codes (`unauthenticated`/`forbidden`/`bad_request`/`internal_error`). | An open `x_`-prefixed extension namespace was considered; rejected because the client cannot act on unknown codes and a closed set keeps schema validation meaningful for the conformance runner. |
 | D6 | Unknown vs. disabled command | Unknown `type` string is `bad_request`; a known command disabled by deployment/policy (`exec` under validation, `preagg` off) is `unsupported_command`. | Go returns `bad_request` for `ErrExecWithValidation`. |
 | D7 | DuckDB execution errors | `internal_error` (500) unless classified: `bad_request` for parse errors and unsupported statement kinds, `forbidden` for policy, `table_not_found` for managed tables. Parse errors MUST be classified even when no policy is active. | Go classifies parse errors only when `json_serialize_sql` validation runs; otherwise a syntax error is a 500. Others 500 everything. Whether a runtime `Catalog Error` on a user table should be 400 is open. |
 | D8 | Arrow encoding | IPC **stream** format, `Content-Type: application/vnd.apache.arrow.stream`, never an empty body. | Rust sends IPC *file* format under the stream media type; Python labels the stream `application/octet-stream`; Node sends 0 bytes for 0 rows. |
@@ -39,7 +41,7 @@ Where the servers disagreed, the spec picks one behaviour. Each is revisable.
 - No JSON error envelope over HTTP (D4).
 - No `preagg` command; must return `400 unsupported_command`, not an unknown-type error.
 - No `deadline_exceeded`, `resource_exhausted`, or `table_not_found` paths; only Go has `unauthenticated`.
-- `exec` runs over GET where GET works at all (D3).
+- `exec` runs over GET where GET works at all (D3), and no server checks that GET SQL is read-only (D3a).
 - `Access-Control-Request-Method: *` is emitted as a *response* header by Python and Node (it is a request header). No server sets `Access-Control-Expose-Headers`, so browsers cannot read `ETag` cross-origin.
 - No server sends `Allow` on 405.
 
@@ -56,6 +58,7 @@ Already conforming: WebSocket error frames carry `code` (`bad_request`, `unauthe
 | Parse errors without policy | 500 `internal_error` with raw DuckDB text | 400 `bad_request` (D7) | Run `json_serialize_sql` (or statement extraction) unconditionally, or map DuckDB parser errors. |
 | `type` missing | 400 `missing required 'type' parameter` (`server.go:345-362`) | default `arrow` (D1) | Default in `Validate`. |
 | Exec over GET | runs (`server.go:264-276`) | 400 `bad_request` (D3) | Reject in GET branch. |
+| GET read-only SQL | not checked; `json_serialize_sql` runs only under policy (`query.go:185-209`) | reject non-SELECT roots (D3a) | Run the serializer for GET unconditionally and check the root node class. |
 | Multi-statement `arrow` | runs all, returns last (duckdb-go `prepareStmts`) | reject (D16) | Count statements before execution. |
 | 405 | plain text, no `Allow` (`server.go:278-281`) | envelope + `Allow` | Set header. |
 | 413 | plain `Request Entity Too Large` | envelope `bad_request` | Mapper. Also expose `WithMaxMessageBytes` on the CLI; the binary is unbounded. |
@@ -87,6 +90,7 @@ Source: `packages/server/duckdb-server-rust/src/{app.rs,query.rs,interfaces.rs,d
 | Malformed JSON | 400 plain `Failed to parse the request body as JSON…` | 400 envelope | Custom `Json` rejection handler. |
 | DuckDB error | 500 plain `Something went wrong: …` (`interfaces.rs:62-64`) | 500 envelope `internal_error`; parse errors 400 (D7) | Map `duckdb::Error` variants. |
 | Exec over GET | runs | 400 `bad_request` (D3) | Reject in `handle_get`. |
+| GET read-only SQL | not checked | reject non-SELECT roots (D3a) | Parse via `json_serialize_sql` or the DuckDB C API statement type before execution. |
 | Multi-statement `arrow` | `prepare` fails → 500 | 400 `bad_request` (D16) | Classify. |
 | 405 | empty, `Allow: GET,HEAD,POST` | envelope + `Allow: GET, POST, OPTIONS` | Custom fallback. HEAD runs the query today; drop or document. |
 | README GET example | `?query={…}` (`Readme.md:47`) does not work | flat params | Fix README. |
@@ -113,6 +117,7 @@ Source: `packages/server/duckdb-server/pkg/{server.py,query.py,__main__.py}`.
 | DuckDB error | plain `str(e)` | 500 envelope; parse errors 400 (D7) | Map `duckdb.ParserException`/`BinderException`. |
 | Arrow Content-Type | `application/octet-stream` (`server.py:67`) | `application/vnd.apache.arrow.stream` (D8) | Change header; body is already a stream. |
 | Exec over GET | runs | 400 `bad_request` (D3) | Reject. |
+| GET read-only SQL | not checked | reject non-SELECT roots (D3a) | `duckdb.extract_statements()` exposes the statement type. |
 | Non-GET/POST/OPTIONS | no response; hangs until uWS timeout (`server.py:146-157`) | 405 + `Allow` + envelope | Add fallthrough. |
 | WS missing `sql`/`type` | **no frame at all** (exception in sync handler) | `Error` frame (D11) | Wrap `handle_query` in try/except. Breaks pipelining clients today. |
 | WS errors | `{"error"}` no code | envelope with `code` | Add. |
@@ -129,6 +134,7 @@ Source: `packages/server/duckdb/src/{data-server.js,DuckDB.js}`, `bin/run-server
 | Area | Current | Spec | Fix |
 |------|---------|------|-----|
 | GET | always 400: `JSON.parse` of the parsed query object (`data-server.js:39-40,76`) | flat params (D2) | Build the command from `url.query`. |
+| GET read-only SQL | n/a (GET broken) | reject non-SELECT roots (D3a) | Needed once GET works; `json_serialize_sql` via the same connection. |
 | `sql` missing | not validated → DuckDB parser error → 500 | 400 `bad_request` | Validate. |
 | Non-string / `null` `type` | `Unrecognized command: null` 400 | fine, but body empty | Envelope. |
 | HTTP errors | **empty body**, no Content-Type (`data-server.js:119-123`) | envelope (D4) | Rewrite `error()`. |
@@ -159,6 +165,6 @@ Declarative cases in `packages/server/spec/cases/*.yaml`, one TypeScript runner
 5. Skips cases whose `requires` capability the adapter lacks, but fails if the
    server returns anything other than `unsupported_command` for them.
 
-Case groups: request decoding (D1–D3, D9, D10), Arrow encoding (D8, D16),
+Case groups: request decoding (D1–D3a, D9, D10), Arrow encoding (D8, D16),
 error envelope per code (D4–D7), WebSocket framing/order/open-after-error
 (D11, D12), size floors (D13), caching headers (D14), CORS preflight.

--- a/packages/server/spec/CONFORMANCE.md
+++ b/packages/server/spec/CONFORMANCE.md
@@ -7,8 +7,8 @@ at `b623fb60` and will drift.
 
 Client baseline: `packages/mosaic/core/src/connectors` on
 [#1224](https://github.com/uwdata/mosaic/pull/1224), which builds on main
-after #1172 (drop `json`), #1213 (drop `persist` and result caches), and
-#1209 (socket pipelining).
+after #1172 (drop `json`), #1213 (drop `persist` and result caches),
+#1209 (socket pipelining), and #1228 (`type` required).
 
 ## Decisions made while drafting
 
@@ -16,7 +16,7 @@ Where the servers disagreed, the spec picks one behaviour. Each is revisable.
 
 | # | Topic | Decision | Alternatives observed |
 |---|-------|----------|-----------------------|
-| D1 | `type` default | `arrow` when omitted (matches `ArrowQueryRequest.type?` and the Node server). | Python, Rust, Go require it. |
+| D1 | `type` required | Required; missing → `400 bad_request` with the canonical message `missing required 'type' parameter`, as settled by #1228 across the client types and all four servers. | An earlier draft defaulted to `arrow` when Node did; #1228 removed that default. |
 | D2 | GET parameters | Flat `?type=&sql=`. | Python reads `?query=<json>`; Rust README documents `?query=` but its code reads flat params; Node GET always 400s. |
 | D3 | GET command set | `arrow` only; `exec`/`preagg` over GET are `400 bad_request`. | Rust and Go run `exec` over GET. |
 | D3a | GET read-only SQL | GET `sql` must satisfy `ReadOnlySql` (SELECT/VALUES/set-op/CTE root), verified before execution even with no policy active. Restricting `type` alone is insufficient: `DELETE FROM t RETURNING *` is one statement that returns rows. `POST` `arrow` is deliberately not restricted; revisit if `exec` is ever removed. | No server checks statement kind over GET. Go can reuse its `json_serialize_sql` walker; the others need a parser step. |
@@ -56,7 +56,6 @@ Already conforming: WebSocket error frames carry `code` (`bad_request`, `unauthe
 | HTTP errors | `http.Error` plain text (`server.go:127-130`); `classifyError` already yields a code | JSON envelope (D4) | Reuse `classifyError`; write `{error,code}` with `application/json`. |
 | `ErrExecWithValidation` | `bad_request` (`errors.go`) | `unsupported_command` (D6) | Remap. |
 | Parse errors without policy | 500 `internal_error` with raw DuckDB text | 400 `bad_request` (D7) | Run `json_serialize_sql` (or statement extraction) unconditionally, or map DuckDB parser errors. |
-| `type` missing | 400 `missing required 'type' parameter` (`server.go:345-362`) | default `arrow` (D1) | Default in `Validate`. |
 | Exec over GET | runs (`server.go:264-276`) | 400 `bad_request` (D3) | Reject in GET branch. |
 | GET read-only SQL | not checked; `json_serialize_sql` runs only under policy (`query.go:185-209`) | reject non-SELECT roots (D3a) | Run the serializer for GET unconditionally and check the root node class. |
 | Multi-statement `arrow` | runs all, returns last (duckdb-go `prepareStmts`) | reject (D16) | Count statements before execution. |
@@ -84,8 +83,7 @@ Source: `packages/server/duckdb-server-rust/src/{app.rs,query.rs,interfaces.rs,d
 | Area | Current | Spec | Fix |
 |------|---------|------|-----|
 | Arrow body | IPC **file** via `FileWriter` (`db.rs:44`) under stream media type (`interfaces.rs:40`) | IPC stream (D8) | Use `StreamWriter`; update `test.rs:84`. |
-| `type` missing | 400 empty (`query.rs:25`) | default `arrow` (D1) | Default in `QueryParams`. |
-| `sql` missing | 400 empty | 400 envelope | Add body. |
+| `type`/`sql` missing | 400 plain `missing required '…' parameter` (`query.rs`, since #1228) | 400 envelope | Wrap in envelope. |
 | Unknown `type` | GET 400 / POST 422 plain serde text (`interfaces.rs:14-19`) | 400 envelope `bad_request` | Custom rejection or `String` + manual match. |
 | Malformed JSON | 400 plain `Failed to parse the request body as JSON…` | 400 envelope | Custom `Json` rejection handler. |
 | DuckDB error | 500 plain `Something went wrong: …` (`interfaces.rs:62-64`) | 500 envelope `internal_error`; parse errors 400 (D7) | Map `duckdb::Error` variants. |
@@ -95,7 +93,7 @@ Source: `packages/server/duckdb-server-rust/src/{app.rs,query.rs,interfaces.rs,d
 | 405 | empty, `Allow: GET,HEAD,POST` | envelope + `Allow: GET, POST, OPTIONS` | Custom fallback. HEAD runs the query today; drop or document. |
 | README GET example | `?query={…}` (`Readme.md:47`) does not work | flat params | Fix README. |
 | `name` field | parsed, logged, unused (`interfaces.rs:21-27`) | dropped (D15) | Remove. |
-| WS errors | `{"error"}` no code (`websocket.rs:29-35`); message differs from HTTP (`Something went wrong:` prefix) | envelope with `code`, same message both transports | Shared mapper. |
+| WS errors | `{"error"}` no code (`websocket.rs`); DuckDB message differs from HTTP (`Something went wrong:` prefix) | envelope with `code`, same message both transports | Shared mapper. |
 | WS binary frames | ignored, **no reply** (`websocket.rs:59`) | SHOULD accept; MUST reply (D11) | Treat as text or answer with `bad_request`. |
 | WS upgrade edge | malformed upgrade falls through to GET handler (`app.rs:22-34`) | 400 envelope | Return the upgrade rejection. |
 | Cache headers | none | optional (D14) | Straightforward; results are buffered. |
@@ -110,9 +108,9 @@ Source: `packages/server/duckdb-server/pkg/{server.py,query.py,__main__.py}`.
 |------|---------|------|-----|
 | HTTP error status | CORS `write_header` runs first, so uWS emits `200` and the later `write_status(500)` is ignored (`server.py:71,111,136-140`) — errors are very likely **200** | mapped status | Call `write_status` before any `write_header`. Verify empirically. |
 | GET params | `?query=<json>` (`server.py:149-151`) | flat `type`/`sql` (D2) | Read flat params. |
-| `type` missing | `KeyError` escapes → `Error 'type'` (`server.py:85`) | default `arrow` (D1) | `query.get("type", "arrow")`. |
-| `sql` missing | `Error 'sql'` via `on_error` | 400 envelope | Validate before dispatch. |
-| Unknown `type` | `Unknown command X` plain (`server.py:94-96`) | 400 envelope `bad_request` | Classify. |
+| `type` missing | `handler.error(…, 400)` with the canonical message (since #1228), but see the status caveat above | 400 envelope | Wrap in envelope; fix status ordering. |
+| `sql` missing | `KeyError` escapes → `Error 'sql'` via `on_error` | 400 envelope | Validate before dispatch. |
+| Unknown `type` | `Unknown command X` plain, 400 nominal (`server.py`) | 400 envelope `bad_request` | Wrap in envelope. |
 | Malformed/falsy POST body | `NotImplementedError` → body `Error ` (`server.py:157`) | 400 envelope | Validate `get_json()` result. |
 | DuckDB error | plain `str(e)` | 500 envelope; parse errors 400 (D7) | Map `duckdb.ParserException`/`BinderException`. |
 | Arrow Content-Type | `application/octet-stream` (`server.py:67`) | `application/vnd.apache.arrow.stream` (D8) | Change header; body is already a stream. |
@@ -135,9 +133,9 @@ Source: `packages/server/duckdb/src/{data-server.js,DuckDB.js}`, `bin/run-server
 |------|---------|------|-----|
 | GET | always 400: `JSON.parse` of the parsed query object (`data-server.js:39-40,76`) | flat params (D2) | Build the command from `url.query`. |
 | GET read-only SQL | n/a (GET broken) | reject non-SELECT roots (D3a) | Needed once GET works; `json_serialize_sql` via the same connection. |
+| `type` missing | 400 plain `missing required 'type' parameter` (since #1228) | 400 envelope | Wrap in envelope. |
 | `sql` missing | not validated → DuckDB parser error → 500 | 400 `bad_request` | Validate. |
-| Non-string / `null` `type` | `Unrecognized command: null` 400 | fine, but body empty | Envelope. |
-| HTTP errors | **empty body**, no Content-Type (`data-server.js:119-123`) | envelope (D4) | Rewrite `error()`. |
+| HTTP errors | plain `String(err)` body, no Content-Type (`data-server.js`, since #1228) | envelope (D4) | Rewrite `error()`. |
 | Unsupported method | 400 (`data-server.js:49-50`) | 405 + `Allow` | Change status. |
 | Empty Arrow result | 0 bytes (`DuckDB.js:91`; `duckdb.test.js:26-30` asserts it) | schema + EOS (D8) | Emit a schema-only stream. |
 | Arrow trailing `;` / multi-statement | wrapped as `to_arrow_ipc((sql))` (`DuckDB.js:88-90`) → parser error 500 | trailing `;` allowed; multi → 400 (D16) | Strip trailing `;`; classify. |

--- a/packages/server/spec/CONFORMANCE.md
+++ b/packages/server/spec/CONFORMANCE.md
@@ -1,0 +1,164 @@
+# Server conformance
+
+Gap analysis of each server implementation against `openapi.yaml`,
+`asyncapi.yaml`, and `schemas.yaml`. The spec describes the *desired* state;
+none of the servers fully conform yet. Line references are to `origin/main`
+at `b623fb60` and will drift.
+
+Client baseline: `packages/mosaic/core/src/connectors` on
+[#1224](https://github.com/uwdata/mosaic/pull/1224), which builds on main
+after #1172 (drop `json`), #1213 (drop `persist` and result caches), and
+#1209 (socket pipelining).
+
+## Decisions made while drafting
+
+Where the servers disagreed, the spec picks one behaviour. Each is revisable.
+
+| # | Topic | Decision | Alternatives observed |
+|---|-------|----------|-----------------------|
+| D1 | `type` default | `arrow` when omitted (matches `ArrowQueryRequest.type?` and the Node server). | Python, Rust, Go require it. |
+| D2 | GET parameters | Flat `?type=&sql=`. | Python reads `?query=<json>`; Rust README documents `?query=` but its code reads flat params; Node GET always 400s. |
+| D3 | GET command set | `arrow` only; `exec`/`preagg` over GET are `400 bad_request`. | Rust and Go run `exec` over GET. |
+| D4 | Error body | JSON `Error` envelope on every transport and every status, including 405/412/413/415. | Go emits `{code,error}` over WebSocket only; HTTP is plain text everywhere; Rust/Node send empty bodies for some errors. |
+| D5 | Codes for transport-level rejects | 405, 412, 413, 415 carry `code: bad_request`. | Could add dedicated codes; #1218 defines none. |
+| D6 | Unknown vs. disabled command | Unknown `type` string is `bad_request`; a known command disabled by deployment/policy (`exec` under validation, `preagg` off) is `unsupported_command`. | Go returns `bad_request` for `ErrExecWithValidation`. |
+| D7 | DuckDB execution errors | `internal_error` (500) unless classified: `bad_request` for parse errors and unsupported statement kinds, `forbidden` for policy, `table_not_found` for managed tables. Parse errors MUST be classified even when no policy is active. | Go classifies parse errors only when `json_serialize_sql` validation runs; otherwise a syntax error is a 500. Others 500 everything. Whether a runtime `Catalog Error` on a user table should be 400 is open. |
+| D8 | Arrow encoding | IPC **stream** format, `Content-Type: application/vnd.apache.arrow.stream`, never an empty body. | Rust sends IPC *file* format under the stream media type; Python labels the stream `application/octet-stream`; Node sends 0 bytes for 0 rows. |
+| D9 | Application-owned fields | Servers MUST accept unknown properties and pass them to authorization; they MUST NOT override `type`/`sql`. Matches the Go `WithAuthorizer` design (#1215). | Go's `encoding/json` matches keys case-insensitively with last-wins, so `TYPE` can shadow `type`; flagged below. |
+| D10 | Request `Content-Type` | Client sends `application/json`; servers MAY 415 anything else. | Rust 415s; others ignore the header. |
+| D11 | WebSocket order | Exactly one response per command, in request order, including commands that fail before execution. Required by #1209 pipelining. | All servers serialize per connection today; Python sends no reply for a missing `sql`/`type`, which desynchronizes a pipelining client. |
+| D12 | WebSocket malformed JSON | `Error` text frame, connection stays open. | Go closes with 1007. |
+| D13 | Size floor | SHOULD accept ≥ 1 MiB. | Python WS 16 KiB; Go WS 32 KiB default; Rust POST 2 MiB. |
+| D14 | Caching | Adopt the Go `--cache-control`/`--vary` design (#1216): GET `arrow` only; strong `ETag` over the body; weak `If-None-Match` → 304; strong `If-Match` → 412; `no-store` on everything else once enabled; identity headers in `Vary`. No server-side result cache. | Only Go implements any of it. |
+| D15 | `name` field | Dropped from the protocol. | Rust and Go still parse it and never use it. |
+| D16 | Multi-statement | `exec` MAY contain several statements; `arrow`/`preagg` exactly one, trailing `;` allowed. | Go and Python run all statements for `arrow` and return the last; Rust errors; Node rejects a trailing `;`. |
+| D17 | `preagg_drop`, `refresh` | Out of scope until a client sends them. | Defined in #1218. |
+
+## Common gaps (all four servers)
+
+- No JSON error envelope over HTTP (D4).
+- No `preagg` command; must return `400 unsupported_command`, not an unknown-type error.
+- No `deadline_exceeded`, `resource_exhausted`, or `table_not_found` paths; only Go has `unauthenticated`.
+- `exec` runs over GET where GET works at all (D3).
+- `Access-Control-Request-Method: *` is emitted as a *response* header by Python and Node (it is a request header). No server sets `Access-Control-Expose-Headers`, so browsers cannot read `ETag` cross-origin.
+- No server sends `Allow` on 405.
+
+## Go `duckdb-server-go`
+
+Source: `packages/server/duckdb-server-go/{main.go,flags.go,pkg/server/*.go,pkg/query/*.go}`. Closest to the target; intended first `preagg` implementation (#1234).
+
+Already conforming: WebSocket error frames carry `code` (`bad_request`, `unauthenticated`, `forbidden`, `internal_error`; `pkg/server/errors.go:31-69`); Arrow IPC stream with EOS marker; GET caching with strong `ETag`, weak `If-None-Match` → 304, strong `If-Match` → 412, `no-store` elsewhere (`pkg/server/cache.go`, `server.go:295-307`); application payload passthrough via `WithAuthorizer` (`pkg/server/authorization.go:75-107`); `Vary` auto-includes schema-match headers.
+
+| Area | Current | Spec | Fix |
+|------|---------|------|-----|
+| HTTP errors | `http.Error` plain text (`server.go:127-130`); `classifyError` already yields a code | JSON envelope (D4) | Reuse `classifyError`; write `{error,code}` with `application/json`. |
+| `ErrExecWithValidation` | `bad_request` (`errors.go`) | `unsupported_command` (D6) | Remap. |
+| Parse errors without policy | 500 `internal_error` with raw DuckDB text | 400 `bad_request` (D7) | Run `json_serialize_sql` (or statement extraction) unconditionally, or map DuckDB parser errors. |
+| `type` missing | 400 `missing required 'type' parameter` (`server.go:345-362`) | default `arrow` (D1) | Default in `Validate`. |
+| Exec over GET | runs (`server.go:264-276`) | 400 `bad_request` (D3) | Reject in GET branch. |
+| Multi-statement `arrow` | runs all, returns last (duckdb-go `prepareStmts`) | reject (D16) | Count statements before execution. |
+| 405 | plain text, no `Allow` (`server.go:278-281`) | envelope + `Allow` | Set header. |
+| 413 | plain `Request Entity Too Large` | envelope `bad_request` | Mapper. Also expose `WithMaxMessageBytes` on the CLI; the binary is unbounded. |
+| 401 schema-match | plain `no allowed schemas found in request headers` (`server.go:228-232`) | envelope `unauthenticated` | Mapper. |
+| JSON key matching | case-insensitive, last-wins (`encoding/json`); `TYPE` overrides `type` (`metadata_test.go:301`) | protocol fields decoded exactly (D9) | Decode protocol fields with a strict decoder or reject duplicate/case-variant keys. |
+| WS malformed JSON | close 1007 via `wsjson.Read` (`server.go:193-198`) | `Error` frame, open (D12) | Read raw, unmarshal manually. |
+| WS read limit | 32 KiB library default unless `WithMaxMessageBytes` | ≥ 1 MiB (D13) | Set a default; add CLI flag. |
+| WS error frame | trailing `\n` from `json.Encoder` (`server.go:203-207`) | acceptable, but match HTTP body byte-for-byte | Use `json.Marshal`. |
+| WS close | always `Close(1011)` on loop exit (`server.go:168-173`) | 1000 on clean client close | Distinguish `CloseError` from other read errors. |
+| WS pings | answered only inside `conn.Read` | SHOULD answer during execution | Reader goroutine or `conn.Ping` ticker. |
+| WS context | `r.Context()` after hijack; cancellation on disconnect undetermined | needed for deadlines | Derive from connection lifecycle. |
+| Upgrade detection | whole-value `EqualFold` on `Connection` (`server.go:102-103`) | token-based | Scan `Connection` tokens. |
+| `Cache-Control: private` | operator value used verbatim even with an authorizer | identity → `Vary` or `private` (D14) | Document; optionally add identity headers to `Vary` from `AuthorizeRequest`. |
+| `Access-Control-Expose-Headers` | not set (`security.go`) | expose `ETag` | Add to `WithCORS` defaults. |
+| Remote URI rejection (#1152) | option only, no CLI flag (`main.go`) | deployment choice | Add flag if it should be reachable from the binary. |
+| `name` field | parsed, unused (`server.go:19-24`) | dropped (D15) | Remove. |
+| Timeouts | none | `deadline_exceeded` | Per-command deadline; also needed by #1234. |
+
+## Rust `duckdb-server-rust`
+
+Source: `packages/server/duckdb-server-rust/src/{app.rs,query.rs,interfaces.rs,db.rs,websocket.rs,main.rs}`.
+
+| Area | Current | Spec | Fix |
+|------|---------|------|-----|
+| Arrow body | IPC **file** via `FileWriter` (`db.rs:44`) under stream media type (`interfaces.rs:40`) | IPC stream (D8) | Use `StreamWriter`; update `test.rs:84`. |
+| `type` missing | 400 empty (`query.rs:25`) | default `arrow` (D1) | Default in `QueryParams`. |
+| `sql` missing | 400 empty | 400 envelope | Add body. |
+| Unknown `type` | GET 400 / POST 422 plain serde text (`interfaces.rs:14-19`) | 400 envelope `bad_request` | Custom rejection or `String` + manual match. |
+| Malformed JSON | 400 plain `Failed to parse the request body as JSON…` | 400 envelope | Custom `Json` rejection handler. |
+| DuckDB error | 500 plain `Something went wrong: …` (`interfaces.rs:62-64`) | 500 envelope `internal_error`; parse errors 400 (D7) | Map `duckdb::Error` variants. |
+| Exec over GET | runs | 400 `bad_request` (D3) | Reject in `handle_get`. |
+| Multi-statement `arrow` | `prepare` fails → 500 | 400 `bad_request` (D16) | Classify. |
+| 405 | empty, `Allow: GET,HEAD,POST` | envelope + `Allow: GET, POST, OPTIONS` | Custom fallback. HEAD runs the query today; drop or document. |
+| README GET example | `?query={…}` (`Readme.md:47`) does not work | flat params | Fix README. |
+| `name` field | parsed, logged, unused (`interfaces.rs:21-27`) | dropped (D15) | Remove. |
+| WS errors | `{"error"}` no code (`websocket.rs:29-35`); message differs from HTTP (`Something went wrong:` prefix) | envelope with `code`, same message both transports | Shared mapper. |
+| WS binary frames | ignored, **no reply** (`websocket.rs:59`) | SHOULD accept; MUST reply (D11) | Treat as text or answer with `bad_request`. |
+| WS upgrade edge | malformed upgrade falls through to GET handler (`app.rs:22-34`) | 400 envelope | Return the upgrade rejection. |
+| Cache headers | none | optional (D14) | Straightforward; results are buffered. |
+| CORS | `max-age` 86400, no `Expose-Headers` | expose `ETag` | Edit `CorsLayer`. |
+| Timeouts | none; blocking DuckDB calls on tokio workers (`db.rs:29-54`) | `deadline_exceeded` | `spawn_blocking` + `duckdb_interrupt`. |
+
+## Python `duckdb-server`
+
+Source: `packages/server/duckdb-server/pkg/{server.py,query.py,__main__.py}`.
+
+| Area | Current | Spec | Fix |
+|------|---------|------|-----|
+| HTTP error status | CORS `write_header` runs first, so uWS emits `200` and the later `write_status(500)` is ignored (`server.py:71,111,136-140`) — errors are very likely **200** | mapped status | Call `write_status` before any `write_header`. Verify empirically. |
+| GET params | `?query=<json>` (`server.py:149-151`) | flat `type`/`sql` (D2) | Read flat params. |
+| `type` missing | `KeyError` escapes → `Error 'type'` (`server.py:85`) | default `arrow` (D1) | `query.get("type", "arrow")`. |
+| `sql` missing | `Error 'sql'` via `on_error` | 400 envelope | Validate before dispatch. |
+| Unknown `type` | `Unknown command X` plain (`server.py:94-96`) | 400 envelope `bad_request` | Classify. |
+| Malformed/falsy POST body | `NotImplementedError` → body `Error ` (`server.py:157`) | 400 envelope | Validate `get_json()` result. |
+| DuckDB error | plain `str(e)` | 500 envelope; parse errors 400 (D7) | Map `duckdb.ParserException`/`BinderException`. |
+| Arrow Content-Type | `application/octet-stream` (`server.py:67`) | `application/vnd.apache.arrow.stream` (D8) | Change header; body is already a stream. |
+| Exec over GET | runs | 400 `bad_request` (D3) | Reject. |
+| Non-GET/POST/OPTIONS | no response; hangs until uWS timeout (`server.py:146-157`) | 405 + `Allow` + envelope | Add fallthrough. |
+| WS missing `sql`/`type` | **no frame at all** (exception in sync handler) | `Error` frame (D11) | Wrap `handle_query` in try/except. Breaks pipelining clients today. |
+| WS errors | `{"error"}` no code | envelope with `code` | Add. |
+| WS message size | 16 KiB default | ≥ 1 MiB (D13) | Set `max_payload_length`. |
+| WS idle | 120 s close, no pings | SHOULD ping | `send_pings_automatically` or raise idle timeout. |
+| CORS | bogus `Access-Control-Request-Method`, no `Expose-Headers` (`server.py:136-140`) | fix | Edit header set. |
+| Concurrency | single connection, sync handler blocks the event loop | (prerequisite for deadlines) | Not a wire gap. |
+| CLI | positional db path only; port hardcoded 3000 (`server.py:174`) | runner needs `--port` | Add `--port`/`--address`. |
+
+## Node `packages/server/duckdb`
+
+Source: `packages/server/duckdb/src/{data-server.js,DuckDB.js}`, `bin/run-server.js`. README steers users to the Python server; decide whether this server is in scope for the conformance suite or retired. If kept:
+
+| Area | Current | Spec | Fix |
+|------|---------|------|-----|
+| GET | always 400: `JSON.parse` of the parsed query object (`data-server.js:39-40,76`) | flat params (D2) | Build the command from `url.query`. |
+| `sql` missing | not validated → DuckDB parser error → 500 | 400 `bad_request` | Validate. |
+| Non-string / `null` `type` | `Unrecognized command: null` 400 | fine, but body empty | Envelope. |
+| HTTP errors | **empty body**, no Content-Type (`data-server.js:119-123`) | envelope (D4) | Rewrite `error()`. |
+| Unsupported method | 400 (`data-server.js:49-50`) | 405 + `Allow` | Change status. |
+| Empty Arrow result | 0 bytes (`DuckDB.js:91`; `duckdb.test.js:26-30` asserts it) | schema + EOS (D8) | Emit a schema-only stream. |
+| Arrow trailing `;` / multi-statement | wrapped as `to_arrow_ipc((sql))` (`DuckDB.js:88-90`) → parser error 500 | trailing `;` allowed; multi → 400 (D16) | Strip trailing `;`; classify. |
+| WS error | `{"error": String(err)}` with `"Error: "` prefix; status argument dropped (`data-server.js:141-144`) | envelope with `code` | Rewrite. |
+| WS ordering | serialized per connection since #1209 (`data-server.js:58-65`) | in order (D11) | Conforms. |
+| Shared connection | one DuckDB connection for all clients (`DuckDB.js:21`) | (no spec requirement) | Note only. |
+| CLI | positional db path only; no `--port`; not in `package.json` `bin` (`bin/run-server.js:5`) | runner needs `--port` | Add flags. |
+| Wire tests | none | — | Conformance suite will cover. |
+
+## Conformance suite sketch
+
+Declarative cases in `packages/server/spec/cases/*.yaml`, one TypeScript runner
+(vitest) that:
+
+1. Starts a server from a per-server adapter (`command`, `args`, `readyProbe`,
+   `capabilities: { preagg, exec, caching, tenantHeaders }`) on a free port.
+2. Loads a fixture database (`data/` already exists in each server package;
+   prefer one shared parquet file).
+3. Runs each case over HTTP and WebSocket, asserting status, headers, frame
+   type, and body against `schemas.yaml` (ajv 2020-12) plus case-specific
+   expectations. Arrow bodies are decoded with Flechette and compared as row
+   objects against an in-process DuckDB result for the same SQL.
+4. Pipelines several WebSocket commands, including deliberately invalid ones,
+   and asserts positional correlation (D11).
+5. Skips cases whose `requires` capability the adapter lacks, but fails if the
+   server returns anything other than `unsupported_command` for them.
+
+Case groups: request decoding (D1–D3, D9, D10), Arrow encoding (D8, D16),
+error envelope per code (D4–D7), WebSocket framing/order/open-after-error
+(D11, D12), size floors (D13), caching headers (D14), CORS preflight.

--- a/packages/server/spec/asyncapi.yaml
+++ b/packages/server/spec/asyncapi.yaml
@@ -1,0 +1,168 @@
+asyncapi: 3.0.0
+info:
+  title: Mosaic DuckDB server protocol (WebSocket)
+  version: 0.1.0-draft
+  description: |
+    WebSocket transport for the same commands described in `openapi.yaml`.
+    This document is written from the server's point of view: the server
+    *receives* command messages and *sends* result messages.
+
+    ### Framing rules
+
+    * The upgrade is served at the same path as the HTTP endpoint (`/` on the
+      reference servers). No subprotocol is negotiated.
+    * The client sends one command per **text** frame containing a JSON
+      `Request`. Servers SHOULD also accept a binary frame containing UTF-8
+      JSON, but clients MUST send text.
+    * Clients pipeline: they send commands without waiting for earlier
+      replies. For every command message the server sends **exactly one**
+      response message, delivered **in the order commands were received**.
+      There is no request identifier; clients correlate by position. Servers
+      MAY execute commands concurrently but MUST buffer responses to preserve
+      order, and MUST reply even to commands that fail before execution.
+    * Frame type encodes the result kind:
+
+      | request `type` | success frame | payload                                   |
+      |----------------|---------------|-------------------------------------------|
+      | `arrow`        | binary        | Arrow IPC stream, same bytes as HTTP      |
+      | `exec`         | text          | `{}`                                      |
+      | `preagg`       | text          | `PreaggResponse`                          |
+      | any            | text          | `Error` envelope                          |
+
+      A client receiving a text frame for an `arrow` command treats it as an
+      error (either the `Error` envelope, or a protocol violation if it lacks
+      `error`). A client receiving a binary frame for `preagg` treats it as a
+      protocol violation.
+    * Errors, including malformed JSON and unknown `type`, are reported with
+      an `Error` text frame; the connection **stays open** and later commands
+      are still answered. Servers MUST NOT close the socket for
+      application-level failures. Servers MAY close with `1009` for frames
+      above their size limit and `1002`/`1007` for protocol violations.
+    * Servers SHOULD accept command messages of at least 1 MiB.
+    * Servers SHOULD answer WebSocket pings during long-running commands so
+      proxies do not drop idle-looking connections, and MAY send pings.
+    * SQL policy and application-owned request fields behave exactly as over
+      HTTP. Nothing is cached over WebSocket.
+    * Authentication material is carried on the upgrade request (cookies or
+      headers set by a proxy); browsers cannot set custom headers, so servers
+      MUST NOT require a header the browser `WebSocket` API cannot send unless
+      a proxy adds it. Authentication failure on the upgrade returns an HTTP
+      `401` with the `Error` envelope instead of upgrading.
+  license:
+    name: BSD-3-Clause
+
+defaultContentType: application/json
+
+servers:
+  local:
+    host: localhost:3000
+    protocol: ws
+    description: Default for all reference servers. `wss` when TLS is configured.
+
+channels:
+  commands:
+    address: /
+    description: Single bidirectional channel carrying commands and their positional replies.
+    messages:
+      command:
+        $ref: '#/components/messages/Command'
+      arrowResult:
+        $ref: '#/components/messages/ArrowResult'
+      execAck:
+        $ref: '#/components/messages/ExecAck'
+      preaggResult:
+        $ref: '#/components/messages/PreaggResult'
+      error:
+        $ref: '#/components/messages/Error'
+
+operations:
+  receiveCommand:
+    action: receive
+    channel:
+      $ref: '#/channels/commands'
+    summary: Server receives a command and replies with exactly one message on the same socket.
+    messages:
+      - $ref: '#/channels/commands/messages/command'
+    reply:
+      channel:
+        $ref: '#/channels/commands'
+      messages:
+        - $ref: '#/channels/commands/messages/arrowResult'
+        - $ref: '#/channels/commands/messages/execAck'
+        - $ref: '#/channels/commands/messages/preaggResult'
+        - $ref: '#/channels/commands/messages/error'
+
+  sendResult:
+    action: send
+    channel:
+      $ref: '#/channels/commands'
+    summary: Server sends exactly one of these per received command, in request order, even when clients pipeline.
+    messages:
+      - $ref: '#/channels/commands/messages/arrowResult'
+      - $ref: '#/channels/commands/messages/execAck'
+      - $ref: '#/channels/commands/messages/preaggResult'
+      - $ref: '#/channels/commands/messages/error'
+
+components:
+  messages:
+    Command:
+      name: Command
+      title: Command (text frame)
+      contentType: application/json
+      payload:
+        $ref: './schemas.yaml#/$defs/Request'
+      examples:
+        - name: arrow
+          payload: { type: arrow, sql: "SELECT 1 AS x" }
+        - name: exec
+          payload: { type: exec, sql: "CREATE TABLE t AS SELECT 1 AS x" }
+        - name: preagg
+          payload: { type: preagg, sql: "SELECT category, count(*) AS n FROM analytics.public.events GROUP BY category" }
+
+    ArrowResult:
+      name: ArrowResult
+      title: Arrow result (binary frame)
+      contentType: application/vnd.apache.arrow.stream
+      payload:
+        type: string
+        format: binary
+        description: Arrow IPC stream. Never empty; an empty result still carries the schema and EOS marker.
+
+    ExecAck:
+      name: ExecAck
+      title: Exec acknowledgement (text frame)
+      contentType: application/json
+      payload:
+        $ref: './schemas.yaml#/$defs/ExecResponse'
+      examples:
+        - payload: {}
+
+    PreaggResult:
+      name: PreaggResult
+      title: Preaggregate reference (text frame)
+      contentType: application/json
+      payload:
+        $ref: './schemas.yaml#/$defs/PreaggResponse'
+      examples:
+        - payload:
+            catalog: memory
+            schema: mosaic_scope_a7
+            table: preagg_c92f
+            createdAt: "2026-09-08T20:00:00Z"
+
+    Error:
+      name: Error
+      title: Error envelope (text frame)
+      contentType: application/json
+      payload:
+        $ref: './schemas.yaml#/$defs/Error'
+      examples:
+        - name: bad_request
+          payload: { error: "missing required 'sql' parameter", code: bad_request }
+        - name: table_not_found
+          payload:
+            error: Materialized table is unavailable
+            code: table_not_found
+            catalog: memory
+            schema: mosaic_scope_a7
+            table: preagg_c92f

--- a/packages/server/spec/index.html
+++ b/packages/server/spec/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Mosaic DuckDB server protocol</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="https://cdn.jsdelivr.net/npm/js-yaml@4/dist/js-yaml.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.68.0"></script>
+    <script type="module">
+      // Scalar does not dereference cross-file $refs, so inline schemas.yaml
+      // into each document's components.schemas before handing it over.
+      const load = async (file) => jsyaml.load(await (await fetch(file)).text());
+      const shared = await load('./schemas.yaml');
+
+      const inline = (doc) => {
+        const text = JSON.stringify({ ...doc, components: { ...doc.components, schemas: shared.$defs } })
+          .replaceAll('"./schemas.yaml#/$defs/', '"#/components/schemas/')
+          .replaceAll('"#/$defs/', '"#/components/schemas/');
+        return JSON.parse(text);
+      };
+
+      const [openapi, asyncapi] = await Promise.all([load('./openapi.yaml'), load('./asyncapi.yaml')]);
+
+      Scalar.createApiReference('#app', {
+        sources: [
+          { title: 'HTTP', slug: 'http', content: inline(openapi), default: true },
+          { title: 'WebSocket', slug: 'websocket', content: inline(asyncapi) }
+        ],
+        hideClientButton: true,
+        hideTestRequestButton: true
+      });
+    </script>
+  </body>
+</html>

--- a/packages/server/spec/openapi.yaml
+++ b/packages/server/spec/openapi.yaml
@@ -132,16 +132,15 @@ paths:
       summary: Run a read-only `arrow` query supplied as query parameters.
       description: |
         Equivalent to `POST` with the same fields, restricted to `arrow` with
-        read-only SQL. `type` defaults to `arrow` when omitted. This is the
-        only cacheable form; see *Caching* above.
+        read-only SQL. `type` is required here as on `POST`. This is the only
+        cacheable form; see *Caching* above.
       parameters:
         - name: type
           in: query
-          required: false
+          required: true
           schema:
             type: string
             enum: [arrow]
-            default: arrow
         - name: sql
           in: query
           required: true
@@ -254,6 +253,8 @@ components:
         application/json:
           schema: { $ref: './schemas.yaml#/$defs/Error' }
           examples:
+            missing_type:
+              value: { error: "missing required 'type' parameter", code: bad_request }
             missing_sql:
               value: { error: "missing required 'sql' parameter", code: bad_request }
             unknown_type:

--- a/packages/server/spec/openapi.yaml
+++ b/packages/server/spec/openapi.yaml
@@ -1,0 +1,328 @@
+openapi: 3.1.0
+info:
+  title: Mosaic DuckDB server protocol (HTTP)
+  version: 0.1.0-draft
+  summary: HTTP transport for Mosaic coordinator commands against a DuckDB-backed server.
+  description: |
+    A Mosaic server exposes one endpoint that accepts a JSON command object and
+    returns an Arrow IPC stream, an empty acknowledgement, or a preaggregate
+    table reference. The same command objects travel over WebSocket; see
+    `asyncapi.yaml`. Shapes are defined once in `schemas.yaml`.
+
+    This document describes the desired state agreed for all server
+    implementations (Python, Rust, Go, Node). Per-server gaps are tracked in
+    `CONFORMANCE.md`. Items marked **Decision** are choices made where the
+    existing servers disagreed and are open for revision.
+
+    ### Transport rules
+
+    * The endpoint path is deployment-defined; the reference servers use `/`.
+      Servers MUST serve the same commands at the same path over HTTP and
+      WebSocket upgrade.
+    * `POST` carries the command as a JSON body. Clients send
+      `Content-Type: application/json`. **Decision:** servers MAY reject other
+      media types with `415` + `bad_request`, and MUST NOT require a `charset`.
+    * `GET` carries `type` and `sql` as flat query-string parameters
+      (percent-encoded, not JSON-wrapped; `+` decodes to a space, so clients
+      MUST percent-encode it). Only `arrow` is allowed on GET; `exec` and
+      `preagg` MUST be rejected with `400` + `bad_request` so that reads can
+      be cached and side effects cannot be triggered by a link.
+    * Any other method returns `405` with `Allow: GET, POST, OPTIONS` and a
+      `bad_request` error body.
+    * Properties other than `type` and `sql` are application-owned and pass
+      through to deployment authorization untouched. Protocol fields MUST be
+      decoded independently of that payload.
+    * Success bodies are fully formed: an `arrow` response for zero rows MUST
+      still contain the schema message and end-of-stream marker.
+    * Errors are always the JSON envelope in `schemas.yaml#/$defs/Error` with
+      `Content-Type: application/json`, using the status listed for the code.
+      Servers MUST NOT return plain-text or empty error bodies, and MUST NOT
+      return `200` for a failed command.
+    * Servers SHOULD accept request bodies and query strings of at least 1 MiB
+      so that long generated SQL is not silently truncated. Servers MAY cap
+      bodies and reject larger ones with `413` + `bad_request`.
+    * Servers MAY compress response bodies per `Accept-Encoding`.
+
+    ### Caching
+
+    Servers keep no result cache; clients own freshness. HTTP caching is
+    optional and, when enabled, applies only to successful `GET` `arrow`
+    responses:
+
+    * The server emits a strong `ETag` derived from the encoded body and the
+      operator-configured `Cache-Control` value. Authorization and execution
+      always run before conditional evaluation, so a revoked caller gets
+      `403`, never `304`.
+    * `If-None-Match` is compared weakly (RFC 9110); a match returns `304`
+      with no body and the same `ETag`, `Cache-Control`, and `Vary`.
+    * `If-Match` is compared strongly; a mismatch returns `412` with a
+      `bad_request` envelope and no `ETag`.
+    * Every other response — `POST`, `exec`, errors, preflight, the WebSocket
+      `101` — carries `Cache-Control: no-store` and no `ETag`.
+    * Responses that depend on caller identity MUST list the identifying
+      headers in `Vary` (or use `private`/`no-store`).
+  license:
+    name: BSD-3-Clause
+    identifier: BSD-3-Clause
+
+servers:
+  - url: http://localhost:3000
+    description: Default for all reference servers.
+
+security: []
+
+tags:
+  - name: commands
+    description: Command endpoint shared by all `type` values.
+
+paths:
+  /:
+    post:
+      tags: [commands]
+      operationId: postCommand
+      summary: Run a command supplied as a JSON body.
+      description: |
+        The response depends on `type`:
+
+        | `type`   | status | Content-Type                          | body                              |
+        |----------|--------|---------------------------------------|-----------------------------------|
+        | `arrow`  | 200    | `application/vnd.apache.arrow.stream` | Arrow IPC **stream** (not file)   |
+        | `exec`   | 200    | none                                  | empty                             |
+        | `preagg` | 200    | `application/json`                    | `PreaggResponse`                  |
+
+        `POST` responses are never cacheable and carry `Cache-Control: no-store`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: './schemas.yaml#/$defs/Request'
+            examples:
+              arrow:
+                value: { type: arrow, sql: "SELECT 1 AS x" }
+              exec:
+                value: { type: exec, sql: "CREATE TABLE t AS SELECT 1 AS x; INSERT INTO t VALUES (2)" }
+              preagg:
+                value: { type: preagg, sql: "SELECT category, count(*) AS n FROM analytics.public.events GROUP BY category" }
+              application_payload:
+                summary: Application-owned fields pass through to authorization.
+                value: { type: arrow, sql: "SELECT 1 AS x", projectId: "p_42" }
+      responses:
+        '200':
+          $ref: '#/components/responses/CommandSuccess'
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthenticated' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/TableNotFound' }
+        '413': { $ref: '#/components/responses/PayloadTooLarge' }
+        '415': { $ref: '#/components/responses/UnsupportedMediaType' }
+        '429': { $ref: '#/components/responses/ResourceExhausted' }
+        '500': { $ref: '#/components/responses/InternalError' }
+        '504': { $ref: '#/components/responses/DeadlineExceeded' }
+
+    get:
+      tags: [commands]
+      operationId: getCommand
+      summary: Run a read-only `arrow` query supplied as query parameters.
+      description: |
+        Equivalent to `POST` with the same fields, restricted to `arrow`.
+        `type` defaults to `arrow` when omitted. This is the only cacheable
+        form; see *Caching* above.
+      parameters:
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [arrow]
+            default: arrow
+        - name: sql
+          in: query
+          required: true
+          schema:
+            $ref: './schemas.yaml#/$defs/Sql'
+        - $ref: '#/components/parameters/IfNoneMatch'
+        - $ref: '#/components/parameters/IfMatch'
+      responses:
+        '200':
+          $ref: '#/components/responses/CommandSuccess'
+        '304':
+          $ref: '#/components/responses/NotModified'
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthenticated' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/TableNotFound' }
+        '412': { $ref: '#/components/responses/PreconditionFailed' }
+        '429': { $ref: '#/components/responses/ResourceExhausted' }
+        '500': { $ref: '#/components/responses/InternalError' }
+        '504': { $ref: '#/components/responses/DeadlineExceeded' }
+
+    options:
+      tags: [commands]
+      operationId: preflight
+      summary: CORS preflight.
+      description: |
+        Browser clients call with `mode: 'cors'` and `credentials: 'omit'`.
+        Allowed origins, headers, and max-age are deployment configuration.
+        Servers SHOULD expose `ETag` via `Access-Control-Expose-Headers` when
+        caching is enabled. Preflight bypasses authorization and carries no
+        body.
+      responses:
+        '204':
+          description: Preflight accepted. `200` with an empty body is also acceptable.
+          headers:
+            Access-Control-Allow-Origin: { schema: { type: string } }
+            Access-Control-Allow-Methods: { schema: { type: string }, example: "GET, POST" }
+            Access-Control-Allow-Headers: { schema: { type: string } }
+            Access-Control-Expose-Headers: { schema: { type: string }, example: "ETag" }
+            Access-Control-Max-Age: { schema: { type: integer } }
+            Vary: { $ref: '#/components/headers/Vary' }
+
+components:
+  parameters:
+    IfNoneMatch:
+      name: If-None-Match
+      in: header
+      required: false
+      schema: { type: string }
+      description: Weak comparison against the current `ETag`; a match yields `304`.
+    IfMatch:
+      name: If-Match
+      in: header
+      required: false
+      schema: { type: string }
+      description: Strong comparison against the current `ETag`; a mismatch yields `412`.
+
+  headers:
+    ETag:
+      schema: { type: string }
+      description: Strong validator for the encoded body. Only on cacheable `GET` `arrow` responses.
+    Cache-Control:
+      schema: { type: string }
+      description: Operator-configured value on cacheable responses; `no-store` on everything else once caching is enabled.
+    Vary:
+      schema: { type: string }
+      description: MUST include any request header that influenced the response, such as tenant headers.
+    Allow:
+      schema: { type: string }
+      example: "GET, POST, OPTIONS"
+
+  responses:
+    CommandSuccess:
+      description: Command completed. Media type is determined by the request `type`.
+      headers:
+        ETag: { $ref: '#/components/headers/ETag' }
+        Cache-Control: { $ref: '#/components/headers/Cache-Control' }
+        Vary: { $ref: '#/components/headers/Vary' }
+      content:
+        application/vnd.apache.arrow.stream:
+          schema:
+            type: string
+            format: binary
+            description: |
+              Arrow IPC stream: schema message, zero or more record batches,
+              end-of-stream marker. Servers MUST NOT send the IPC file format
+              (`ARROW1` magic + footer) and MUST NOT send an empty body for an
+              empty result.
+        application/json:
+          schema:
+            $ref: './schemas.yaml#/$defs/PreaggResponse'
+          example:
+            catalog: memory
+            schema: mosaic_scope_a7
+            table: preagg_c92f
+            createdAt: "2026-09-08T20:00:00Z"
+    NotModified:
+      description: The `If-None-Match` validator matched. No body.
+      headers:
+        ETag: { $ref: '#/components/headers/ETag' }
+        Cache-Control: { $ref: '#/components/headers/Cache-Control' }
+        Vary: { $ref: '#/components/headers/Vary' }
+    BadRequest:
+      description: "`bad_request` or `unsupported_command`. The same body shape is used for `405`."
+      headers:
+        Allow:
+          $ref: '#/components/headers/Allow'
+          description: Only on `405`.
+      content:
+        application/json:
+          schema: { $ref: './schemas.yaml#/$defs/Error' }
+          examples:
+            missing_sql:
+              value: { error: "missing required 'sql' parameter", code: bad_request }
+            unknown_type:
+              value: { error: "invalid 'type' parameter: csv", code: bad_request }
+            get_exec:
+              value: { error: "exec is not allowed over GET", code: bad_request }
+            parse:
+              value: { error: "Parser Error: syntax error at or near \"SELEC\"", code: bad_request }
+            exec_disabled:
+              value: { error: "exec command is disabled when query validation is active", code: unsupported_command }
+            preagg_disabled:
+              value: { error: "preagg is not enabled on this server", code: unsupported_command }
+    Unauthenticated:
+      description: "`unauthenticated`."
+      content:
+        application/json:
+          schema: { $ref: './schemas.yaml#/$defs/Error' }
+          example: { error: "no allowed schemas found in request headers", code: unauthenticated }
+    Forbidden:
+      description: "`forbidden`."
+      content:
+        application/json:
+          schema: { $ref: './schemas.yaml#/$defs/Error' }
+          examples:
+            schema:
+              value: { error: "unauthorized access to schema 'other_tenant'", code: forbidden }
+            remote_uri:
+              value: { error: "remote URI prefix 's3://' is not allowed in path argument to function 'read_parquet'", code: forbidden }
+    TableNotFound:
+      description: "`table_not_found`, with the authorized reference so the coordinator can rebuild a live preaggregate recipe."
+      content:
+        application/json:
+          schema: { $ref: './schemas.yaml#/$defs/Error' }
+          example:
+            error: Materialized table is unavailable
+            code: table_not_found
+            catalog: memory
+            schema: mosaic_scope_a7
+            table: preagg_c92f
+    PreconditionFailed:
+      description: "`bad_request`; the `If-Match` validator did not match. No `ETag`."
+      content:
+        application/json:
+          schema: { $ref: './schemas.yaml#/$defs/Error' }
+          example: { error: "Precondition Failed", code: bad_request }
+    PayloadTooLarge:
+      description: "`bad_request`; body exceeded the server's limit."
+      content:
+        application/json:
+          schema: { $ref: './schemas.yaml#/$defs/Error' }
+          example: { error: "Request Entity Too Large", code: bad_request }
+    UnsupportedMediaType:
+      description: "`bad_request`; request `Content-Type` was not JSON."
+      content:
+        application/json:
+          schema: { $ref: './schemas.yaml#/$defs/Error' }
+    ResourceExhausted:
+      description: "`resource_exhausted`."
+      headers:
+        Retry-After:
+          schema: { type: integer }
+          description: Optional seconds to wait before retrying.
+      content:
+        application/json:
+          schema: { $ref: './schemas.yaml#/$defs/Error' }
+          example: { error: "materialization queue is full", code: resource_exhausted }
+    InternalError:
+      description: "`internal_error`, including unclassified DuckDB execution errors."
+      content:
+        application/json:
+          schema: { $ref: './schemas.yaml#/$defs/Error' }
+          example: { error: "Catalog Error: Table with name foo does not exist!", code: internal_error }
+    DeadlineExceeded:
+      description: "`deadline_exceeded`."
+      content:
+        application/json:
+          schema: { $ref: './schemas.yaml#/$defs/Error' }
+          example: { error: "command deadline exceeded after 30s", code: deadline_exceeded }

--- a/packages/server/spec/openapi.yaml
+++ b/packages/server/spec/openapi.yaml
@@ -24,9 +24,14 @@ info:
       media types with `415` + `bad_request`, and MUST NOT require a `charset`.
     * `GET` carries `type` and `sql` as flat query-string parameters
       (percent-encoded, not JSON-wrapped; `+` decodes to a space, so clients
-      MUST percent-encode it). Only `arrow` is allowed on GET; `exec` and
-      `preagg` MUST be rejected with `400` + `bad_request` so that reads can
-      be cached and side effects cannot be triggered by a link.
+      MUST percent-encode it). Only `arrow` is allowed on GET, and its `sql`
+      MUST satisfy `schemas.yaml#/$defs/ReadOnlySql`; servers MUST verify
+      that before execution, independent of any deployment policy, because a
+      single statement such as `DELETE ... RETURNING *` returns rows.
+      `exec`, `preagg`, and non-read-only SQL over GET are rejected with
+      `400` + `bad_request` so that reads can be cached and side effects
+      cannot be triggered by a link. `POST` `arrow` is not restricted this
+      way.
     * Any other method returns `405` with `Allow: GET, POST, OPTIONS` and a
       `bad_request` error body.
     * Properties other than `type` and `sql` are application-owned and pass
@@ -35,9 +40,10 @@ info:
     * Success bodies are fully formed: an `arrow` response for zero rows MUST
       still contain the schema message and end-of-stream marker.
     * Errors are always the JSON envelope in `schemas.yaml#/$defs/Error` with
-      `Content-Type: application/json`, using the status listed for the code.
-      Servers MUST NOT return plain-text or empty error bodies, and MUST NOT
-      return `200` for a failed command.
+      `Content-Type: application/json`, using the status listed for the code
+      in `ErrorCode`, including the `405`/`412`/`413`/`415` exceptions listed
+      there for `bad_request`. Servers MUST NOT return plain-text or empty
+      error bodies, and MUST NOT return `200` for a failed command.
     * Servers SHOULD accept request bodies and query strings of at least 1 MiB
       so that long generated SQL is not silently truncated. Servers MAY cap
       bodies and reject larger ones with `413` + `bad_request`.
@@ -125,9 +131,9 @@ paths:
       operationId: getCommand
       summary: Run a read-only `arrow` query supplied as query parameters.
       description: |
-        Equivalent to `POST` with the same fields, restricted to `arrow`.
-        `type` defaults to `arrow` when omitted. This is the only cacheable
-        form; see *Caching* above.
+        Equivalent to `POST` with the same fields, restricted to `arrow` with
+        read-only SQL. `type` defaults to `arrow` when omitted. This is the
+        only cacheable form; see *Caching* above.
       parameters:
         - name: type
           in: query
@@ -140,7 +146,7 @@ paths:
           in: query
           required: true
           schema:
-            $ref: './schemas.yaml#/$defs/Sql'
+            $ref: './schemas.yaml#/$defs/ReadOnlySql'
         - $ref: '#/components/parameters/IfNoneMatch'
         - $ref: '#/components/parameters/IfMatch'
       responses:
@@ -254,6 +260,8 @@ components:
               value: { error: "invalid 'type' parameter: csv", code: bad_request }
             get_exec:
               value: { error: "exec is not allowed over GET", code: bad_request }
+            get_not_read_only:
+              value: { error: "only read-only statements are allowed over GET", code: bad_request }
             parse:
               value: { error: "Parser Error: syntax error at or near \"SELEC\"", code: bad_request }
             exec_disabled:

--- a/packages/server/spec/redocly.yaml
+++ b/packages/server/spec/redocly.yaml
@@ -1,0 +1,6 @@
+apis:
+  http:
+    root: openapi.yaml
+rules:
+  no-server-example.com: off
+  operation-4xx-response: off

--- a/packages/server/spec/schemas.yaml
+++ b/packages/server/spec/schemas.yaml
@@ -161,7 +161,9 @@ $defs:
       status) and WebSocket (text frame). `catalog`, `schema`, and `table` are
       present together only for `table_not_found`, and only after the server
       has established that the reference belongs to the caller's managed
-      namespace; servers MUST NOT echo arbitrary forbidden targets.
+      namespace; servers MUST NOT echo arbitrary forbidden targets. For every
+      other code the three properties are prohibited so that a forbidden
+      target or a partial reference cannot leak through the envelope.
     if:
       properties:
         code: { const: table_not_found }
@@ -171,3 +173,8 @@ $defs:
         schema: { $ref: '#/$defs/Identifier' }
         table: { $ref: '#/$defs/Identifier' }
       required: [catalog, schema, table]
+    else:
+      properties:
+        catalog: false
+        schema: false
+        table: false

--- a/packages/server/spec/schemas.yaml
+++ b/packages/server/spec/schemas.yaml
@@ -1,0 +1,159 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://idl.uw.edu/mosaic/server/schemas.yaml
+title: Mosaic DuckDB server protocol schemas
+description: |
+  Request, response, and error shapes shared by the HTTP (openapi.yaml) and
+  WebSocket (asyncapi.yaml) transports. Both transports carry the same JSON
+  command object and the same JSON error envelope; only framing differs.
+
+  Client source of truth is `packages/mosaic/core/src/connectors`
+  (`Connector.ts`, `rest.ts`, `socket.ts`, `errors.ts`) as of uwdata/mosaic#1224.
+
+$defs:
+  CommandType:
+    type: string
+    enum: [arrow, exec, preagg]
+    description: |
+      Discriminates the command. `arrow` returns a result table; `exec` runs
+      statements for their side effects; `preagg` materializes a SELECT into
+      a server-managed table and returns its reference.
+
+  Sql:
+    type: string
+    minLength: 1
+    description: |
+      SQL text. For `arrow` and `preagg` this MUST be exactly one statement;
+      a trailing semicolon is permitted. For `exec` it MAY contain several
+      `;`-separated statements, executed in order.
+
+  ArrowRequest:
+    type: object
+    required: [sql]
+    properties:
+      type:
+        const: arrow
+        description: Default when `type` is omitted.
+      sql: { $ref: '#/$defs/Sql' }
+    unevaluatedProperties: true
+
+  ExecRequest:
+    type: object
+    required: [type, sql]
+    properties:
+      type: { const: exec }
+      sql: { $ref: '#/$defs/Sql' }
+    unevaluatedProperties: true
+
+  PreaggRequest:
+    type: object
+    required: [type, sql]
+    properties:
+      type: { const: preagg }
+      sql:
+        allOf: [{ $ref: '#/$defs/Sql' }]
+        description: |
+          Exactly one SELECT-like statement (SELECT, VALUES, set operation, or
+          CTE). The server validates it under the same source, function, and
+          external-access policy as `arrow` queries, then materializes it.
+    unevaluatedProperties: true
+
+  Request:
+    description: |
+      A command object. `type` discriminates; an omitted `type` means `arrow`.
+      Properties other than `type` and `sql` are application-owned: servers
+      MUST accept them, MUST NOT let them override `type` or `sql`, and MAY
+      pass them to a deployment-specific authorizer. Mosaic defines no
+      metadata envelope.
+    oneOf:
+      - $ref: '#/$defs/ArrowRequest'
+      - $ref: '#/$defs/ExecRequest'
+      - $ref: '#/$defs/PreaggRequest'
+
+  ExecResponse:
+    type: object
+    description: |
+      Acknowledgement of a completed `exec`. Over HTTP the body is empty; over
+      WebSocket the server sends this empty JSON object as a text frame.
+    additionalProperties: false
+    maxProperties: 0
+
+  Identifier:
+    type: string
+    minLength: 1
+    description: A single unquoted SQL identifier component. Clients quote each component separately.
+
+  PreaggResponse:
+    type: object
+    required: [catalog, schema, table, createdAt]
+    properties:
+      catalog: { $ref: '#/$defs/Identifier' }
+      schema: { $ref: '#/$defs/Identifier' }
+      table: { $ref: '#/$defs/Identifier' }
+      createdAt:
+        type: string
+        format: date-time
+        description: |
+          RFC 3339 timestamp of the successful build's completion. Reusing an
+          existing table preserves it; rebuilding updates it.
+    additionalProperties: false
+    description: |
+      Fully qualified reference to a complete, queryable table. Clients
+      construct `TableRefNode([catalog, schema, table])`; a dotted string is
+      not a substitute.
+
+  ErrorCode:
+    type: string
+    description: |
+      Machine-readable failure class. Clients treat unknown codes as generic
+      failures, so servers MAY add codes, but MUST use these for the listed
+      situations. HTTP status is the canonical mapping; WebSocket errors carry
+      only the code.
+
+      | code                  | HTTP | when                                                                                   |
+      |-----------------------|------|----------------------------------------------------------------------------------------|
+      | `bad_request`         | 400  | Malformed body, unknown `type`, missing `sql`, wrong method/media type, oversized body, GET with `exec`/`preagg`, invalid SQL syntax or unsupported statement kind. |
+      | `unauthenticated`     | 401  | Caller identity required but absent or invalid.                                        |
+      | `forbidden`           | 403  | Authenticated caller denied by source/function/external-access policy, or a disallowed cross-origin request. |
+      | `table_not_found`     | 404  | A referenced table in the caller's managed namespace does not exist. `catalog`/`schema`/`table` MUST be included. |
+      | `unsupported_command` | 400  | The command is known but not available in this deployment (for example `preagg` on a server without preaggregation, or `exec` when query validation is active). Clients MUST NOT fall back to `exec`. |
+      | `resource_exhausted`  | 429  | Admission, quota, row/byte, or concurrency limit reached. Clients suppress immediate retries. |
+      | `deadline_exceeded`   | 504  | The server's command deadline elapsed. The attempt is over; partial output MUST NOT have been published. |
+      | `internal_error`      | 500  | Any other server-side failure, including DuckDB execution errors not classified above. |
+    enum:
+      - bad_request
+      - unauthenticated
+      - forbidden
+      - table_not_found
+      - unsupported_command
+      - resource_exhausted
+      - deadline_exceeded
+      - internal_error
+
+  Error:
+    type: object
+    required: [error, code]
+    properties:
+      error:
+        type: string
+        minLength: 1
+        description: Human-readable message. MAY include the DuckDB error text.
+      code: { $ref: '#/$defs/ErrorCode' }
+      catalog: { $ref: '#/$defs/Identifier' }
+      schema: { $ref: '#/$defs/Identifier' }
+      table: { $ref: '#/$defs/Identifier' }
+    additionalProperties: true
+    description: |
+      Structured error envelope, identical over HTTP (JSON body with the mapped
+      status) and WebSocket (text frame). `catalog`, `schema`, and `table` are
+      present together only for `table_not_found`, and only after the server
+      has established that the reference belongs to the caller's managed
+      namespace; servers MUST NOT echo arbitrary forbidden targets.
+    if:
+      properties:
+        code: { const: table_not_found }
+    then:
+      properties:
+        catalog: { $ref: '#/$defs/Identifier' }
+        schema: { $ref: '#/$defs/Identifier' }
+        table: { $ref: '#/$defs/Identifier' }
+      required: [catalog, schema, table]

--- a/packages/server/spec/schemas.yaml
+++ b/packages/server/spec/schemas.yaml
@@ -26,6 +26,19 @@ $defs:
       a trailing semicolon is permitted. For `exec` it MAY contain several
       `;`-separated statements, executed in order.
 
+  ReadOnlySql:
+    allOf: [{ $ref: '#/$defs/Sql' }]
+    description: |
+      Exactly one read-only statement. The statement's root MUST be a
+      SELECT, VALUES, set operation, or CTE (DuckDB `SELECT_NODE`,
+      `SET_OPERATION_NODE`, `CTE_NODE`, `RECURSIVE_CTE_NODE`) and MUST NOT be
+      a DML, DDL, PRAGMA, SET, ATTACH, COPY, or other side-effecting
+      statement, including ones that return rows such as
+      `DELETE ... RETURNING`. Servers MUST verify this before execution
+      whether or not a deployment policy is active, and reject violations
+      with `bad_request`. Required for `preagg` and for any command
+      delivered over HTTP GET.
+
   ArrowRequest:
     type: object
     required: [sql]
@@ -50,11 +63,10 @@ $defs:
     properties:
       type: { const: preagg }
       sql:
-        allOf: [{ $ref: '#/$defs/Sql' }]
+        allOf: [{ $ref: '#/$defs/ReadOnlySql' }]
         description: |
-          Exactly one SELECT-like statement (SELECT, VALUES, set operation, or
-          CTE). The server validates it under the same source, function, and
-          external-access policy as `arrow` queries, then materializes it.
+          The server validates the statement under the same source, function,
+          and external-access policy as `arrow` queries, then materializes it.
     unevaluatedProperties: true
 
   Request:
@@ -104,14 +116,16 @@ $defs:
   ErrorCode:
     type: string
     description: |
-      Machine-readable failure class. Clients treat unknown codes as generic
-      failures, so servers MAY add codes, but MUST use these for the listed
-      situations. HTTP status is the canonical mapping; WebSocket errors carry
-      only the code.
+      Machine-readable failure class. The vocabulary is closed: servers MUST
+      use exactly these codes, and adding one requires a change to this
+      schema. Clients treat any code they do not recognise as a generic
+      failure. The HTTP column is the canonical status; where the HTTP
+      transport itself dictates a more specific status, that exception is
+      listed and takes precedence. WebSocket errors carry only the code.
 
       | code                  | HTTP | when                                                                                   |
       |-----------------------|------|----------------------------------------------------------------------------------------|
-      | `bad_request`         | 400  | Malformed body, unknown `type`, missing `sql`, wrong method/media type, oversized body, GET with `exec`/`preagg`, invalid SQL syntax or unsupported statement kind. |
+      | `bad_request`         | 400  | Malformed body, unknown `type`, missing `sql`, GET with `exec`/`preagg`, non-read-only SQL over GET, invalid SQL syntax or unsupported statement kind. HTTP exceptions: `405` wrong method, `412` failed `If-Match`, `413` oversized body, `415` unsupported media type. |
       | `unauthenticated`     | 401  | Caller identity required but absent or invalid.                                        |
       | `forbidden`           | 403  | Authenticated caller denied by source/function/external-access policy, or a disallowed cross-origin request. |
       | `table_not_found`     | 404  | A referenced table in the caller's managed namespace does not exist. `catalog`/`schema`/`table` MUST be included. |

--- a/packages/server/spec/schemas.yaml
+++ b/packages/server/spec/schemas.yaml
@@ -41,11 +41,9 @@ $defs:
 
   ArrowRequest:
     type: object
-    required: [sql]
+    required: [type, sql]
     properties:
-      type:
-        const: arrow
-        description: Default when `type` is omitted.
+      type: { const: arrow }
       sql: { $ref: '#/$defs/Sql' }
     unevaluatedProperties: true
 
@@ -71,7 +69,10 @@ $defs:
 
   Request:
     description: |
-      A command object. `type` discriminates; an omitted `type` means `arrow`.
+      A command object. `type` is required and discriminates; a missing
+      `type` is rejected with `bad_request` and the message
+      `missing required 'type' parameter`, a missing `sql` with
+      `missing required 'sql' parameter`.
       Properties other than `type` and `sql` are application-owned: servers
       MUST accept them, MUST NOT let them override `type` or `sql`, and MAY
       pass them to a deployment-specific authorizer. Mosaic defines no


### PR DESCRIPTION
Defines the desired wire contract for all DuckDB server implementations (Python, Rust, Go, Node) so they can be brought into sync and eventually tested by one language-agnostic conformance suite. Follows #1224 and the RFC in #1218; intended to inform the Go implementation in #1234.

**What's here**

- `packages/server/spec/schemas.yaml` – single source of truth for `Request` (`arrow` / `exec` / `preagg`), `ExecResponse`, `PreaggResponse`, and the `Error` envelope with the full `ErrorCode` enum from #1218 (`bad_request`, `unauthenticated`, `forbidden`, `table_not_found`, `unsupported_command`, `resource_exhausted`, `deadline_exceeded`, `internal_error`) and its HTTP status mapping. No server implements the envelope over HTTP yet; that's intentional.
- `openapi.yaml` (HTTP) and `asyncapi.yaml` (WebSocket) referencing the shared schemas. Caching follows the Go `--cache-control`/`--vary` design from #1216.
- `CONFORMANCE.md` – 17 numbered decisions made where servers disagree (D1–D17, all revisable), common gaps, and a per-server table of current → spec → fix with file references at `origin/main`.
- Docs page **Reference → Mosaic DuckDB → Server Protocol**, rendered with Scalar loaded from a pinned CDN build (no new dependencies). `pnpm spec:preview` serves the same page standalone.
- `.github/workflows/server-protocol.yml` runs `pnpm spec:lint` (Redocly + AsyncAPI CLI, pinned) on spec changes. This is where per-server conformance jobs will land.

**Decisions worth a look**

- D1: `type` defaults to `arrow` (only Node does this today).
- D3: GET is `arrow`-only; `exec`/`preagg` over GET → `400 bad_request` (Rust and Go currently run `exec` over GET).
- D7: parse errors are `400 bad_request` even with no policy active, which obliges every server to parse or statement-split before execution. Relax to MAY if that's too strong.
- D11: pipelining clients (#1209) mean servers must reply to *every* command in order, including ones that fail before execution. Python currently sends nothing for a missing `sql`/`type`.

**Findings from the audit that may deserve their own issues**

- Python HTTP errors are almost certainly all `200`: CORS headers are written before `write_status`, and uWS ignores a status written after a header.
- Go decodes protocol fields with `encoding/json`'s case-insensitive, last-wins matching, so `"TYPE"` can shadow `"type"`.
- Rust sends Arrow IPC *file* format under the `…arrow.stream` media type; Node sends 0 bytes for an empty Arrow result.
- Rust ignores binary WebSocket frames without replying.

Validated: `pnpm spec:lint`, `pnpm docs:build`, `pnpm run lint`; the docs page was checked headlessly in light and dark mode.

The rendered OpenAPI / AsyncAPI specs can be viewed here
https://raw.githack.com/uwdata/mosaic/refs/heads/feat/server-protocol-spec/packages/server/spec/index.html#http/description/introduction